### PR TITLE
Add confirmation dialog for state change

### DIFF
--- a/frontend/src/api/artifactToggleMutations.ts
+++ b/frontend/src/api/artifactToggleMutations.ts
@@ -108,8 +108,8 @@ export function useUpdateArtifactTracingStatus() {
 
   return {
     ...mutation,
-    mutate: (input: ArtifactTracingInput) => mutation.mutate({ ...input, value: input.trace }),
-    mutateAsync: (input: ArtifactTracingInput) => mutation.mutateAsync({ ...input, value: input.trace }),
+    mutate: (input: ArtifactTracingInput, options?: Parameters<typeof mutation.mutate>[1]) => mutation.mutate({ ...input, value: input.trace }, options),
+    mutateAsync: (input: ArtifactTracingInput, options?: Parameters<typeof mutation.mutateAsync>[1]) => mutation.mutateAsync({ ...input, value: input.trace }, options),
   };
 }
 
@@ -118,7 +118,7 @@ export function useUpdateArtifactStatisticsStatus() {
 
   return {
     ...mutation,
-    mutate: (input: ArtifactStatisticsInput) => mutation.mutate({ ...input, value: input.statistics }),
-    mutateAsync: (input: ArtifactStatisticsInput) => mutation.mutateAsync({ ...input, value: input.statistics }),
+    mutate: (input: ArtifactStatisticsInput, options?: Parameters<typeof mutation.mutate>[1]) => mutation.mutate({ ...input, value: input.statistics }, options),
+    mutateAsync: (input: ArtifactStatisticsInput, options?: Parameters<typeof mutation.mutateAsync>[1]) => mutation.mutateAsync({ ...input, value: input.statistics }, options),
   };
 }

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -19,6 +19,7 @@
 import { Autocomplete, Box, Button, Card, CardContent, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Divider, IconButton, InputAdornment, Stack, Switch, TextField, Typography } from '@wso2/oxygen-ui';
 import { RefreshCw, ListFilter, LayoutGrid } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useArtifacts, useRefreshEnvironmentArtifacts, type GqlArtifact, type GqlEnvironment } from '../api/queries';
 import { useUpdateArtifactTracingStatus, useUpdateArtifactStatisticsStatus } from '../api/artifactToggleMutations';
 import { ArtifactApiDefinition, ServiceResources } from './ArtifactTabs';
@@ -30,6 +31,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   const [statisticsEnabled, setStatisticsEnabled] = useState(false);
   const [pendingToggle, setPendingToggle] = useState<{ type: 'tracing' | 'statistics'; checked: boolean } | null>(null);
   const { artifact, artifactType, envId, componentId, projectId } = selected;
+  const queryClient = useQueryClient();
   const updateTracingStatus = useUpdateArtifactTracingStatus();
   const updateStatisticsStatus = useUpdateArtifactStatisticsStatus();
   const config = ENTRY_POINT_CONFIG[artifactType];
@@ -63,24 +65,27 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
 
   const handleConfirmToggle = () => {
     if (!pendingToggle) return;
+    const artifactQueryKey = ['artifacts', artifactType, envId, componentId];
     if (pendingToggle.type === 'tracing') {
+      const previousValue = tracingEnabled;
       setTracingEnabled(pendingToggle.checked);
-      updateTracingStatus.mutate({
-        envId,
-        componentId,
-        artifactType,
-        artifactName: artifact.name?.toString() ?? '',
-        trace: pendingToggle.checked ? 'enable' : 'disable',
-      });
+      updateTracingStatus.mutate(
+        { envId, componentId, artifactType, artifactName: artifact.name?.toString() ?? '', trace: pendingToggle.checked ? 'enable' : 'disable' },
+        {
+          onError: () => setTracingEnabled(previousValue),
+          onSettled: () => queryClient.invalidateQueries({ queryKey: artifactQueryKey }),
+        },
+      );
     } else {
+      const previousValue = statisticsEnabled;
       setStatisticsEnabled(pendingToggle.checked);
-      updateStatisticsStatus.mutate({
-        envId,
-        componentId,
-        artifactType,
-        artifactName: artifact.name?.toString() ?? '',
-        statistics: pendingToggle.checked ? 'enable' : 'disable',
-      });
+      updateStatisticsStatus.mutate(
+        { envId, componentId, artifactType, artifactName: artifact.name?.toString() ?? '', statistics: pendingToggle.checked ? 'enable' : 'disable' },
+        {
+          onError: () => setStatisticsEnabled(previousValue),
+          onSettled: () => queryClient.invalidateQueries({ queryKey: artifactQueryKey }),
+        },
+      );
     }
     setPendingToggle(null);
   };
