### PR TITLE
Reject empty project name

### DIFF
--- a/icp_server/modules/storage/project_repository.bal
+++ b/icp_server/modules/storage/project_repository.bal
@@ -43,9 +43,14 @@ public isolated function createProject(types:ProjectInput project, types:UserCon
     string userId = userContext.userId;
     string displayName = userContext.displayName;
 
-    // Use projectHandler as the handler field, fallback to handler if projectHandler is not provided
+    if project.name.trim() == "" {
+        log:printWarn("Project creation attempted with empty name");
+        return error("Project name is required");
+    }
+
     string handler = project.projectHandler;
     if handler.trim() == "" {
+        log:printWarn("Project creation attempted without handler for project: " + project.name);
         return error("Project handler is required");
     }
 


### PR DESCRIPTION
Validate project name is non-empty in createProject mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation and error messaging for project creation to provide clearer feedback when invalid input is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->