### PR TITLE
Sanitize SQL errors in GraphQL responses

### DIFF
--- a/icp_server/modules/storage/auth_repository.bal
+++ b/icp_server/modules/storage/auth_repository.bal
@@ -62,8 +62,16 @@ public isolated function createGroup(types:GroupInput input) returns string|erro
          VALUES (${groupId}, ${input.groupName}, ${orgId}, ${input.description})`
     );
 
+    if result is sql:Error {
+        log:printError(string `Failed to create group ${input.groupName}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A group with this name already exists", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
     if result is error {
-        log:printError(string `Failed to create group ${input.groupName}`, result);
+        log:printError(string `Failed to create group ${input.groupName}`, 'error = result);
         return result;
     }
 
@@ -107,12 +115,21 @@ public isolated function getGroupsByOrgId(int orgId) returns types:Group[]|error
 public isolated function updateGroup(string groupId, types:GroupInput input) returns error? {
     log:printDebug(string `Updating group: ${groupId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
-        `UPDATE user_groups 
-         SET group_name = ${input.groupName}, 
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
+        `UPDATE user_groups
+         SET group_name = ${input.groupName},
              description = ${input.description}
          WHERE group_id = ${groupId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to update group ${groupId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A group with this name already exists", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Group not found: ${groupId}`);
@@ -126,9 +143,17 @@ public isolated function updateGroup(string groupId, types:GroupInput input) ret
 public isolated function deleteGroup(string groupId) returns error? {
     log:printDebug(string `Deleting group: ${groupId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
         `DELETE FROM user_groups WHERE group_id = ${groupId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to delete group ${groupId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete group because it has dependent role assignments or members", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Group not found: ${groupId}`);
@@ -154,8 +179,16 @@ public isolated function createRoleV2(types:RoleV2Input input) returns string|er
          VALUES (${roleId}, ${input.roleName}, ${orgId}, ${input.description})`
     );
 
+    if result is sql:Error {
+        log:printError(string `Failed to create role ${input.roleName}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A role with this name already exists", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
     if result is error {
-        log:printError(string `Failed to create role ${input.roleName}`, result);
+        log:printError(string `Failed to create role ${input.roleName}`, 'error = result);
         return result;
     }
 
@@ -200,12 +233,21 @@ public isolated function getAllRolesV2(int orgId) returns types:RoleV2[]|error {
 public isolated function updateRoleV2(string roleId, types:RoleV2Input input) returns error? {
     log:printDebug(string `Updating role: ${roleId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
-        `UPDATE roles_v2 
-         SET role_name = ${input.roleName}, 
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
+        `UPDATE roles_v2
+         SET role_name = ${input.roleName},
              description = ${input.description}
          WHERE role_id = ${roleId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to update role ${roleId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A role with this name already exists", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Role not found: ${roleId}`);
@@ -219,9 +261,17 @@ public isolated function updateRoleV2(string roleId, types:RoleV2Input input) re
 public isolated function deleteRoleV2(string roleId) returns error? {
     log:printDebug(string `Deleting role: ${roleId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
         `DELETE FROM roles_v2 WHERE role_id = ${roleId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to delete role ${roleId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete role because it is assigned to one or more groups", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Role not found: ${roleId}`);
@@ -313,8 +363,16 @@ public isolated function addUserToGroup(string userId, string groupId) returns e
          VALUES (${groupId}, ${userId})`
     );
 
+    if result is sql:Error {
+        log:printError(string `Failed to add user ${userId} to group ${groupId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("This user is already a member of the group", result); }
+            FOREIGN_KEY_VIOLATION => { return error("The specified user or group does not exist", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
     if result is error {
-        log:printError(string `Failed to add user ${userId} to group ${groupId}`, result);
+        log:printError(string `Failed to add user ${userId} to group ${groupId}`, 'error = result);
         return result;
     }
 
@@ -326,10 +384,15 @@ public isolated function addUserToGroup(string userId, string groupId) returns e
 public isolated function removeUserFromGroup(string userId, string groupId) returns error? {
     log:printDebug(string `Removing user ${userId} from group ${groupId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
-        `DELETE FROM group_user_mapping 
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
+        `DELETE FROM group_user_mapping
          WHERE group_id = ${groupId} AND user_uuid = ${userId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to remove user ${userId} from group ${groupId}`, 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `User ${userId} not found in group ${groupId}`);
@@ -350,8 +413,16 @@ public isolated function assignRoleToGroup(types:AssignRoleToGroupInput input) r
          VALUES (${input.groupId}, ${input.roleId}, ${orgId}, ${input.projectUuid}, ${input.envUuid}, ${input.integrationUuid})`
     );
 
+    if result is sql:Error {
+        log:printError(string `Failed to assign role ${input.roleId} to group ${input.groupId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("This role assignment already exists", result); }
+            FOREIGN_KEY_VIOLATION => { return error("The specified group or role does not exist", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
     if result is error {
-        log:printError(string `Failed to assign role ${input.roleId} to group ${input.groupId}`, result);
+        log:printError(string `Failed to assign role ${input.roleId} to group ${input.groupId}`, 'error = result);
         return result;
     }
 
@@ -368,9 +439,14 @@ public isolated function assignRoleToGroup(types:AssignRoleToGroupInput input) r
 public isolated function removeRoleFromGroup(int mappingId) returns error? {
     log:printDebug(string `Removing group-role mapping with ID: ${mappingId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
         `DELETE FROM group_role_mapping WHERE id = ${mappingId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to remove group-role mapping ${mappingId}`, 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Group-role mapping not found: ${mappingId}`);
@@ -439,7 +515,16 @@ public isolated function updateGroupRoleMapping(int mappingId, types:UpdateGroup
 
     updateQuery = sql:queryConcat(updateQuery, ` WHERE id = ${mappingId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(updateQuery);
+    sql:ExecutionResult|sql:Error result = dbClient->execute(updateQuery);
+
+    if result is sql:Error {
+        log:printError(string `Failed to update group-role mapping ${mappingId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("This role assignment already exists", result); }
+            FOREIGN_KEY_VIOLATION => { return error("The specified group or role does not exist", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `Group-role mapping not found: ${mappingId}`);
@@ -464,8 +549,15 @@ public isolated function assignPermissionsToRole(string roleId, string[] permiss
         check commit;
         log:printInfo(string `Successfully assigned ${permissionIds.length()} permissions to role ${roleId}`);
     } on fail error e {
-        log:printError(string `Transaction failed while assigning permissions to role ${roleId}`, e);
-        return error(string `Failed to assign permissions to role ${roleId}`, e);
+        log:printError(string `Transaction failed while assigning permissions to role ${roleId}`, 'error = e);
+        if e is sql:Error {
+            match classifySqlError(e) {
+                DUPLICATE_KEY => { return error("This permission is already assigned to the role", e); }
+                FOREIGN_KEY_VIOLATION => { return error("The specified permission does not exist", e); }
+                _ => { return error("An unexpected error occurred. Please contact your administrator.", e); }
+            }
+        }
+        return error("An unexpected error occurred while assigning permissions. Please contact your administrator.", e);
     }
 
     return ();
@@ -490,8 +582,8 @@ public isolated function removePermissionsFromRole(string roleId, string[] permi
         check commit;
         log:printInfo(string `Successfully removed permissions from role ${roleId}`);
     } on fail error e {
-        log:printError(string `Transaction failed while removing permissions from role ${roleId}`, e);
-        return error(string `Failed to remove permissions from role ${roleId}`, e);
+        log:printError(string `Transaction failed while removing permissions from role ${roleId}`, 'error = e);
+        return error("An unexpected error occurred while removing permissions. Please contact your administrator.", e);
     }
 
     return ();

--- a/icp_server/modules/storage/auth_token_repository.bal
+++ b/icp_server/modules/storage/auth_token_repository.bal
@@ -38,8 +38,11 @@ public isolated function storeRefreshToken(string tokenId, string userId, string
     sql:ExecutionResult|sql:Error result = dbClient->execute(insertQuery);
 
     if result is sql:Error {
-        log:printError(string `Failed to store refresh token for user ${userId}`, result);
-        return result;
+        log:printError(string `Failed to store refresh token for user ${userId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A refresh token with this ID already exists", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
 
     log:printInfo(string `Successfully stored refresh token for user ${userId}`);
@@ -117,8 +120,8 @@ public isolated function revokeRefreshToken(string tokenHash) returns error? {
     sql:ExecutionResult|sql:Error result = dbClient->execute(updateQuery);
 
     if result is sql:Error {
-        log:printError("Failed to revoke refresh token", result);
-        return result;
+        log:printError("Failed to revoke refresh token", 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
     }
 
     int? affectedRows = result.affectedRowCount;
@@ -144,8 +147,8 @@ public isolated function revokeAllUserRefreshTokens(string userId) returns error
     sql:ExecutionResult|sql:Error result = dbClient->execute(updateQuery);
 
     if result is sql:Error {
-        log:printError(string `Failed to revoke refresh tokens for user ${userId}`, result);
-        return result;
+        log:printError(string `Failed to revoke refresh tokens for user ${userId}`, 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
     }
 
     int? affectedRows = result.affectedRowCount;
@@ -164,8 +167,8 @@ public isolated function cleanupExpiredRefreshTokens() returns error? {
     sql:ExecutionResult|sql:Error result = dbClient->execute(deleteQuery);
 
     if result is sql:Error {
-        log:printError("Failed to cleanup expired refresh tokens", result);
-        return result;
+        log:printError("Failed to cleanup expired refresh tokens", 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
     }
 
     int? deletedCount = result.affectedRowCount;

--- a/icp_server/modules/storage/component_repository.bal
+++ b/icp_server/modules/storage/component_repository.bal
@@ -33,7 +33,13 @@ public isolated function createComponent(types:ComponentInput component) returns
                                           VALUES (${componentId}, ${component.projectId}, ${component.name}, ${displayName}, ${component.description}, ${componentTypeValue}, ${component.createdBy})`;
     var result = dbClient->execute(insertQuery);
     if result is sql:Error {
-        return result;
+        log:printError(string `Failed to create component: ${component.name}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A component with this name already exists in this project", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            FOREIGN_KEY_VIOLATION => { return error("The specified project does not exist", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     return getComponentById(componentId);
 }
@@ -270,8 +276,11 @@ public isolated function deleteComponent(string componentId) returns error? {
     sql:ParameterizedQuery deleteQuery = `DELETE FROM components WHERE component_id = ${componentId}`;
     var result = dbClient->execute(deleteQuery);
     if result is sql:Error {
-        log:printError(string `Failed to delete component ${componentId}`, result);
-        return result;
+        log:printError(string `Failed to delete component ${componentId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete component because it has dependent resources", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully deleted component ${componentId}`);
     return ();
@@ -295,8 +304,12 @@ public isolated function updateComponent(string componentId, string? name, strin
     sql:ParameterizedQuery updateQuery = sql:queryConcat(`UPDATE components `, updateFields, whereClause);
     var result = dbClient->execute(updateQuery);
     if result is sql:Error {
-        log:printError(string `Failed to update component ${componentId}`, result);
-        return result;
+        log:printError(string `Failed to update component ${componentId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("A component with this name already exists in this project", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully updated component ${componentId}`);
     return ();

--- a/icp_server/modules/storage/environment_repository.bal
+++ b/icp_server/modules/storage/environment_repository.bal
@@ -216,12 +216,12 @@ public isolated function createEnvironment(types:EnvironmentInput environment) r
     VALUES (${envId}, ${environment.name}, ${environment.description}, ${environment.critical}, ${environment.createdBy})`;
     var result = dbClient->execute(insertQuery);
     if result is sql:Error {
-        // If error is not duplicate entry, log and return
-        if !result.toString().toLowerAscii().includes("duplicate") {
-            log:printError(string `Failed to insert environment: ${environment.name}`, result);
-            return result;
+        log:printError(string `Failed to insert environment: ${environment.name}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return (); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
         }
-        return ();
     }
 
     // Return the created environment
@@ -246,8 +246,12 @@ public isolated function updateEnvironment(string environmentId, string? name, s
     sql:ParameterizedQuery updateQuery = sql:queryConcat(`UPDATE environments `, updateFields, whereClause);
     var result = dbClient->execute(updateQuery);
     if result is sql:Error {
-        log:printError(string `Failed to update environment ${environmentId}`, result);
-        return result;
+        log:printError(string `Failed to update environment ${environmentId}`, 'error = result);
+        match classifySqlError(result) {
+            DUPLICATE_KEY => { return error("An environment with this name already exists", result); }
+            VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully updated environment ${environmentId}`);
     return ();
@@ -258,8 +262,8 @@ public isolated function updateEnvironmentProductionStatus(string environmentId,
     sql:ParameterizedQuery updateQuery = `UPDATE environments SET critical = ${critical}, updated_at = CURRENT_TIMESTAMP WHERE environment_id = ${environmentId}`;
     var result = dbClient->execute(updateQuery);
     if result is sql:Error {
-        log:printError(string `Failed to update environment production status ${environmentId}`, result);
-        return result;
+        log:printError(string `Failed to update environment production status ${environmentId}`, 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
     }
     log:printInfo(string `Successfully updated environment production status ${environmentId}`);
     return ();
@@ -285,8 +289,11 @@ public isolated function deleteEnvironment(string environmentId) returns error? 
     sql:ParameterizedQuery deleteQuery = `DELETE FROM environments WHERE environment_id = ${environmentId}`;
     var result = dbClient->execute(deleteQuery);
     if result is sql:Error {
-        log:printError(string `Failed to delete environment ${environmentId}`, result);
-        return result;
+        log:printError(string `Failed to delete environment ${environmentId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete environment because it has dependent resources", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully deleted environment ${environmentId}`);
     return ();

--- a/icp_server/modules/storage/error_mapper.bal
+++ b/icp_server/modules/storage/error_mapper.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/sql;
+
+// Category of a database error, determined by inspecting the raw sql:Error
+// message. Call sites use this to select a domain-specific, user-friendly
+// message without the classifier needing to know about any entity.
+enum SqlErrorCategory {
+    DUPLICATE_KEY,
+    VALUE_TOO_LONG,
+    FOREIGN_KEY_VIOLATION,
+    UNKNOWN_SQL_ERROR
+}
+
+// Classifies a raw sql:Error into a high-level category by inspecting
+// the error message for well-known database error patterns
+// (PostgreSQL, MySQL, MSSQL).
+//
+// The classifier has NO knowledge of entities, constraint names, or
+// user-facing messages — that belongs to the call site.
+isolated function classifySqlError(sql:Error err) returns SqlErrorCategory {
+    string msg = err.message().toLowerAscii();
+
+    if msg.includes("duplicate key") || msg.includes("duplicate entry") ||
+            msg.includes("unique constraint") || msg.includes("unique_violation") {
+        return DUPLICATE_KEY;
+    }
+
+    if msg.includes("value too long") || msg.includes("data too long") ||
+            msg.includes("string or binary data would be truncated") {
+        return VALUE_TOO_LONG;
+    }
+
+    if msg.includes("foreign key") || msg.includes("violates foreign key") {
+        return FOREIGN_KEY_VIOLATION;
+    }
+
+    return UNKNOWN_SQL_ERROR;
+}

--- a/icp_server/modules/storage/project_repository.bal
+++ b/icp_server/modules/storage/project_repository.bal
@@ -64,8 +64,8 @@ public isolated function createProject(types:ProjectInput project, types:UserCon
     transaction {
         // Insert project with all new fields
         sql:ParameterizedQuery insertQuery = `INSERT INTO projects (
-            project_id, org_id, name, version, handler, region, description, 
-            default_deployment_pipeline_id, deployment_pipeline_ids, type, 
+            project_id, org_id, name, version, handler, region, description,
+            default_deployment_pipeline_id, deployment_pipeline_ids, type,
             git_provider, git_organization, repository, branch, secret_ref,
             owner_id, created_by
         ) VALUES (
@@ -85,15 +85,22 @@ public isolated function createProject(types:ProjectInput project, types:UserCon
                 createdBy = displayName);
 
         // RBAC v2: Create project-specific admin group and assign Project Admin role
+        // Errors from the RBAC setup are handled individually so that a duplicate
+        // group name is not misreported as a duplicate project name.
+
         // 1. Create project admin group
         string adminGroupId = uuid:createType1AsString();
         string groupName = string `${project.name} Admins`;
         string groupDescription = string `Admin group for project: ${project.name}`;
 
-        sql:ExecutionResult _ = check dbClient->execute(`
+        sql:ExecutionResult|sql:Error groupResult = dbClient->execute(`
             INSERT INTO user_groups (group_id, group_name, org_uuid, description)
             VALUES (${adminGroupId}, ${groupName}, 1, ${groupDescription})
         `);
+        if groupResult is sql:Error {
+            log:printError(string `Failed to create admin group for project: ${project.name}`, 'error = groupResult);
+            fail error("Failed to set up project admin group. Please contact your administrator.", groupResult);
+        }
         log:printInfo(string `Created project admin group: ${groupName}`,
                 groupId = adminGroupId,
                 projectId = projectId);
@@ -102,20 +109,28 @@ public isolated function createProject(types:ProjectInput project, types:UserCon
         string projectAdminRoleId = check getProjectAdminRoleId();
 
         // 3. Map group to Project Admin role (project-scoped, all environments)
-        sql:ExecutionResult _ = check dbClient->execute(`
+        sql:ExecutionResult|sql:Error roleMappingResult = dbClient->execute(`
             INSERT INTO group_role_mapping (group_id, role_id, org_uuid, project_uuid)
             VALUES (${adminGroupId}, ${projectAdminRoleId}, 1, ${projectId})
         `);
+        if roleMappingResult is sql:Error {
+            log:printError(string `Failed to assign admin role for project: ${project.name}`, 'error = roleMappingResult);
+            fail error("Failed to set up project admin role. Please contact your administrator.", roleMappingResult);
+        }
         log:printInfo(string `Mapped group to Project Admin role for project`,
                 groupId = adminGroupId,
                 roleId = projectAdminRoleId,
                 projectId = projectId);
 
         // 4. Add creator to admin group
-        sql:ExecutionResult _ = check dbClient->execute(`
+        sql:ExecutionResult|sql:Error userMappingResult = dbClient->execute(`
             INSERT INTO group_user_mapping (group_id, user_uuid)
             VALUES (${adminGroupId}, ${userId})
         `);
+        if userMappingResult is sql:Error {
+            log:printError(string `Failed to add creator to admin group for project: ${project.name}`, 'error = userMappingResult);
+            fail error("Failed to add user to project admin group. Please contact your administrator.", userMappingResult);
+        }
         log:printInfo(string `Added project creator to admin group`,
                 userId = userId,
                 groupId = adminGroupId,
@@ -125,6 +140,19 @@ public isolated function createProject(types:ProjectInput project, types:UserCon
         log:printInfo(string `Successfully created project and assigned admin roles`,
                 projectId = projectId,
                 owner = displayName);
+    } on fail error e {
+        log:printError(string `Failed to create project: ${project.name}`, 'error = e);
+        // Only the project INSERT uses `check`, so sql:Error here is project-specific.
+        // RBAC setup errors arrive as plain errors with their own messages via `fail`.
+        if e is sql:Error {
+            match classifySqlError(e) {
+                DUPLICATE_KEY => { return error("A project with this name already exists in this organization", e); }
+                VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", e); }
+                FOREIGN_KEY_VIOLATION => { return error("Cannot complete the operation due to a dependency constraint", e); }
+                _ => { return error("An unexpected error occurred. Please contact your administrator.", e); }
+            }
+        }
+        return e;
     }
 
     return getProjectById(projectId);
@@ -282,8 +310,15 @@ public isolated function updateProjectWithInput(types:ProjectUpdateInput project
         check commit;
         log:printInfo(string `Successfully updated project ${project.id}`);
     } on fail error e {
-        log:printError(string `Failed to update project ${project.id}`, e);
-        return error(string `Failed to update project ${project.id}`, e);
+        log:printError(string `Failed to update project ${project.id}`, 'error = e);
+        if e is sql:Error {
+            match classifySqlError(e) {
+                DUPLICATE_KEY => { return error("A project with this name already exists in this organization", e); }
+                VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", e); }
+                _ => { return error("An unexpected error occurred. Please contact your administrator.", e); }
+            }
+        }
+        return error("An unexpected error occurred while updating the project. Please contact your administrator.", e);
     }
 
     return ();
@@ -294,8 +329,11 @@ public isolated function deleteProject(string projectId) returns error? {
     sql:ParameterizedQuery deleteQuery = `DELETE FROM projects WHERE project_id = ${projectId}`;
     var result = dbClient->execute(deleteQuery);
     if result is sql:Error {
-        log:printError(string `Failed to delete project ${projectId}`, result);
-        return result;
+        log:printError(string `Failed to delete project ${projectId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete project because it has dependent resources", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully deleted project ${projectId}`);
     return ();

--- a/icp_server/modules/storage/runtime_repository.bal
+++ b/icp_server/modules/storage/runtime_repository.bal
@@ -168,8 +168,11 @@ public isolated function deleteRuntime(string runtimeId) returns error? {
     sql:ParameterizedQuery deleteQuery = `DELETE FROM runtimes WHERE runtime_id = ${runtimeId}`;
     var result = dbClient->execute(deleteQuery);
     if result is sql:Error {
-        log:printError(string `Failed to delete runtime ${runtimeId}`, result);
-        return result;
+        log:printError(string `Failed to delete runtime ${runtimeId}`, 'error = result);
+        match classifySqlError(result) {
+            FOREIGN_KEY_VIOLATION => { return error("Cannot delete runtime because it has dependent resources", result); }
+            _ => { return error("An unexpected error occurred. Please contact your administrator.", result); }
+        }
     }
     log:printInfo(string `Successfully deleted runtime ${runtimeId}`);
 }

--- a/icp_server/modules/storage/user_repository.bal
+++ b/icp_server/modules/storage/user_repository.bal
@@ -157,8 +157,16 @@ public isolated function createUserV2(string userId, string username, string dis
         check commit;
         log:printInfo(string `Successfully created user ${username} with ${groupIds.length()} group assignments`, userId = userId);
     } on fail error e {
-        log:printError(string `Transaction failed while creating user ${username}`, e);
-        return error(string `Failed to create user ${username}`, e);
+        log:printError(string `Transaction failed while creating user ${username}`, 'error = e);
+        if e is sql:Error {
+            match classifySqlError(e) {
+                DUPLICATE_KEY => { return error("A user with this username already exists", e); }
+                VALUE_TOO_LONG => { return error("The provided value exceeds the maximum allowed length", e); }
+                FOREIGN_KEY_VIOLATION => { return error("The specified group does not exist", e); }
+                _ => { return error("An unexpected error occurred. Please contact your administrator.", e); }
+            }
+        }
+        return error("An unexpected error occurred while creating the user. Please contact your administrator.", e);
     }
     
     // Fetch and return the created user with groups
@@ -222,8 +230,14 @@ public isolated function deleteUserV2(string userId, string currentUserId) retur
         
         log:printInfo(string `Successfully deleted user ${userId} from main database`);
     } on fail error e {
-        log:printError(string `Transaction failed while deleting user ${userId}`, e);
-        return error(string `Failed to delete user ${userId}`, e);
+        log:printError(string `Transaction failed while deleting user ${userId}`, 'error = e);
+        if e is sql:Error {
+            match classifySqlError(e) {
+                FOREIGN_KEY_VIOLATION => { return error("Cannot delete user because they have dependent resources", e); }
+                _ => { return error("An unexpected error occurred. Please contact your administrator.", e); }
+            }
+        }
+        return error("An unexpected error occurred while deleting the user. Please contact your administrator.", e);
     }
 }
 
@@ -231,11 +245,16 @@ public isolated function deleteUserV2(string userId, string currentUserId) retur
 public isolated function setRequirePasswordChange(string userId, boolean requireChange) returns error? {
     log:printDebug(string `Setting require_password_change=${requireChange.toString()} for user: ${userId}`);
 
-    sql:ExecutionResult result = check dbClient->execute(
+    sql:ExecutionResult|sql:Error result = dbClient->execute(
         `UPDATE users
          SET require_password_change = ${requireChange}, updated_at = CURRENT_TIMESTAMP
          WHERE user_id = ${userId}`
     );
+
+    if result is sql:Error {
+        log:printError(string `Failed to update password change flag for user ${userId}`, 'error = result);
+        return error("An unexpected error occurred. Please contact your administrator.", result);
+    }
 
     if result.affectedRowCount == 0 {
         return error(string `User not found: ${userId}`);


### PR DESCRIPTION
## Summary
- Fixes #421
- Adds a shared `classifySqlError()` classifier that categorizes `sql:Error` into high-level enums (`DUPLICATE_KEY`, `VALUE_TOO_LONG`, `FOREIGN_KEY_VIOLATION`, etc.) without any entity-specific knowledge
- Each repository call site matches on the category and returns its own domain-specific, user-friendly error message with the original error preserved as the cause
- Raw SQL statements, table names, column names, and constraint names are no longer exposed in GraphQL `errors[].message`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and improved user-facing error messages across storage operations (projects, environments, components, runtimes, users, groups, roles, permissions) for duplicates, length limits, foreign-key conflicts and transaction failures.
  * Consistent structured logging for database failures; unexpected cases now return a generic administrator-contact message.

* **New Features**
  * Centralized SQL error classification to drive clearer, contextual error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->