### PR TITLE
Fix POSIX compatibility in icp.sh

### DIFF
--- a/distribution/scripts/icp.sh
+++ b/distribution/scripts/icp.sh
@@ -19,7 +19,7 @@
 # ICP Server Launcher Script
 # Usage: ./icp.sh
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 JAR_FILE="$SCRIPT_DIR/icp-server.jar"
 PARENT_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG_FILE="$PARENT_DIR/conf/deployment.toml"


### PR DESCRIPTION
## Purpose
> ${BASH_SOURCE[0]} is Bash-only and fails on systems where sh is a minimal POSIX shell (Alpine's ash, Debian/Ubuntu's dash). Replacing with $0 ensures the script works when invoked with sh or bash on all platforms.

## Goals
> Fixes : https://github.com/wso2/product-integrator/issues/186.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal script initialization logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->