### PR TITLE
Fix icp startup instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,8 +235,8 @@ jobs:
           2. Extract the archive: `unzip wso2-integration-control-plane-${{ steps.version.outputs.version }}.zip`
           3. Navigate to the bin directory: `cd wso2-integration-control-plane-${{ steps.version.outputs.version }}/bin`
           4. Run the server:
-             - Linux/macOS: `./icp.sh start`
-             - Windows: `icp.bat start`
+             - Linux/macOS: `./icp.sh`
+             - Windows: `icp.bat`
 
           ### System Requirements
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ unzip build/distribution/wso2-integration-control-plane-<version>.zip -d build/d
 cd build/distribution/wso2-integration-control-plane-<version>/bin
 
 # Start the server
-./icp.sh start    # Linux/macOS
-icp.bat start     # Windows
+./icp.sh    # Linux/macOS
+icp.bat    # Windows
 ```
 
 ## Development Setup


### PR DESCRIPTION
_##_ Purpose
- Fix icp startup instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified startup commands required to run the distribution across all platforms by removing unnecessary arguments from platform-specific scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->