### PR TITLE
Mark payload as an optional parameter in control command

### DIFF
--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -214,7 +214,7 @@ public type ControlCommand record {
     ControlAction action;
     time:Utc issuedAt;
     ControlCommandStatus status; // pending, sent, acknowledged, failed
-    string? payload?; // JSON payload for actions that need additional data
+    string payload?; // JSON payload for actions that need additional data
 };
 
 public type HeartbeatResponse record {


### PR DESCRIPTION
## Purpose
- Mark payload as an optional parameter in the control command


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined command payload type structure to ensure consistent handling and validation across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->