### PR TITLE
BOT - VERIFY: Fix #269: Remove redundant timestamp from auth response and log calls

### DIFF
--- a/icp_server/default_user_service.bal
+++ b/icp_server/default_user_service.bal
@@ -137,8 +137,7 @@ service / on defaultAuthServiceListener {
                             authenticated: true,
                             userId: credentials.userId,
                             displayName: credentials.displayName,
-                            isSuperAdmin: credentials.username == "admin",
-                            timestamp: time:utcToString(time:utcNow())
+                            isSuperAdmin: credentials.username == "admin"
                         }
                     };
                 }
@@ -422,7 +421,7 @@ isolated function clearLockoutAttrs(string userId) returns error? {
 
 isolated function recordFailedLogin(string userId, int currentFailedAttempts) returns error? {
     string now = time:utcToString(time:utcNow());
-    log:printDebug("Recording failed login", userId = userId, newCount = currentFailedAttempts + 1, timestamp = now);
+    log:printDebug("Recording failed login", userId = userId, newCount = currentFailedAttempts + 1);
     check upsertUserAttr(userId, FAILED_LOGIN_ATTEMPTS, (currentFailedAttempts + 1).toString());
     check upsertUserAttr(userId, LAST_FAILED_LOGIN_AT, now);
 }

--- a/icp_server/ldap_user_service.bal
+++ b/icp_server/ldap_user_service.bal
@@ -18,7 +18,6 @@ import ballerina/crypto;
 import ballerina/http;
 import ballerina/ldap;
 import ballerina/log;
-import ballerina/time;
 
 import icp_server.types;
 import icp_server.utils;
@@ -216,8 +215,7 @@ service object {
                 authenticated: true,
                 userId: userId,
                 displayName: displayName,
-                isSuperAdmin: isSuperAdmin,
-                timestamp: time:utcToString(time:utcNow())
+                isSuperAdmin: isSuperAdmin
             }
         };
     }

--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -1910,9 +1910,8 @@ public type AuthenticateResponse record {
     boolean authenticated;
     string? userId;
     string? displayName;
-    string? timestamp;
     // Optional: auth backends that manage role-to-superadmin mapping (e.g. LDAP)
-    // may include this to signal the ICP server to grant superadmin on login.
+    // may indicate this to grant superadmin on login.
     boolean? isSuperAdmin;
 };
 

--- a/icp_server/tests/auth_tests_v2.bal
+++ b/icp_server/tests/auth_tests_v2.bal
@@ -996,3 +996,29 @@ function testDeleteRole() returns error? {
     );
     test:assertEquals(getResponse.statusCode, 404, "Role should not exist after deletion");
 }
+
+// =============================================================================
+// Regression test: Issue #269 — Timestamp must not be duplicated in logs
+// The auth backend response body must NOT contain a 'timestamp' field;
+// the Ballerina log framework already prefixes every line with 'time=<ISO-8601>'.
+// =============================================================================
+
+@test:Config {
+    groups: ["auth-v2", "login", "regression"]
+}
+function testLoginResponseDoesNotContainTimestamp() returns error? {
+    json loginRequest = {
+        username: SUPER_ADMIN_USERNAME,
+        password: SUPER_ADMIN_PASSWORD
+    };
+
+    http:Response response = check authV2Client->post("/auth/login", loginRequest);
+    test:assertEquals(response.statusCode, 200, "Login should succeed with valid credentials");
+
+    json responseBody = check response.getJsonPayload();
+
+    // The 'timestamp' field must NOT be present in the login response.
+    // Its presence would cause duplicate timestamps in logs (issue #269).
+    json|error tsField = responseBody.timestamp;
+    test:assertTrue(tsField is error, "Login response must not include a 'timestamp' field (issue #269)");
+}


### PR DESCRIPTION
## Related Issue

Fixes wso2/product-integrator#456 — Timestamp is repeated in logs

## Root Cause

Two sources produced duplicate timestamp output:

1. **Auth backend HTTP responses** (`default_user_service.bal`, `ldap_user_service.bal`) included `timestamp: time:utcToString(time:utcNow())` in their JSON response bodies. The `auth_service.bal` front-end never read this field — the Ballerina `log` module already prefixes every log line with `time=<ISO-8601>` automatically.

2. **`recordFailedLogin` log call** (`default_user_service.bal`) passed `timestamp = now` as an explicit named parameter to `log:printDebug`, causing the runtime-generated `time=` prefix to appear alongside an additional `timestamp=` key in the same log line.

## Changes

| File | Change |
|------|--------|
| `icp_server/default_user_service.bal` | Removed `timestamp: time:utcToString(time:utcNow())` from `<http:Ok>` authenticate response body; removed `timestamp = now` named arg from `log:printDebug` in `recordFailedLogin` |
| `icp_server/ldap_user_service.bal` | Removed `timestamp: time:utcToString(time:utcNow())` from `<http:Ok>` authenticate response body; removed now-unused `import ballerina/time;` |
| `icp_server/modules/types/types.bal` | Removed `string? timestamp;` field from `AuthenticateResponse` record |
| `icp_server/tests/auth_tests_v2.bal` | Added regression test `testLoginResponseDoesNotContainTimestamp` that asserts the login response body does not contain a `timestamp` field |

## Test Coverage

- New regression test in group `["auth-v2", "login", "regression"]` verifies `POST /auth/login` response body has no `timestamp` field.
- Existing `testSuperAdminLoginWithV2JWT` and all other auth tests continue to pass unchanged.

---

> This PR was created by the WSO2 ICP AI Agent. Please review and verify before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the optional `timestamp` field from authentication API responses. The authentication endpoints now return only `authenticated`, `userId`, `displayName`, and `isSuperAdmin` fields.

* **Tests**
  * Added regression test to verify authentication API responses do not include the `timestamp` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->