@@ -91,7 +96,9 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   return (
     <>
       <Dialog open={pendingToggle !== null} onClose={() => setPendingToggle(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>Confirm {toggleAction === 'enable' ? 'Enable' : 'Disable'} {toggleLabel.charAt(0).toUpperCase() + toggleLabel.slice(1)}</DialogTitle>
+        <DialogTitle>
+          Confirm {toggleAction === 'enable' ? 'Enable' : 'Disable'} {toggleLabel.charAt(0).toUpperCase() + toggleLabel.slice(1)}
+        </DialogTitle>
         <DialogContent>
           <DialogContentText>
             Are you sure you want to {toggleAction} {toggleLabel} for <strong>{artifact.name?.toString()}</strong>?
@@ -104,63 +111,63 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
           </Button>
         </DialogActions>
       </Dialog>
-    <Box sx={{ mt: 2 }}>
-      {/* Header row */}
-      <Stack direction="row" alignItems="center" gap={1.5} sx={{ px: 2, py: 1.5 }}>
-        {carbonApp && <Chip label={`C-App: ${carbonApp}`} size="small" variant="outlined" sx={{ bgcolor: '#e8eaf6', color: '#3949ab', fontSize: 11 }} />}
-        {carbonApp && <Divider orientation="vertical" flexItem />}
-        {showTracingToggle && (
-          <Stack direction="row" alignItems="center" gap={1}>
-            <Typography variant="body2" color="text.secondary">
-              Tracing
-            </Typography>
-            <Switch size="small" checked={tracingEnabled} onChange={(e) => handleToggleTracing(e.target.checked)} disabled={updateTracingStatus.isPending} aria-label="Enable tracing" />
-          </Stack>
-        )}
-        {showTracingToggle && showStatisticsToggle && <Divider orientation="vertical" flexItem />}
-        {showStatisticsToggle && (
-          <Stack direction="row" alignItems="center" gap={1}>
-            <Typography variant="body2" color="text.secondary">
-              Statistics
-            </Typography>
-            <Switch size="small" checked={statisticsEnabled} onChange={(e) => handleToggleStatistics(e.target.checked)} disabled={updateStatisticsStatus.isPending} aria-label="Enable statistics" />
-          </Stack>
-        )}
-        <Stack direction="row" gap={1} sx={{ ml: 'auto' }}>
-          {drawerTabs.map((tab) => (
-            <Button key={tab} variant="outlined" size="small" onClick={() => onOpenDrawerTab(tab)}>
-              View {tab}
-            </Button>
-          ))}
-        </Stack>
-      </Stack>
-      {/* Overview columns */}
-      {overviewFields.length > 0 && (
-        <Box sx={{ display: 'grid', gridTemplateColumns: `repeat(${overviewFields.length}, 1fr)` }}>
-          {overviewFields.map((f, i) => (
-            <Box key={f} sx={{ px: 2, py: 1.5, ...(i < overviewFields.length - 1 && { borderRight: '1px solid', borderColor: 'divider' }) }}>
-              <Typography variant="overline" color="text.secondary" sx={{ fontSize: 10, fontWeight: 600, display: 'block' }}>
-                {f.toUpperCase()}
+      <Box sx={{ mt: 2 }}>
+        {/* Header row */}
+        <Stack direction="row" alignItems="center" gap={1.5} sx={{ px: 2, py: 1.5 }}>
+          {carbonApp && <Chip label={`C-App: ${carbonApp}`} size="small" variant="outlined" sx={{ bgcolor: '#e8eaf6', color: '#3949ab', fontSize: 11 }} />}
+          {carbonApp && <Divider orientation="vertical" flexItem />}
+          {showTracingToggle && (
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Typography variant="body2" color="text.secondary">
+                Tracing
               </Typography>
-              {f === 'state' ? (
-                <Chip
-                  label={artifact[f] ? artifact[f].toString().charAt(0).toUpperCase() + artifact[f].toString().slice(1).toLowerCase() : '—'}
-                  size="small"
-                  variant="outlined"
-                  color={artifact[f]?.toString().toLowerCase() === 'enabled' ? 'success' : 'default'}
-                  sx={{ mt: 0.5, fontSize: 13 }}
-                />
-              ) : (
-                <Typography variant="body2" sx={{ fontFamily: 'monospace', mt: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {artifact[f] ? artifact[f].toString() : '—'}
+              <Switch size="small" checked={tracingEnabled} onChange={(e) => handleToggleTracing(e.target.checked)} disabled={updateTracingStatus.isPending} aria-label="Enable tracing" />
+            </Stack>
+          )}
+          {showTracingToggle && showStatisticsToggle && <Divider orientation="vertical" flexItem />}
+          {showStatisticsToggle && (
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Typography variant="body2" color="text.secondary">
+                Statistics
+              </Typography>
+              <Switch size="small" checked={statisticsEnabled} onChange={(e) => handleToggleStatistics(e.target.checked)} disabled={updateStatisticsStatus.isPending} aria-label="Enable statistics" />
+            </Stack>
+          )}
+          <Stack direction="row" gap={1} sx={{ ml: 'auto' }}>
+            {drawerTabs.map((tab) => (
+              <Button key={tab} variant="outlined" size="small" onClick={() => onOpenDrawerTab(tab)}>
+                View {tab}
+              </Button>
+            ))}
+          </Stack>
+        </Stack>
+        {/* Overview columns */}
+        {overviewFields.length > 0 && (
+          <Box sx={{ display: 'grid', gridTemplateColumns: `repeat(${overviewFields.length}, 1fr)` }}>
+            {overviewFields.map((f, i) => (
+              <Box key={f} sx={{ px: 2, py: 1.5, ...(i < overviewFields.length - 1 && { borderRight: '1px solid', borderColor: 'divider' }) }}>
+                <Typography variant="overline" color="text.secondary" sx={{ fontSize: 10, fontWeight: 600, display: 'block' }}>
+                  {f.toUpperCase()}
                 </Typography>
-              )}
-            </Box>
-          ))}
-        </Box>
-      )}
-      {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Resources') && <Box sx={{ px: 2, py: 1.5 }}>{artifactType === 'RestApi' ? <ArtifactApiDefinition {...tabProps} /> : <ServiceResources {...tabProps} />}</Box>}
-    </Box>
+                {f === 'state' ? (
+                  <Chip
+                    label={artifact[f] ? artifact[f].toString().charAt(0).toUpperCase() + artifact[f].toString().slice(1).toLowerCase() : '—'}
+                    size="small"
+                    variant="outlined"
+                    color={artifact[f]?.toString().toLowerCase() === 'enabled' ? 'success' : 'default'}
+                    sx={{ mt: 0.5, fontSize: 13 }}
+                  />
+                ) : (
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace', mt: 0.5, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {artifact[f] ? artifact[f].toString() : '—'}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
+        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Resources') && <Box sx={{ px: 2, py: 1.5 }}>{artifactType === 'RestApi' ? <ArtifactApiDefinition {...tabProps} /> : <ServiceResources {...tabProps} />}</Box>}
+      </Box>
     </>
   );
 }


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tracing and statistics toggles now require user confirmation before applying changes, with dialogs clearly displaying which setting is being modified and the intended action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->