### PR TITLE
Make metrics graphs legend clickable

### DIFF
--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -420,7 +420,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   }, [apis, selectedApiKeys]);
 
   const showIntegrationName = true;
-  const showDate = (TIME_RANGES[timeRange] ?? 1) > 24;
+  const showDate = (TIME_RANGES[timeRange] ?? 1) >= 24;
   const makeLabel = useCallback((iso: string) => formatLabel(iso, showDate), [showDate]);
   const overviewXAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
   const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, makeLabel), [effectiveSelectedApis, makeLabel]);

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -35,6 +35,18 @@ const DEFAULT_RESOLUTION: Record<string, string> = {
 };
 const LINE_OPTS = { dot: false, connectNulls: true, type: 'linear' as const };
 
+const OVERVIEW_REQUEST_LINES = [
+  { dataKey: 'successful', name: 'Success', stroke: '#4caf50' },
+  { dataKey: 'failed', name: 'Failed', stroke: '#d32f2f' },
+] as const;
+
+const OVERVIEW_LATENCY_LINES = [
+  { dataKey: 'avg', name: 'Average', stroke: '#4caf50' },
+  { dataKey: 'p50', name: '50th Percentile', stroke: '#2196f3' },
+  { dataKey: 'p95', name: '95th Percentile', stroke: '#ff9800' },
+  { dataKey: 'p99', name: '99th Percentile', stroke: '#9c27b0' },
+] as const;
+
 function normalizeServiceType(st?: string): string {
   if (!st || st.toLowerCase() === 'ballerina' || st === 'BI') return 'BI';
   return st.toUpperCase();
@@ -66,6 +78,7 @@ interface ApiSummary {
   integrationName: string;
   key: string;
   requestCount: number;
+  errorCount: number;
   avgResponseTime: number;
   errorRate: number;
   entries: MetricEntry[];
@@ -123,6 +136,7 @@ function deriveApis(metrics: MetricEntry[], runtimeComponentMap: Record<string, 
         integrationName,
         key,
         requestCount: total,
+        errorCount: failReqs,
         avgResponseTime: avgMs,
         errorRate: total > 0 ? (failReqs / total) * 100 : 0,
         entries: allEntries,
@@ -183,7 +197,7 @@ function aggregate(metrics: MetricEntry[]) {
 }
 
 // Build per-API chart data: each selected API becomes a line
-function buildApiChartData(apis: ApiSummary[], showType: boolean) {
+function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (iso: string) => string) {
   const allTimestamps = new Set<string>();
   for (const api of apis) {
     for (const entry of api.entries) {
@@ -192,7 +206,7 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean) {
   }
   const sorted = [...allTimestamps].sort();
   const reqData = sorted.map((ts) => {
-    const row: Record<string, string | number> = { label: formatTime(ts) };
+    const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
       const key = apiDisplayLabelWithType(api, showType);
       row[key] = api.entries.reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
@@ -200,7 +214,7 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean) {
     return row;
   });
   const latData = sorted.map((ts) => {
-    const row: Record<string, string | number> = { label: formatTime(ts) };
+    const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
       const key = apiDisplayLabelWithType(api, showType);
       let sum = 0,
@@ -219,8 +233,14 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean) {
   return { reqData, latData };
 }
 
-function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+function formatLabel(iso: string, showDate: boolean): string {
+  const d = new Date(iso);
+  if (showDate) {
+    const date = `${d.getMonth() + 1}/${d.getDate()}`;
+    const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    return `${date} ${time}`;
+  }
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 function isUnavailable(error: unknown): boolean {
@@ -259,6 +279,26 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   const [timeRange, setTimeRange] = useState('Past 1 hour');
   const [integrationFilter, setIntegrationFilter] = useState('all');
   const [selectedApiKeys, setSelectedApiKeys] = useState<string[]>([]);
+  const [hiddenOverviewLines, setHiddenOverviewLines] = useState<Set<string>>(new Set());
+  const [hiddenApiLines, setHiddenApiLines] = useState<Set<string>>(new Set());
+
+  const toggleOverviewLine = useCallback((key: string) => {
+    setHiddenOverviewLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const toggleApiLine = useCallback((key: string) => {
+    setHiddenApiLines((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
 
   const effectiveEnvId = envFilter || environments[0]?.id || '';
   const componentId = isComponent ? (singleComponent?.id ?? '') : '';
@@ -315,11 +355,14 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   }, [apis, selectedApiKeys]);
 
   const showIntegrationName = true;
-  const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, showIntegrationName), [effectiveSelectedApis, showIntegrationName]);
+  const showDate = (TIME_RANGES[timeRange] ?? 1) > 24;
+  const makeLabel = useCallback((iso: string) => formatLabel(iso, showDate), [showDate]);
+  const xAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
+  const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
   const apiLineKeys = effectiveSelectedApis.map((a) => apiDisplayLabelWithType(a, showIntegrationName));
 
-  const requestsChartData = useMemo(() => requestsData.map((d) => ({ ...d, label: formatTime(d.time) })), [requestsData]);
-  const latencyChartData = useMemo(() => latencyData.map((d) => ({ ...d, label: formatTime(d.time) })), [latencyData]);
+  const requestsChartData = useMemo(() => requestsData.map((d) => ({ ...d, label: makeLabel(d.time) })), [requestsData, makeLabel]);
+  const latencyChartData = useMemo(() => latencyData.map((d) => ({ ...d, label: makeLabel(d.time) })), [latencyData, makeLabel]);
 
   // Early returns
   const loadingContext = isComponent ? loadingComponent : loadingComponents;
@@ -441,13 +484,22 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                     data={requestsChartData}
                     xAxisDataKey="label"
                     height={350}
-                    legend={{ show: true, align: 'center', verticalAlign: 'bottom' }}
+                    legend={{ show: false }}
                     grid={{ show: true, strokeDasharray: '3 3' }}
-                    lines={[
-                      { dataKey: 'successful', name: 'Success', stroke: '#4caf50', ...LINE_OPTS },
-                      { dataKey: 'failed', name: 'Failed', stroke: '#d32f2f', ...LINE_OPTS },
-                    ]}
+                    xAxis={{ interval: xAxisInterval }}
+                    margin={{ bottom: 20 }}
+                    lines={OVERVIEW_REQUEST_LINES.map((l) => ({ ...l, hide: hiddenOverviewLines.has(l.dataKey), ...LINE_OPTS }))}
                   />
+                  <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
+                    {OVERVIEW_REQUEST_LINES.map((l) => (
+                      <Stack key={l.dataKey} direction="row" alignItems="center" gap={0.75} onClick={() => toggleOverviewLine(l.dataKey)} sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                        <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
+                        <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
+                          {l.name}
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
                 </CardContent>
               </Card>
             </Grid>
@@ -455,21 +507,28 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
               <Card variant="outlined">
                 <CardContent>
                   <Typography variant="h6" sx={{ mb: 1 }}>
-                    Request Latency
+                    Request Latency (ms)
                   </Typography>
                   <LineChart
                     data={latencyChartData}
                     xAxisDataKey="label"
                     height={350}
-                    legend={{ show: true, align: 'center', verticalAlign: 'bottom' }}
+                    legend={{ show: false }}
                     grid={{ show: true, strokeDasharray: '3 3' }}
-                    lines={[
-                      { dataKey: 'avg', name: 'Average', stroke: '#4caf50', ...LINE_OPTS },
-                      { dataKey: 'p50', name: '50th Percentile', stroke: '#2196f3', ...LINE_OPTS },
-                      { dataKey: 'p95', name: '95th Percentile', stroke: '#ff9800', ...LINE_OPTS },
-                      { dataKey: 'p99', name: '99th Percentile', stroke: '#9c27b0', ...LINE_OPTS },
-                    ]}
+                    xAxis={{ interval: xAxisInterval }}
+                    margin={{ bottom: 20 }}
+                    lines={OVERVIEW_LATENCY_LINES.map((l) => ({ ...l, hide: hiddenOverviewLines.has(l.dataKey), ...LINE_OPTS }))}
                   />
+                  <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
+                    {OVERVIEW_LATENCY_LINES.map((l) => (
+                      <Stack key={l.dataKey} direction="row" alignItems="center" gap={0.75} onClick={() => toggleOverviewLine(l.dataKey)} sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                        <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
+                        <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
+                          {l.name}
+                        </Typography>
+                      </Stack>
+                    ))}
+                  </Stack>
                 </CardContent>
               </Card>
             </Grid>
@@ -492,6 +551,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                           <TableCell>API Name</TableCell>
                           <TableCell>Method</TableCell>
                           <TableCell align="right">Request Count</TableCell>
+                          <TableCell align="right">Error Count</TableCell>
                           <TableCell align="right">Avg Response Time (ms)</TableCell>
                           <TableCell align="right">Error Rate (%)</TableCell>
                         </TableRow>
@@ -507,6 +567,9 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                             </TableCell>
                             <TableCell>{api.method || '\u2014'}</TableCell>
                             <TableCell align="right">{api.requestCount}</TableCell>
+                            <TableCell align="right" sx={{ color: api.errorCount > 0 ? 'error.main' : 'inherit' }}>
+                              {api.errorCount}
+                            </TableCell>
                             <TableCell align="right">{api.avgResponseTime.toFixed(2)}</TableCell>
                             <TableCell align="right">{api.errorRate.toFixed(2)}</TableCell>
                           </TableRow>
@@ -549,13 +612,15 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         height={350}
                         legend={{ show: false }}
                         grid={{ show: true, strokeDasharray: '3 3' }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], ...LINE_OPTS }))}
+                        xAxis={{ interval: xAxisInterval }}
+                        margin={{ bottom: 20 }}
+                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack key={k} direction="row" alignItems="center" gap={1}>
+                          <Stack key={k} direction="row" alignItems="center" gap={1} onClick={() => toggleApiLine(k)} sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap>
+                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}
                             </Typography>
                           </Stack>
@@ -568,7 +633,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                   <Card variant="outlined">
                     <CardContent>
                       <Typography variant="h6" sx={{ mb: 1 }}>
-                        Average Request Latency
+                        Average Request Latency (ms)
                       </Typography>
                       <LineChart
                         data={apiLatData}
@@ -576,13 +641,15 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         height={350}
                         legend={{ show: false }}
                         grid={{ show: true, strokeDasharray: '3 3' }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], ...LINE_OPTS }))}
+                        xAxis={{ interval: xAxisInterval }}
+                        margin={{ bottom: 20 }}
+                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack key={k} direction="row" alignItems="center" gap={1}>
+                          <Stack key={k} direction="row" alignItems="center" gap={1} onClick={() => toggleApiLine(k)} sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap>
+                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}
                             </Typography>
                           </Stack>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -197,7 +197,7 @@ function aggregate(metrics: MetricEntry[]) {
 }
 
 // Build per-API chart data: each selected API becomes a line
-function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (iso: string) => string) {
+function buildApiChartData(apis: ApiSummary[], formatLabel: (iso: string) => string) {
   const allTimestamps = new Set<string>();
   for (const api of apis) {
     for (const entry of api.entries) {
@@ -208,15 +208,13 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
   const reqData = sorted.map((ts) => {
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
-      const key = apiDisplayLabelWithType(api, showType);
-      row[key] = api.entries.reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
+      row[api.key] = api.entries.reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
     }
     return row;
   });
   const latData = sorted.map((ts) => {
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
-      const key = apiDisplayLabelWithType(api, showType);
       let sum = 0,
         count = 0;
       for (const e of api.entries) {
@@ -226,7 +224,7 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
           count++;
         }
       }
-      row[key] = count > 0 ? (sum / count) * 1000 : 0;
+      row[api.key] = count > 0 ? (sum / count) * 1000 : 0;
     }
     return row;
   });
@@ -234,17 +232,16 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
 }
 
 // Build per-API success/error breakdowns: each selected API gets a line per chart
-function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabel: (iso: string) => string) {
+function buildApiBreakdownData(apis: ApiSummary[], formatLabel: (iso: string) => string) {
   const allTimestamps = new Set<string>();
   // Pre-aggregate per-API success/error timestamp maps to avoid re-filtering inside the sorted loop
   const apiSuccessMap: Record<string, Record<string, number>> = {};
   const apiErrorMap: Record<string, Record<string, number>> = {};
   for (const api of apis) {
-    const key = apiDisplayLabelWithType(api, showType);
-    apiSuccessMap[key] = {};
-    apiErrorMap[key] = {};
+    apiSuccessMap[api.key] = {};
+    apiErrorMap[api.key] = {};
     for (const entry of api.entries) {
-      const target = entry.tags.status === 'failed' ? apiErrorMap[key] : apiSuccessMap[key];
+      const target = entry.tags.status === 'failed' ? apiErrorMap[api.key] : apiSuccessMap[api.key];
       for (const [ts, val] of Object.entries(entry.requests_total.timeSeriesData)) {
         allTimestamps.add(ts);
         target[ts] = (target[ts] ?? 0) + val;
@@ -255,16 +252,14 @@ function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabe
   const successData = sorted.map((ts) => {
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
-      const key = apiDisplayLabelWithType(api, showType);
-      row[key] = apiSuccessMap[key][ts] ?? 0;
+      row[api.key] = apiSuccessMap[api.key][ts] ?? 0;
     }
     return row;
   });
   const errorData = sorted.map((ts) => {
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
-      const key = apiDisplayLabelWithType(api, showType);
-      row[key] = apiErrorMap[key][ts] ?? 0;
+      row[api.key] = apiErrorMap[api.key][ts] ?? 0;
     }
     return row;
   });
@@ -300,7 +295,7 @@ function LegendItem({ label, color, hidden, onToggle }: { label: string; color: 
       role="button"
       tabIndex={0}
       aria-pressed={hidden}
-      aria-label={`${hidden ? 'Show' : 'Hide'} ${label}`}
+      aria-label={`Toggle ${label}`}
       onClick={onToggle}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -428,10 +423,10 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   const showDate = (TIME_RANGES[timeRange] ?? 1) > 24;
   const makeLabel = useCallback((iso: string) => formatLabel(iso, showDate), [showDate]);
   const overviewXAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
-  const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
+  const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, makeLabel), [effectiveSelectedApis, makeLabel]);
   const apiXAxisInterval = useMemo(() => Math.max(0, Math.ceil((apiReqData?.length || apiLatData?.length || 1) / 5) - 1), [apiReqData?.length, apiLatData?.length]);
-  const { successData: apiSuccessData, errorData: apiErrorData } = useMemo(() => buildApiBreakdownData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
-  const apiLineKeys = effectiveSelectedApis.map((a) => apiDisplayLabelWithType(a, showIntegrationName));
+  const { successData: apiSuccessData, errorData: apiErrorData } = useMemo(() => buildApiBreakdownData(effectiveSelectedApis, makeLabel), [effectiveSelectedApis, makeLabel]);
+  const apiLines = effectiveSelectedApis.map((a) => ({ key: a.key, label: apiDisplayLabelWithType(a, showIntegrationName) }));
 
   const requestsChartData = useMemo(() => requestsData.map((d) => ({ ...d, label: makeLabel(d.time) })), [requestsData, makeLabel]);
   const latencyChartData = useMemo(() => latencyData.map((d) => ({ ...d, label: makeLabel(d.time) })), [latencyData, makeLabel]);
@@ -676,11 +671,11 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         grid={{ show: true, strokeDasharray: '3 3' }}
                         xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                        lines={apiLines.map((item, i) => ({ dataKey: item.key, name: item.label, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(item.key), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
-                        {apiLineKeys.map((k, i) => (
-                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
+                        {apiLines.map((item, i) => (
+                          <LegendItem key={item.key} label={item.label} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(item.key)} onToggle={() => toggleApiLine(item.key)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -700,11 +695,11 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         grid={{ show: true, strokeDasharray: '3 3' }}
                         xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                        lines={apiLines.map((item, i) => ({ dataKey: item.key, name: item.label, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(item.key), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
-                        {apiLineKeys.map((k, i) => (
-                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
+                        {apiLines.map((item, i) => (
+                          <LegendItem key={item.key} label={item.label} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(item.key)} onToggle={() => toggleApiLine(item.key)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -727,11 +722,11 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         grid={{ show: true, strokeDasharray: '3 3' }}
                         xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                        lines={apiLines.map((item, i) => ({ dataKey: item.key, name: item.label, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(item.key), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
-                        {apiLineKeys.map((k, i) => (
-                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
+                        {apiLines.map((item, i) => (
+                          <LegendItem key={item.key} label={item.label} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(item.key)} onToggle={() => toggleApiLine(item.key)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -751,11 +746,11 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         grid={{ show: true, strokeDasharray: '3 3' }}
                         xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
-                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                        lines={apiLines.map((item, i) => ({ dataKey: item.key, name: item.label, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(item.key), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
-                        {apiLineKeys.map((k, i) => (
-                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
+                        {apiLines.map((item, i) => (
+                          <LegendItem key={item.key} label={item.label} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(item.key)} onToggle={() => toggleApiLine(item.key)} />
                         ))}
                       </Stack>
                     </CardContent>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -235,12 +235,13 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
 
 function formatLabel(iso: string, showDate: boolean): string {
   const d = new Date(iso);
+  const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
   if (showDate) {
     const date = `${d.getMonth() + 1}/${d.getDate()}`;
-    const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    const time = d.toLocaleTimeString([], timeOptions);
     return `${date} ${time}`;
   }
-  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return d.toLocaleTimeString([], timeOptions);
 }
 
 function isUnavailable(error: unknown): boolean {
@@ -509,7 +510,12 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                             toggleOverviewLine(l.dataKey);
                           }
                         }}
-                        sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                        sx={{
+                          cursor: 'pointer',
+                          opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1,
+                          borderRadius: '4px',
+                          '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                        }}>
                         <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
                         <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
                           {l.name}
@@ -554,7 +560,12 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                             toggleOverviewLine(l.dataKey);
                           }
                         }}
-                        sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                        sx={{
+                          cursor: 'pointer',
+                          opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1,
+                          borderRadius: '4px',
+                          '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                        }}>
                         <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
                         <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
                           {l.name}
@@ -667,7 +678,12 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                                 toggleApiLine(k);
                               }
                             }}
-                            sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
+                            sx={{
+                              cursor: 'pointer',
+                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
+                              borderRadius: '4px',
+                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                            }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
                             <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}
@@ -712,7 +728,12 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                                 toggleApiLine(k);
                               }
                             }}
-                            sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
+                            sx={{
+                              cursor: 'pointer',
+                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
+                              borderRadius: '4px',
+                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                            }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
                             <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -233,6 +233,34 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
   return { reqData, latData };
 }
 
+// Build per-API success/error breakdowns: each selected API gets a line per chart
+function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabel: (iso: string) => string) {
+  const allTimestamps = new Set<string>();
+  for (const api of apis) {
+    for (const entry of api.entries) {
+      for (const ts of Object.keys(entry.requests_total.timeSeriesData)) allTimestamps.add(ts);
+    }
+  }
+  const sorted = [...allTimestamps].sort();
+  const successData = sorted.map((ts) => {
+    const row: Record<string, string | number> = { label: formatLabel(ts) };
+    for (const api of apis) {
+      const key = apiDisplayLabelWithType(api, showType);
+      row[key] = api.entries.filter((e) => e.tags.status !== 'failed').reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
+    }
+    return row;
+  });
+  const errorData = sorted.map((ts) => {
+    const row: Record<string, string | number> = { label: formatLabel(ts) };
+    for (const api of apis) {
+      const key = apiDisplayLabelWithType(api, showType);
+      row[key] = api.entries.filter((e) => e.tags.status === 'failed').reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
+    }
+    return row;
+  });
+  return { successData, errorData };
+}
+
 function formatLabel(iso: string, showDate: boolean): string {
   const d = new Date(iso);
   const timeOptions: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
@@ -361,6 +389,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   const overviewXAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
   const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
   const apiXAxisInterval = useMemo(() => Math.max(0, Math.ceil((apiReqData?.length || apiLatData?.length || 1) / 5) - 1), [apiReqData?.length, apiLatData?.length]);
+  const { successData: apiSuccessData, errorData: apiErrorData } = useMemo(() => buildApiBreakdownData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
   const apiLineKeys = effectiveSelectedApis.map((a) => apiDisplayLabelWithType(a, showIntegrationName));
 
   const requestsChartData = useMemo(() => requestsData.map((d) => ({ ...d, label: makeLabel(d.time) })), [requestsData, makeLabel]);
@@ -702,6 +731,109 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                       </Typography>
                       <LineChart
                         data={apiLatData}
+                        xAxisDataKey="label"
+                        height={350}
+                        legend={{ show: false }}
+                        grid={{ show: true, strokeDasharray: '3 3' }}
+                        xAxis={{ interval: apiXAxisInterval }}
+                        margin={{ bottom: 20 }}
+                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                      />
+                      <Stack sx={{ mt: 1 }} gap={0.5}>
+                        {apiLineKeys.map((k, i) => (
+                          <Stack
+                            key={k}
+                            direction="row"
+                            alignItems="center"
+                            gap={1}
+                            role="button"
+                            tabIndex={0}
+                            aria-pressed={hiddenApiLines.has(k)}
+                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
+                            onClick={() => toggleApiLine(k)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                toggleApiLine(k);
+                              }
+                            }}
+                            sx={{
+                              cursor: 'pointer',
+                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
+                              borderRadius: '4px',
+                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                            }}>
+                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
+                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
+                              {k}
+                            </Typography>
+                          </Stack>
+                        ))}
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              </Grid>
+
+              <Grid container spacing={2} sx={{ mt: 2 }}>
+                <Grid size={{ xs: 12, md: 6 }}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="h6" sx={{ mb: 1 }}>
+                        Successful Requests by API
+                      </Typography>
+                      <LineChart
+                        data={apiSuccessData}
+                        xAxisDataKey="label"
+                        height={350}
+                        legend={{ show: false }}
+                        grid={{ show: true, strokeDasharray: '3 3' }}
+                        xAxis={{ interval: apiXAxisInterval }}
+                        margin={{ bottom: 20 }}
+                        lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
+                      />
+                      <Stack sx={{ mt: 1 }} gap={0.5}>
+                        {apiLineKeys.map((k, i) => (
+                          <Stack
+                            key={k}
+                            direction="row"
+                            alignItems="center"
+                            gap={1}
+                            role="button"
+                            tabIndex={0}
+                            aria-pressed={hiddenApiLines.has(k)}
+                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
+                            onClick={() => toggleApiLine(k)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                toggleApiLine(k);
+                              }
+                            }}
+                            sx={{
+                              cursor: 'pointer',
+                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
+                              borderRadius: '4px',
+                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+                            }}>
+                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
+                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
+                              {k}
+                            </Typography>
+                          </Stack>
+                        ))}
+                      </Stack>
+                    </CardContent>
+                  </Card>
+                </Grid>
+                <Grid size={{ xs: 12, md: 6 }}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="h6" sx={{ mb: 1 }}>
+                        Failed Requests by API
+                      </Typography>
+                      <LineChart
+                        data={apiErrorData}
                         xAxisDataKey="label"
                         height={350}
                         legend={{ show: false }}

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -236,9 +236,19 @@ function buildApiChartData(apis: ApiSummary[], showType: boolean, formatLabel: (
 // Build per-API success/error breakdowns: each selected API gets a line per chart
 function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabel: (iso: string) => string) {
   const allTimestamps = new Set<string>();
+  // Pre-aggregate per-API success/error timestamp maps to avoid re-filtering inside the sorted loop
+  const apiSuccessMap: Record<string, Record<string, number>> = {};
+  const apiErrorMap: Record<string, Record<string, number>> = {};
   for (const api of apis) {
+    const key = apiDisplayLabelWithType(api, showType);
+    apiSuccessMap[key] = {};
+    apiErrorMap[key] = {};
     for (const entry of api.entries) {
-      for (const ts of Object.keys(entry.requests_total.timeSeriesData)) allTimestamps.add(ts);
+      const target = entry.tags.status === 'failed' ? apiErrorMap[key] : apiSuccessMap[key];
+      for (const [ts, val] of Object.entries(entry.requests_total.timeSeriesData)) {
+        allTimestamps.add(ts);
+        target[ts] = (target[ts] ?? 0) + val;
+      }
     }
   }
   const sorted = [...allTimestamps].sort();
@@ -246,7 +256,7 @@ function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabe
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
       const key = apiDisplayLabelWithType(api, showType);
-      row[key] = api.entries.filter((e) => e.tags.status !== 'failed').reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
+      row[key] = apiSuccessMap[key][ts] ?? 0;
     }
     return row;
   });
@@ -254,7 +264,7 @@ function buildApiBreakdownData(apis: ApiSummary[], showType: boolean, formatLabe
     const row: Record<string, string | number> = { label: formatLabel(ts) };
     for (const api of apis) {
       const key = apiDisplayLabelWithType(api, showType);
-      row[key] = api.entries.filter((e) => e.tags.status === 'failed').reduce((s, e) => s + (e.requests_total.timeSeriesData[ts] ?? 0), 0);
+      row[key] = apiErrorMap[key][ts] ?? 0;
     }
     return row;
   });
@@ -280,6 +290,37 @@ function isUnavailable(error: unknown): boolean {
 }
 
 const COLORS = ['#4caf50', '#2196f3', '#ff9800', '#e91e63', '#9c27b0'];
+
+function LegendItem({ label, color, hidden, onToggle }: { label: string; color: string; hidden: boolean; onToggle: () => void }) {
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      gap={0.75}
+      role="button"
+      tabIndex={0}
+      aria-pressed={hidden}
+      aria-label={`${hidden ? 'Show' : 'Hide'} ${label}`}
+      onClick={onToggle}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+      sx={{
+        cursor: 'pointer',
+        opacity: hidden ? 0.4 : 1,
+        borderRadius: '4px',
+        '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
+      }}>
+      <span style={{ width: 14, height: 3, backgroundColor: color, display: 'inline-block', borderRadius: 1 }} />
+      <Typography variant="caption" noWrap sx={{ textDecoration: hidden ? 'line-through' : 'none' }}>
+        {label}
+      </Typography>
+    </Stack>
+  );
+}
 
 function StatCard({ title, value, color }: { title: string; value: string; color?: string }) {
   return (
@@ -523,33 +564,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                   />
                   <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
                     {OVERVIEW_REQUEST_LINES.map((l) => (
-                      <Stack
-                        key={l.dataKey}
-                        direction="row"
-                        alignItems="center"
-                        gap={0.75}
-                        role="button"
-                        tabIndex={0}
-                        aria-pressed={hiddenOverviewLines.has(l.dataKey)}
-                        aria-label={`${hiddenOverviewLines.has(l.dataKey) ? 'Show' : 'Hide'} ${l.name}`}
-                        onClick={() => toggleOverviewLine(l.dataKey)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            toggleOverviewLine(l.dataKey);
-                          }
-                        }}
-                        sx={{
-                          cursor: 'pointer',
-                          opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1,
-                          borderRadius: '4px',
-                          '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                        }}>
-                        <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
-                        <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
-                          {l.name}
-                        </Typography>
-                      </Stack>
+                      <LegendItem key={l.dataKey} label={l.name} color={l.stroke} hidden={hiddenOverviewLines.has(l.dataKey)} onToggle={() => toggleOverviewLine(l.dataKey)} />
                     ))}
                   </Stack>
                 </CardContent>
@@ -573,33 +588,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                   />
                   <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
                     {OVERVIEW_LATENCY_LINES.map((l) => (
-                      <Stack
-                        key={l.dataKey}
-                        direction="row"
-                        alignItems="center"
-                        gap={0.75}
-                        role="button"
-                        tabIndex={0}
-                        aria-pressed={hiddenOverviewLines.has(l.dataKey)}
-                        aria-label={`${hiddenOverviewLines.has(l.dataKey) ? 'Show' : 'Hide'} ${l.name}`}
-                        onClick={() => toggleOverviewLine(l.dataKey)}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            toggleOverviewLine(l.dataKey);
-                          }
-                        }}
-                        sx={{
-                          cursor: 'pointer',
-                          opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1,
-                          borderRadius: '4px',
-                          '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                        }}>
-                        <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
-                        <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
-                          {l.name}
-                        </Typography>
-                      </Stack>
+                      <LegendItem key={l.dataKey} label={l.name} color={l.stroke} hidden={hiddenOverviewLines.has(l.dataKey)} onToggle={() => toggleOverviewLine(l.dataKey)} />
                     ))}
                   </Stack>
                 </CardContent>
@@ -691,33 +680,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack
-                            key={k}
-                            direction="row"
-                            alignItems="center"
-                            gap={1}
-                            role="button"
-                            tabIndex={0}
-                            aria-pressed={hiddenApiLines.has(k)}
-                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
-                            onClick={() => toggleApiLine(k)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                toggleApiLine(k);
-                              }
-                            }}
-                            sx={{
-                              cursor: 'pointer',
-                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
-                              borderRadius: '4px',
-                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                            }}>
-                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
-                              {k}
-                            </Typography>
-                          </Stack>
+                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -741,33 +704,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack
-                            key={k}
-                            direction="row"
-                            alignItems="center"
-                            gap={1}
-                            role="button"
-                            tabIndex={0}
-                            aria-pressed={hiddenApiLines.has(k)}
-                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
-                            onClick={() => toggleApiLine(k)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                toggleApiLine(k);
-                              }
-                            }}
-                            sx={{
-                              cursor: 'pointer',
-                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
-                              borderRadius: '4px',
-                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                            }}>
-                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
-                              {k}
-                            </Typography>
-                          </Stack>
+                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -794,33 +731,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack
-                            key={k}
-                            direction="row"
-                            alignItems="center"
-                            gap={1}
-                            role="button"
-                            tabIndex={0}
-                            aria-pressed={hiddenApiLines.has(k)}
-                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
-                            onClick={() => toggleApiLine(k)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                toggleApiLine(k);
-                              }
-                            }}
-                            sx={{
-                              cursor: 'pointer',
-                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
-                              borderRadius: '4px',
-                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                            }}>
-                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
-                              {k}
-                            </Typography>
-                          </Stack>
+                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
                         ))}
                       </Stack>
                     </CardContent>
@@ -844,33 +755,7 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack
-                            key={k}
-                            direction="row"
-                            alignItems="center"
-                            gap={1}
-                            role="button"
-                            tabIndex={0}
-                            aria-pressed={hiddenApiLines.has(k)}
-                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
-                            onClick={() => toggleApiLine(k)}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                toggleApiLine(k);
-                              }
-                            }}
-                            sx={{
-                              cursor: 'pointer',
-                              opacity: hiddenApiLines.has(k) ? 0.4 : 1,
-                              borderRadius: '4px',
-                              '&:focus-visible': { outline: '2px solid', outlineColor: 'primary.main', outlineOffset: '2px' },
-                            }}>
-                            <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
-                            <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
-                              {k}
-                            </Typography>
-                          </Stack>
+                          <LegendItem key={k} label={k} color={COLORS[i % COLORS.length]} hidden={hiddenApiLines.has(k)} onToggle={() => toggleApiLine(k)} />
                         ))}
                       </Stack>
                     </CardContent>

--- a/frontend/src/pages/Metrics.tsx
+++ b/frontend/src/pages/Metrics.tsx
@@ -357,8 +357,9 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
   const showIntegrationName = true;
   const showDate = (TIME_RANGES[timeRange] ?? 1) > 24;
   const makeLabel = useCallback((iso: string) => formatLabel(iso, showDate), [showDate]);
-  const xAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
+  const overviewXAxisInterval = useMemo(() => Math.max(0, Math.ceil((requestsData.length || 1) / 5) - 1), [requestsData.length]);
   const { reqData: apiReqData, latData: apiLatData } = useMemo(() => buildApiChartData(effectiveSelectedApis, showIntegrationName, makeLabel), [effectiveSelectedApis, showIntegrationName, makeLabel]);
+  const apiXAxisInterval = useMemo(() => Math.max(0, Math.ceil((apiReqData?.length || apiLatData?.length || 1) / 5) - 1), [apiReqData?.length, apiLatData?.length]);
   const apiLineKeys = effectiveSelectedApis.map((a) => apiDisplayLabelWithType(a, showIntegrationName));
 
   const requestsChartData = useMemo(() => requestsData.map((d) => ({ ...d, label: makeLabel(d.time) })), [requestsData, makeLabel]);
@@ -486,13 +487,29 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                     height={350}
                     legend={{ show: false }}
                     grid={{ show: true, strokeDasharray: '3 3' }}
-                    xAxis={{ interval: xAxisInterval }}
+                    xAxis={{ interval: overviewXAxisInterval }}
                     margin={{ bottom: 20 }}
                     lines={OVERVIEW_REQUEST_LINES.map((l) => ({ ...l, hide: hiddenOverviewLines.has(l.dataKey), ...LINE_OPTS }))}
                   />
                   <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
                     {OVERVIEW_REQUEST_LINES.map((l) => (
-                      <Stack key={l.dataKey} direction="row" alignItems="center" gap={0.75} onClick={() => toggleOverviewLine(l.dataKey)} sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                      <Stack
+                        key={l.dataKey}
+                        direction="row"
+                        alignItems="center"
+                        gap={0.75}
+                        role="button"
+                        tabIndex={0}
+                        aria-pressed={hiddenOverviewLines.has(l.dataKey)}
+                        aria-label={`${hiddenOverviewLines.has(l.dataKey) ? 'Show' : 'Hide'} ${l.name}`}
+                        onClick={() => toggleOverviewLine(l.dataKey)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggleOverviewLine(l.dataKey);
+                          }
+                        }}
+                        sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
                         <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
                         <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
                           {l.name}
@@ -515,13 +532,29 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                     height={350}
                     legend={{ show: false }}
                     grid={{ show: true, strokeDasharray: '3 3' }}
-                    xAxis={{ interval: xAxisInterval }}
+                    xAxis={{ interval: overviewXAxisInterval }}
                     margin={{ bottom: 20 }}
                     lines={OVERVIEW_LATENCY_LINES.map((l) => ({ ...l, hide: hiddenOverviewLines.has(l.dataKey), ...LINE_OPTS }))}
                   />
                   <Stack direction="row" justifyContent="center" gap={2} sx={{ mt: 1, flexWrap: 'wrap' }}>
                     {OVERVIEW_LATENCY_LINES.map((l) => (
-                      <Stack key={l.dataKey} direction="row" alignItems="center" gap={0.75} onClick={() => toggleOverviewLine(l.dataKey)} sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
+                      <Stack
+                        key={l.dataKey}
+                        direction="row"
+                        alignItems="center"
+                        gap={0.75}
+                        role="button"
+                        tabIndex={0}
+                        aria-pressed={hiddenOverviewLines.has(l.dataKey)}
+                        aria-label={`${hiddenOverviewLines.has(l.dataKey) ? 'Show' : 'Hide'} ${l.name}`}
+                        onClick={() => toggleOverviewLine(l.dataKey)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            toggleOverviewLine(l.dataKey);
+                          }
+                        }}
+                        sx={{ cursor: 'pointer', opacity: hiddenOverviewLines.has(l.dataKey) ? 0.4 : 1 }}>
                         <span style={{ width: 14, height: 3, backgroundColor: l.stroke, display: 'inline-block', borderRadius: 1 }} />
                         <Typography variant="caption" sx={{ textDecoration: hiddenOverviewLines.has(l.dataKey) ? 'line-through' : 'none' }}>
                           {l.name}
@@ -612,13 +645,29 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         height={350}
                         legend={{ show: false }}
                         grid={{ show: true, strokeDasharray: '3 3' }}
-                        xAxis={{ interval: xAxisInterval }}
+                        xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
                         lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack key={k} direction="row" alignItems="center" gap={1} onClick={() => toggleApiLine(k)} sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
+                          <Stack
+                            key={k}
+                            direction="row"
+                            alignItems="center"
+                            gap={1}
+                            role="button"
+                            tabIndex={0}
+                            aria-pressed={hiddenApiLines.has(k)}
+                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
+                            onClick={() => toggleApiLine(k)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                toggleApiLine(k);
+                              }
+                            }}
+                            sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
                             <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}
@@ -641,13 +690,29 @@ export default function Metrics(scope: ProjectScope | ComponentScope): JSX.Eleme
                         height={350}
                         legend={{ show: false }}
                         grid={{ show: true, strokeDasharray: '3 3' }}
-                        xAxis={{ interval: xAxisInterval }}
+                        xAxis={{ interval: apiXAxisInterval }}
                         margin={{ bottom: 20 }}
                         lines={apiLineKeys.map((k, i) => ({ dataKey: k, name: k, stroke: COLORS[i % COLORS.length], hide: hiddenApiLines.has(k), ...LINE_OPTS }))}
                       />
                       <Stack sx={{ mt: 1 }} gap={0.5}>
                         {apiLineKeys.map((k, i) => (
-                          <Stack key={k} direction="row" alignItems="center" gap={1} onClick={() => toggleApiLine(k)} sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
+                          <Stack
+                            key={k}
+                            direction="row"
+                            alignItems="center"
+                            gap={1}
+                            role="button"
+                            tabIndex={0}
+                            aria-pressed={hiddenApiLines.has(k)}
+                            aria-label={`${hiddenApiLines.has(k) ? 'Show' : 'Hide'} ${k}`}
+                            onClick={() => toggleApiLine(k)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                toggleApiLine(k);
+                              }
+                            }}
+                            sx={{ cursor: 'pointer', opacity: hiddenApiLines.has(k) ? 0.4 : 1 }}>
                             <span style={{ width: 14, height: 3, backgroundColor: COLORS[i % COLORS.length], display: 'inline-block', borderRadius: 1 }} />
                             <Typography variant="caption" noWrap sx={{ textDecoration: hiddenApiLines.has(k) ? 'line-through' : 'none' }}>
                               {k}

--- a/frontend/src/pages/OrgRuntimes.tsx
+++ b/frontend/src/pages/OrgRuntimes.tsx
@@ -314,9 +314,6 @@ function EnvironmentRuntimeCard({
               <Chip label={`${filtered.length} runtime${filtered.length !== 1 ? 's' : ''}`} size="small" color={filtered.length > 0 ? 'primary' : 'default'} />
             </Stack>
             <Stack direction="row" gap={1} alignItems="center">
-              <IconButton size="small" aria-label={`Refresh runtimes for ${env.name}`} onClick={onRefresh} disabled={isRefreshing}>
-                <RefreshCw size={16} />
-              </IconButton>
               <Authorized permissions={[Permissions.ENVIRONMENT_MANAGE, Permissions.ENVIRONMENT_MANAGE_NONPROD]}>
                 <Stack direction="row" gap={1}>
                   <Button variant="contained" size="small" startIcon={<Key size={14} />} onClick={() => setDrawerOpen(true)}>
@@ -327,6 +324,9 @@ function EnvironmentRuntimeCard({
                   </Button>
                 </Stack>
               </Authorized>
+              <IconButton size="small" aria-label={`Refresh runtimes for ${env.name}`} onClick={onRefresh} disabled={isRefreshing}>
+                <RefreshCw size={16} />
+              </IconButton>
             </Stack>
           </Stack>
           <Divider sx={{ mb: 2 }} />

--- a/frontend/src/pages/Runtime.tsx
+++ b/frontend/src/pages/Runtime.tsx
@@ -360,9 +360,6 @@ function EnvironmentRuntimeCard({
               <Chip label={`${filtered.length} runtime${filtered.length !== 1 ? 's' : ''}`} size="small" color={filtered.length > 0 ? 'primary' : 'default'} />
             </Stack>
             <Stack direction="row" gap={1} alignItems="center">
-              <IconButton size="small" aria-label={`Refresh runtimes for ${environmentName}`} onClick={onRefresh} disabled={isRefreshing}>
-                <RefreshCw size={16} />
-              </IconButton>
               {componentId && (
                 <Authorized permissions={[Permissions.INTEGRATION_MANAGE]}>
                   <Stack direction="row" gap={1}>
@@ -375,6 +372,9 @@ function EnvironmentRuntimeCard({
                   </Stack>
                 </Authorized>
               )}
+              <IconButton size="small" aria-label={`Refresh runtimes for ${environmentName}`} onClick={onRefresh} disabled={isRefreshing}>
+                <RefreshCw size={16} />
+              </IconButton>
             </Stack>
           </Stack>
           <Divider sx={{ mb: 2 }} />


### PR DESCRIPTION
## Purpose
- Make metrics graphs legend clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Error Count" column to Most Used APIs table with conditional error styling
  * Added per-API breakdown charts: Successful Requests and Failed Requests, sharing consistent API lines

* **UI/UX Improvements**
  * Charts support customizable label formatting and adapt x-axis labels for longer ranges
  * Charts now offer interactive per-line hide/show via a custom legend with faded/strikethrough styling
  * Refresh button repositioned in headers for a more consistent layout
<!-- end of auto-generated comment: release notes by coderabbit.ai -->