### PR TITLE
Change log level for trivial logs and refactor MI user store error message

### DIFF
--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -34,6 +34,7 @@ import {
   FormControlLabel,
   IconButton,
   InputAdornment,
+  Link,
   List,
   ListItem,
   ListItemText,
@@ -550,6 +551,8 @@ export default function Environment({
   const deleteMiUser = useDeleteMiUser();
   const { data: miUsers = [], error: miUsersError, isLoading: miUsersLoading } = useListMiUsers(componentId, activeRuntimeId, componentType === 'MI' && settingsPanelOpen && !!activeRuntimeId);
 
+  const FILE_BASED_USER_STORE_ERROR = 'User management is not supported with the file-based user store. Please plug in a user store for the correct functionality';
+
   const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
@@ -619,7 +622,7 @@ export default function Environment({
                 <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                   Runtime Users
                 </Typography>
-                <Tooltip title="Add user">
+                <Tooltip title={miUsersError?.message === FILE_BASED_USER_STORE_ERROR ? "User store not configured" : "Add user"}>
                   <span>
                     <IconButton
                       size="small"
@@ -630,7 +633,7 @@ export default function Environment({
                         setCreateUserError(null);
                         setCreateUserDialogOpen(true);
                       }}
-                      disabled={!activeRuntimeId}
+                      disabled={!activeRuntimeId || miUsersError?.message === FILE_BASED_USER_STORE_ERROR}
                       aria-label="Add user">
                       <UserPlus size={16} />
                     </IconButton>
@@ -665,9 +668,26 @@ export default function Environment({
               {activeRuntimeId && miUsersLoading && <CircularProgress size={20} sx={{ display: 'block', mx: 'auto', mt: 2 }} />}
 
               {activeRuntimeId && !miUsersLoading && miUsersError && (
-                <Typography variant="body2" color="error">
-                  Failed to load users: {miUsersError.message}
-                </Typography>
+                <>
+                  {miUsersError.message === FILE_BASED_USER_STORE_ERROR ? (
+                    <Stack gap={1}>
+                      <Typography variant="body2" color="text.secondary">
+                        Your MI runtime does not have a user store configured. Users will appear here once configured.
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        See{' '}
+                        <Link href="https://mi.docs.wso2.com/en/latest/install-and-setup/setup/user-stores/setting-up-a-userstore-in-mi/" target="_blank" rel="noopener noreferrer">
+                          user store configuration documentation
+                        </Link>
+                        .
+                      </Typography>
+                    </Stack>
+                  ) : (
+                    <Typography variant="body2" color="error">
+                      Failed to load users: {miUsersError.message}
+                    </Typography>
+                  )}
+                </>
               )}
 
               {activeRuntimeId && !miUsersLoading && !miUsersError && miUsers.length === 0 && (

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -46,7 +46,7 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { RefreshCw, ListFilter, LayoutGrid, Server, Settings, Play, Plus, X, Trash2, UserPlus, Code, Sliders, Link, FileText } from '@wso2/oxygen-ui-icons-react';
+import { RefreshCw, ListFilter, LayoutGrid, Server, Settings, Play, Plus, X, Trash2, UserPlus, Code, Sliders, Link as LinkIcon, FileText } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
@@ -324,7 +324,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
             </Button>
           )}
           {showWsdlButton && (
-            <Button variant="contained" size="small" startIcon={<Link size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ ml: showSourceButton || showParametersButton ? 0 : 'auto' }}>
+            <Button variant="contained" size="small" startIcon={<LinkIcon size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ ml: showSourceButton || showParametersButton ? 0 : 'auto' }}>
               View Endpoints
             </Button>
           )}
@@ -622,7 +622,7 @@ export default function Environment({
                 <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
                   Runtime Users
                 </Typography>
-                <Tooltip title={miUsersError?.message === FILE_BASED_USER_STORE_ERROR ? "User store not configured" : "Add user"}>
+                <Tooltip title={miUsersError?.message === FILE_BASED_USER_STORE_ERROR ? 'User store not configured' : 'Add user'}>
                   <span>
                     <IconButton
                       size="small"

--- a/icp_server/auth_service.bal
+++ b/icp_server/auth_service.bal
@@ -2943,7 +2943,7 @@ service /auth on httpListener {
             string? integrationId = (),
             string? environmentId = ()
     ) returns http:Ok|http:BadRequest|http:Unauthorized|http:Forbidden|http:InternalServerError|error {
-        log:printInfo("Fetching effective permissions for user",
+        log:printDebug("Fetching effective permissions for user",
                 orgHandle = orgHandle,
                 userId = userId,
                 projectId = projectId,
@@ -3007,7 +3007,7 @@ service /auth on httpListener {
         string[] permissionNames = from types:Permission p in permissions
             select p.permissionName;
 
-        log:printInfo(string `Successfully fetched ${permissions.length()} effective permissions for user`, userId = userId);
+        log:printDebug(string `Successfully fetched ${permissions.length()} effective permissions for user`, userId = userId);
         return <http:Ok>{
             body: {
                 userId: userId,

--- a/icp_server/graphql_api.bal
+++ b/icp_server/graphql_api.bal
@@ -63,7 +63,7 @@ isolated function fetchMILoggersByRuntime(string runtimeId, types:Runtime runtim
     // Build management API base URL
     string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-    log:printInfo("Fetching loggers from MI runtime management API",
+    log:printDebug("Fetching loggers from MI runtime management API",
             runtimeId = runtimeId,
             managementUrl = baseUrl);
 
@@ -83,7 +83,7 @@ isolated function fetchMILoggersByRuntime(string runtimeId, types:Runtime runtim
     log:printDebug("Fetching loggers via MI management API", runtimeId = runtimeId, managementUrl = baseUrl);
     types:MgmtLoggersResponse loggersResponse = check mi_management:fetchLoggers(mgmtClientResult, hmacToken);
 
-    log:printInfo("Successfully fetched loggers from MI management API",
+    log:printDebug("Successfully fetched loggers from MI management API",
             runtimeId = runtimeId,
             managementUrl = baseUrl,
             loggerCount = loggersResponse.count);
@@ -152,7 +152,7 @@ isolated function contextInit(http:RequestContext reqCtx, http:Request request) 
 
 // Helper function to fetch BI loggers from database
 isolated function fetchBILoggersByRuntime(string runtimeId) returns types:Logger[]|error {
-    log:printInfo("Fetching loggers from BI runtime database", runtimeId = runtimeId);
+    log:printDebug("Fetching loggers from BI runtime database", runtimeId = runtimeId);
 
     // Get log levels for runtime from database
     types:RuntimeLogLevelRecord[] logLevels = check storage:getLogLevelsForRuntime(runtimeId);
@@ -167,7 +167,7 @@ isolated function fetchBILoggersByRuntime(string runtimeId) returns types:Logger
         });
     }
 
-    log:printInfo("Successfully fetched loggers from BI runtime database",
+    log:printDebug("Successfully fetched loggers from BI runtime database",
             runtimeId = runtimeId,
             loggerCount = loggers.length());
 
@@ -176,7 +176,7 @@ isolated function fetchBILoggersByRuntime(string runtimeId) returns types:Logger
 
 // Helper function to fetch MI loggers from management API for environment and component
 isolated function fetchMILoggersByEnvironmentAndComponent(string environmentId, string componentId, string projectId) returns types:LoggerGroup[]|error {
-    log:printInfo("Fetching loggers from MI management API for environment and component",
+    log:printDebug("Fetching loggers from MI management API for environment and component",
             environmentId = environmentId,
             componentId = componentId);
 
@@ -264,7 +264,7 @@ isolated function fetchMILoggersByEnvironmentAndComponent(string environmentId, 
     // Convert map to array
     types:LoggerGroup[] loggerGroups = loggerGroupMap.toArray();
 
-    log:printInfo("Successfully fetched and grouped MI loggers from multiple runtimes",
+    log:printDebug("Successfully fetched and grouped MI loggers from multiple runtimes",
             environmentId = environmentId,
             componentId = componentId,
             runtimeCount = runtimes.length(),
@@ -1943,7 +1943,7 @@ service /graphql on graphqlListener {
 
     // Get a specific environment by handler
     isolated resource function get environmentByHandler(graphql:Context context, string environmentHandler) returns types:Environment?|error {
-        log:printInfo("Fetching environment by handler", environmentHandler = environmentHandler);
+        log:printDebug("Fetching environment by handler", environmentHandler = environmentHandler);
         types:UserContextV2 userContext = check extractUserContext(context);
 
         types:Environment|error env = storage:getEnvironmentByHandler(environmentHandler);
@@ -1983,7 +1983,7 @@ service /graphql on graphqlListener {
             return (); // No access - return null
         }
 
-        log:printInfo("Successfully retrieved environment", environmentId = env.id, environmentHandler = environmentHandler);
+        log:printDebug("Successfully retrieved environment", environmentId = env.id, environmentHandler = environmentHandler);
         return env;
     }
 
@@ -2063,7 +2063,7 @@ service /graphql on graphqlListener {
 
     // Get a specific project by handler (orgId is required for this lookup)
     isolated resource function get projectByHandler(graphql:Context context, int orgId, string projectHandler) returns types:Project?|error {
-        log:printInfo("Fetching project by handler", orgId = orgId, projectHandler = projectHandler);
+        log:printDebug("Fetching project by handler", orgId = orgId, projectHandler = projectHandler);
         types:UserContextV2 userContext = check extractUserContext(context);
         string|error projectId = storage:getProjectIdByHandler(projectHandler, orgId);
         if projectId is error {
@@ -2077,7 +2077,7 @@ service /graphql on graphqlListener {
             log:printWarn("Attempt to access project without permission", userId = userContext.userId, projectId = projectId);
             return (); // No access - return null (404 pattern for queries)
         }
-        log:printInfo("Successfully retrieved project", projectId = projectId);
+        log:printDebug("Successfully retrieved project", projectId = projectId);
         return check storage:getProjectById(projectId);
     }
 
@@ -2745,7 +2745,7 @@ service /graphql on graphqlListener {
         // Build management API base URL
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching artifact from runtime management API",
+        log:printDebug("Fetching artifact from runtime management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 artifactType = artifactType,
@@ -2772,7 +2772,7 @@ service /graphql on graphqlListener {
         string artifactDetails = check mi_management:getArtifactSource(
                 mgmtClientResult, hmacToken, artifactType, artifactName, packageName, templateType);
 
-        log:printInfo("Successfully fetched artifact details from MI management API",
+        log:printDebug("Successfully fetched artifact details from MI management API",
                 runtimeId = runtime.runtimeId,
                 artifactType = artifactType,
                 artifactName = artifactName,
@@ -2825,7 +2825,7 @@ service /graphql on graphqlListener {
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
         // Normalize artifact type
-        log:printInfo("Fetching artifact WSDL via MI management API",
+        log:printDebug("Fetching artifact WSDL via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 artifactType = artifactType,
@@ -2869,7 +2869,7 @@ service /graphql on graphqlListener {
         }
         string wsdlXml = check mi_management:fetchWsdlContent(wsdlUrl, trustedHost, artifactsApiAllowInsecureTLS);
 
-        log:printInfo("Successfully fetched artifact WSDL via MI management API",
+        log:printDebug("Successfully fetched artifact WSDL via MI management API",
                 runtimeId = runtime.runtimeId,
                 artifactType = artifactType,
                 artifactName = artifactName,
@@ -2916,7 +2916,7 @@ service /graphql on graphqlListener {
         // Build management API base URL
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching local entry info via MI management API",
+        log:printDebug("Fetching local entry info via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 entryName = entryName);
@@ -2936,7 +2936,7 @@ service /graphql on graphqlListener {
 
         // Fetch local entry info via MI Management API (/management/local-entries?name=...)
         types:MgmtLocalEntryInfo entryInfo = check mi_management:fetchLocalEntryArtifact(mgmtClient, hmacToken, entryName);
-        log:printInfo("Successfully fetched local entry info from MI management API",
+        log:printDebug("Successfully fetched local entry info from MI management API",
                 runtimeId = runtime.runtimeId,
                 entryName = entryInfo.name,
                 entryType = entryInfo.'type);
@@ -2983,7 +2983,7 @@ service /graphql on graphqlListener {
         // Select runtime using shared helper
         types:Runtime runtime = check utils:selectRuntime(runtimes, componentId, environmentId, runtimeId);
 
-        log:printInfo("Fetching artifact parameters via MI management API",
+        log:printDebug("Fetching artifact parameters via MI management API",
                 runtimeId = runtime.runtimeId,
                 artifactType = artifactType,
                 artifactName = artifactName);
@@ -3042,7 +3042,7 @@ service /graphql on graphqlListener {
         }
         // Add more artifact types here as needed
 
-        log:printInfo("Successfully fetched artifact parameters from MI management API",
+        log:printDebug("Successfully fetched artifact parameters from MI management API",
                 runtimeId = runtime.runtimeId,
                 artifactType = artifactType,
                 artifactName = artifactName,
@@ -3085,7 +3085,7 @@ service /graphql on graphqlListener {
         types:Runtime runtime = check utils:selectRuntime(runtimes, componentId, environmentId, runtimeId);
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching data source overview via MI management API",
+        log:printDebug("Fetching data source overview via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 dataSourceName = dataSourceName);
@@ -3122,7 +3122,7 @@ service /graphql on graphqlListener {
             result.push({name: "url", value: <string>overview.url});
         }
 
-        log:printInfo("Successfully fetched data source overview from MI management API",
+        log:printDebug("Successfully fetched data source overview from MI management API",
                 runtimeId = runtime.runtimeId,
                 dataSourceName = dataSourceName,
                 totalParamCount = result.length());
@@ -3163,7 +3163,7 @@ service /graphql on graphqlListener {
         types:Runtime runtime = check utils:selectRuntime(runtimes, componentId, environmentId, runtimeId);
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching message store overview via MI management API",
+        log:printDebug("Fetching message store overview via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 storeName = storeName);
@@ -3229,7 +3229,7 @@ service /graphql on graphqlListener {
         types:Runtime runtime = check utils:selectRuntime(runtimes, componentId, environmentId, runtimeId);
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching message processor overview via MI management API",
+        log:printDebug("Fetching message processor overview via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 processorName = processorName);
@@ -3295,7 +3295,7 @@ service /graphql on graphqlListener {
         types:Runtime runtime = check utils:selectRuntime(runtimes, componentId, environmentId, runtimeId);
         string baseUrl = check storage:buildManagementBaseUrl(runtime.managementHostname, runtime.managementPort);
 
-        log:printInfo("Fetching data service overview via MI management API",
+        log:printDebug("Fetching data service overview via MI management API",
                 runtimeId = runtime.runtimeId,
                 managementUrl = baseUrl,
                 dataServiceName = dataServiceName);
@@ -3344,7 +3344,7 @@ service /graphql on graphqlListener {
         }
 
         string bearerToken = check storage:issueRuntimeHmacToken(runtimeId);
-        log:printInfo("Fetching MI users from runtime management API", runtimeId = runtimeId);
+        log:printDebug("Fetching MI users from runtime management API", runtimeId = runtimeId);
 
         http:Response|error listResponse = mgmtClient->get("/management/users", {
             "Authorization": string `Bearer ${bearerToken}`,
@@ -3399,7 +3399,7 @@ service /graphql on graphqlListener {
             enrichedUsers.push({username: userIdStr, isAdmin});
         }
 
-        log:printInfo("Successfully fetched MI users from runtime", runtimeId = runtimeId, userCount = enrichedUsers.length());
+        log:printDebug("Successfully fetched MI users from runtime", runtimeId = runtimeId, userCount = enrichedUsers.length());
         return {users: enrichedUsers};
     }
 

--- a/icp_server/modules/auth/utils.bal
+++ b/icp_server/modules/auth/utils.bal
@@ -92,7 +92,7 @@ public isolated function generateJWTTokenV2(
         return error("Failed to generate JWT token V2", jwtToken);
     }
 
-    log:printInfo("JWT token V2 generated successfully", 
+    log:printDebug("JWT token V2 generated successfully", 
         username = username, 
         permissionCount = permissionNames.length());
     return jwtToken;
@@ -151,7 +151,7 @@ public isolated function extractUserContextV2(string authorizationHeader) return
         log:printWarn("JWT token missing or invalid 'scope' claim", userId = userId);
     }
 
-    log:printInfo("Successfully extracted user context V2",
+    log:printDebug("Successfully extracted user context V2",
             userId = userId,
             username = username,
             permissionCount = permissions.length());

--- a/icp_server/modules/storage/component_repository.bal
+++ b/icp_server/modules/storage/component_repository.bal
@@ -409,7 +409,7 @@ public isolated function getComponentDeployment(string componentId, string envir
         cronTimezone: ()
     };
 
-    log:printInfo(string `Retrieved deployment info for component ${componentId}`,
+    log:printDebug(string `Retrieved deployment info for component ${componentId}`,
             status = runtime.status,
             configCount = configCount);
 

--- a/icp_server/modules/storage/environment_repository.bal
+++ b/icp_server/modules/storage/environment_repository.bal
@@ -101,7 +101,7 @@ public isolated function getEnvironmentsByIds(string[] environmentIds) returns t
             });
         };
 
-    log:printInfo("Retrieved environments by IDs", environmentCount = environments.length());
+    log:printDebug("Retrieved environments by IDs", environmentCount = environments.length());
 
     return environments;
 }
@@ -140,7 +140,7 @@ public isolated function getAllEnvironments() returns types:Environment[]|error 
             });
         };
 
-    log:printInfo("Retrieved all environments", environmentCount = environments.length());
+    log:printDebug("Retrieved all environments", environmentCount = environments.length());
 
     return environments;
 }
@@ -173,7 +173,7 @@ public isolated function getEnvironmentIdsByTypes(boolean hasProdAccess, boolean
             environmentIds.push(env.environment_id);
         };
 
-    log:printInfo("Retrieved environment IDs by types", environmentCount = environmentIds.length());
+    log:printDebug("Retrieved environment IDs by types", environmentCount = environmentIds.length());
 
     return environmentIds;
 }
@@ -471,7 +471,7 @@ public isolated function checkEnvironmentHandlerAvailability(string environmentH
         }
     }
 
-    log:printInfo(string `Environment handler availability check completed`,
+    log:printDebug(string `Environment handler availability check completed`,
             environmentHandlerCandidate = environmentHandlerCandidate,
             isHandlerUnique = isHandlerUnique,
             alternateCandidate = alternateCandidate);
@@ -498,6 +498,6 @@ public isolated function getEnvironmentIdsWithRuntimes(string componentId) retur
             environmentIds.push(envRecord.environment_Id);
         };
 
-    log:printInfo(string `Component ${componentId} has runtimes in ${environmentIds.length()} environments`);
+    log:printDebug(string `Component ${componentId} has runtimes in ${environmentIds.length()} environments`);
     return environmentIds;
 }

--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -45,7 +45,7 @@ public isolated function processHeartbeat(types:Heartbeat heartbeat, boolean pre
         if isNewRegistration {
             log:printInfo(string `Registered new runtime via heartbeat: ${runtimeId}`);
         } else {
-            log:printInfo(string `Updated runtime via heartbeat: ${runtimeId}`);
+            log:printDebug(string `Updated runtime via heartbeat: ${runtimeId}`);
         }
 
         // Insert all runtime artifacts
@@ -76,7 +76,7 @@ public isolated function processHeartbeat(types:Heartbeat heartbeat, boolean pre
             )
         `);
         check commit;
-        log:printInfo(string `Successfully processed ${action.toLowerAscii()} for runtime ${runtimeId} with ${totalArtifacts} total artifacts`);
+        log:printDebug(string `Successfully processed ${action.toLowerAscii()} for runtime ${runtimeId} with ${totalArtifacts} total artifacts`);
 
     } on fail error e {
         log:printError(string `Failed to process heartbeat for runtime ${runtimeId}`, e);
@@ -130,7 +130,7 @@ public isolated function processDeltaHeartbeat(types:DeltaHeartbeat deltaHeartbe
     if hashCache.hasKey(runtimeId) {
         any|error cachedHash = hashCache.get(runtimeId);
         hashMatches = cachedHash is string && cachedHash == deltaHeartbeat.runtimeHash;
-        log:printInfo(string `Hash for runtime ${runtimeId} matches: ${hashMatches}`);
+        log:printDebug(string `Hash for runtime ${runtimeId} matches: ${hashMatches}`);
     }
 
     if !hashMatches {
@@ -199,7 +199,7 @@ public isolated function processDeltaHeartbeat(types:DeltaHeartbeat deltaHeartbe
         }
 
         check commit;
-        log:printInfo(string `Successfully processed delta heartbeat for runtime ${runtimeId}`);
+        log:printDebug(string `Successfully processed delta heartbeat for runtime ${runtimeId}`);
 
     } on fail error e {
         log:printError(string `Failed to process delta heartbeat for runtime ${runtimeId}`, e);
@@ -207,7 +207,7 @@ public isolated function processDeltaHeartbeat(types:DeltaHeartbeat deltaHeartbe
     }
 
     if !runtimeExists {
-        log:printInfo(string `Runtime ${runtimeId} does not exist, requesting full heartbeat`);
+        log:printDebug(string `Runtime ${runtimeId} does not exist, requesting full heartbeat`);
     }
 
     return {

--- a/icp_server/modules/storage/project_repository.bal
+++ b/icp_server/modules/storage/project_repository.bal
@@ -186,7 +186,7 @@ public isolated function getProjects() returns types:Project[]|error {
             });
         };
 
-    log:printInfo("Retrieved all projects", projectCount = projects.length());
+    log:printDebug("Retrieved all projects", projectCount = projects.length());
 
     return projects;
 }
@@ -239,7 +239,7 @@ public isolated function getProjectsByIds(string[] projectIds, int? orgId = ()) 
             });
         };
 
-    log:printInfo("Retrieved projects by IDs",
+    log:printDebug("Retrieved projects by IDs",
             projectCount = projects.length(),
             requestedIds = projectIds.length(),
             orgIdFilter = orgId);
@@ -413,7 +413,7 @@ public isolated function checkProjectHandlerAvailability(int orgId, string proje
         }
     }
 
-    log:printInfo(string `Project handler availability check completed`,
+    log:printDebug(string `Project handler availability check completed`,
             orgId = orgId,
             projectHandlerCandidate = projectHandlerCandidate,
             isHandlerUnique = isHandlerUnique,

--- a/icp_server/modules/storage/user_repository.bal
+++ b/icp_server/modules/storage/user_repository.bal
@@ -64,7 +64,7 @@ public isolated function getUserWithGroupsById(string userId) returns json|error
         updatedAt: user?.updatedAt
     };
 
-    log:printInfo(string `Successfully fetched user ${user.username} with group memberships`);
+    log:printDebug(string `Successfully fetched user ${user.username} with group memberships`);
     return userWithGroups;
 }
 
@@ -98,7 +98,7 @@ public isolated function getAllUsersV2() returns json[]|error {
             updatedAt: user?.updatedAt
         };
 
-    log:printInfo(string `Successfully fetched ${usersWithGroups.length()} users with group memberships`);
+    log:printDebug(string `Successfully fetched ${usersWithGroups.length()} users with group memberships`);
     return usersWithGroups;
 }
 

--- a/icp_server/modules/sync/reconcile_dispatch.bal
+++ b/icp_server/modules/sync/reconcile_dispatch.bal
@@ -83,7 +83,7 @@ public isolated function reconcileFromHeartbeat(string runtimeId, string compone
 
         // Reconcile each artifact
         types:ControlCommand[] biCommands = [];
-        log:printInfo("Starting reconciliation from heartbeat", runtimeId = runtimeId,
+        log:printDebug("Starting reconciliation from heartbeat", runtimeId = runtimeId,
                 componentType = componentType, artifactCount = artifactKeys.length());
         foreach types:ReconcileArtifactKey ak in artifactKeys {
             if componentType == types:MI {

--- a/icp_server/observability_service.bal
+++ b/icp_server/observability_service.bal
@@ -145,7 +145,7 @@ service /icp/observability on httpListener {
     }
 
     resource function post logs(http:Request request, types:ICPLogEntryRequest logRequest) returns types:LogEntriesResponse|http:Response|error {
-        log:printInfo("Received log request: " + logRequest.toString());
+        log:printDebug("Received log request: " + logRequest.toString());
 
         // Transform ICPLogEntryRequest to LogEntryRequest by resolving component/environment filters to runtime IDs
         string[] runtimeIdList = check resolveRuntimeIds({
@@ -162,7 +162,7 @@ service /icp/observability on httpListener {
                             (logRequest.environmentList is string[] && (<string[]>logRequest.environmentList).length() > 0);
 
         if (hasFilters && runtimeIdList.length() == 0) {
-            log:printInfo("No runtimes found for the given component/environment filters. Returning empty result.");
+            log:printDebug("No runtimes found for the given component/environment filters. Returning empty result.");
             return {
                 columns: [],
                 rows: []
@@ -198,7 +198,7 @@ service /icp/observability on httpListener {
             sort: logRequest.sort
         };
 
-        log:printInfo("Invoking observability adapter with " + runtimeIdList.length().toString() + " runtime IDs");
+        log:printDebug("Invoking observability adapter with " + runtimeIdList.length().toString() + " runtime IDs");
 
         // Generate fresh JWT token and invoke observability adapter service
         string token = check generateObservabilityToken();
@@ -228,7 +228,7 @@ service /icp/observability on httpListener {
 
     resource function post metrics(http:Request request, types:ICPMetricEntryRequest metricRequest) returns types:MetricEntriesResponse|http:Response|error {
 
-        log:printInfo("Received metric request: " + metricRequest.toString());
+        log:printDebug("Received metric request: " + metricRequest.toString());
 
         // Transform ICPMetricEntryRequest to MetricEntryRequest by resolving component/environment filters to runtime IDs
         string[] runtimeIdList = check resolveRuntimeIds({
@@ -245,7 +245,7 @@ service /icp/observability on httpListener {
                             (metricRequest.environmentList is string[] && (<string[]>metricRequest.environmentList).length() > 0);
 
         if (hasFilters && runtimeIdList.length() == 0) {
-            log:printInfo("No runtimes found for the given component/environment filters. Returning empty result.");
+            log:printDebug("No runtimes found for the given component/environment filters. Returning empty result.");
             return {
                 inboundMetrics: [],
                 outboundMetrics: []
@@ -277,7 +277,7 @@ service /icp/observability on httpListener {
             resolutionInterval: metricRequest.resolutionInterval
         };
 
-        log:printInfo("Invoking observability adapter with " + runtimeIdList.length().toString() + " runtime IDs for component type: " + componentType.toString());
+        log:printDebug("Invoking observability adapter with " + runtimeIdList.length().toString() + " runtime IDs for component type: " + componentType.toString());
 
         // Generate fresh JWT token and invoke observability adapter service with component type path param
         string token = check generateObservabilityToken();
@@ -361,7 +361,7 @@ isolated function resolveRuntimeIds(types:IntegrationDetails integrationDetails)
         }
     }
 
-    log:printInfo("Resolved " + runtimeIds.length().toString() + " runtime IDs from component/environment filters");
+    log:printDebug("Resolved " + runtimeIds.length().toString() + " runtime IDs from component/environment filters");
     return runtimeIds;
 }
 

--- a/icp_server/opensearch_adapter_service.bal
+++ b/icp_server/opensearch_adapter_service.bal
@@ -134,7 +134,7 @@ service /observability on openSerachObservabilityListener {
     }
 
     resource function post logs/[string componentType](@http:Header {name: "X-API-Key"} string? apiKeyHeader, http:Request request, types:LogEntryRequest logRequest) returns types:LogEntriesResponse|error {
-        log:printInfo("Received log request for component: " + logRequest.toString());
+        log:printDebug("Received log request for component: " + logRequest.toString());
 
         // Build OpenSearch query
         json query = buildLogQuery(logRequest);
@@ -254,7 +254,7 @@ service /observability on openSerachObservabilityListener {
         json[][] deduplicatedRows = deduplicateLogEntries(rows);
         int duplicatesRemoved = rows.length() - deduplicatedRows.length();
         if duplicatesRemoved > 0 {
-            log:printInfo(string `Removed ${duplicatesRemoved} duplicate log entries`);
+            log:printDebug(string `Removed ${duplicatesRemoved} duplicate log entries`);
         }
 
         // Trim internal deduplication fields before returning to client
@@ -270,7 +270,7 @@ service /observability on openSerachObservabilityListener {
             clientRows.push(clientRow);
         }
 
-        log:printInfo("Returning " + clientRows.length().toString() + " log entries");
+        log:printDebug("Returning " + clientRows.length().toString() + " log entries");
 
         return {
             columns: columns,
@@ -279,7 +279,7 @@ service /observability on openSerachObservabilityListener {
     }
 
     isolated resource function post metrics/[string componentType](@http:Header {name: "X-API-Key"} string? apiKeyHeader, http:Request request, types:MetricEntryRequest metricRequest) returns types:MetricEntriesResponse|error {
-        log:printInfo("Received metric request for component type " + componentType + ": " + metricRequest.toString());
+        log:printDebug("Received metric request for component type " + componentType + ": " + metricRequest.toString());
 
         if componentType == "BI" {
             return check fetchBIMetrics(metricRequest);
@@ -337,7 +337,7 @@ isolated function fetchBIMetrics(types:MetricEntryRequest metricRequest) returns
     json tagGroups = check aggregations.tag_groups;
     json[] buckets = check tagGroups.buckets.ensureType();
 
-    log:printInfo("BI metrics: Found " + buckets.length().toString() + " unique tag groups");
+    log:printDebug("BI metrics: Found " + buckets.length().toString() + " unique tag groups");
 
     // Process each tag group
     foreach json bucket in buckets {
@@ -446,7 +446,7 @@ isolated function fetchBIMetrics(types:MetricEntryRequest metricRequest) returns
         m.tags.hasKey("src_client_remote") && m.tags.get("src_client_remote") == "true");
     log:printDebug("BI Filtered metrics - Total: " + metrics.length().toString() + ", Inbound: " + inboundMetrics.length().toString() + ", Outbound: " + outboundMetrics.length().toString());
 
-    log:printInfo("Returning " + inboundMetrics.length().toString() + " BI inbound and " + outboundMetrics.length().toString() + " BI outbound metric entries");
+    log:printDebug("Returning " + inboundMetrics.length().toString() + " BI inbound and " + outboundMetrics.length().toString() + " BI outbound metric entries");
 
     return {
         inboundMetrics: inboundMetrics,
@@ -501,7 +501,7 @@ isolated function fetchMIMetrics(types:MetricEntryRequest metricRequest) returns
     json apiGroups = check aggregations.api_groups;
     json[] buckets = check apiGroups.buckets.ensureType();
 
-    log:printInfo("MI metrics: Found " + buckets.length().toString() + " unique API groups");
+    log:printDebug("MI metrics: Found " + buckets.length().toString() + " unique API groups");
 
     foreach json bucket in buckets {
         // Extract composite key fields as tags
@@ -655,7 +655,7 @@ isolated function fetchMIMetrics(types:MetricEntryRequest metricRequest) returns
         }
     }
 
-    log:printInfo("Returning " + inboundMetrics.length().toString() + " MI inbound metric entries");
+    log:printDebug("Returning " + inboundMetrics.length().toString() + " MI inbound metric entries");
 
     return {
         inboundMetrics: inboundMetrics,

--- a/icp_server/runtime_service.bal
+++ b/icp_server/runtime_service.bal
@@ -184,7 +184,7 @@ service /icp on runtimeListener {
                 heartbeatResponse.commands = reconcileCommands;
             }
 
-            log:printInfo(string `Heartbeat processed for runtime=${runtimeId}, kid=${kid}`);
+            log:printDebug(string `Heartbeat processed for runtime=${runtimeId}, kid=${kid}`);
             return heartbeatResponse;
 
         } on fail error e {
@@ -231,7 +231,7 @@ service /icp on runtimeListener {
 
             // Unbound key — delta has no component/environment info to bind with
             if orgSecret.componentId is () {
-                log:printInfo(string `Delta heartbeat: kid=${kid} is unbound, requesting full heartbeat from runtime=${runtimeId}`);
+                log:printDebug(string `Delta heartbeat: kid=${kid} is unbound, requesting full heartbeat from runtime=${runtimeId}`);
                 return <types:HeartbeatResponse>{acknowledged: false, fullHeartbeatRequired: true, commands: []};
             }
 
@@ -251,7 +251,7 @@ service /icp on runtimeListener {
                 }
             }
 
-            log:printInfo(string `Delta heartbeat processed for runtime=${runtimeId}, kid=${kid}`);
+            log:printDebug(string `Delta heartbeat processed for runtime=${runtimeId}, kid=${kid}`);
             return heartbeatResponse;
 
         } on fail error e {


### PR DESCRIPTION
   ## Summary

   Reduced excessive `INFO` logs to `DEBUG` level across 12 files (57 changes total), and improved the MI user store error experience in the frontend.

   ### Log level changes

   These logs were firing on every authenticated request, every heartbeat cycle, and every dashboard/observability query — producing significant noise under normal usage. All changed to `log:printDebug` so they remain accessible when needed without polluting production
 log output.

   | File | Changes | Reason |
   |---|---|---|
   | `modules/auth/utils.bal` | 2 | `extractUserContextV2` and `generateJwtTokenV2` are called on **every** authenticated request — the exact case reported |
   | `auth_service.bal` | 2 | "Fetching/fetched effective permissions for user" — triggered on every permission check during user interaction |
   | `modules/storage/heartbeat_repository.bal` | 5 | Heartbeat is sent periodically by every runtime; "Updated via heartbeat", "Successfully processed", "Hash matches", "Processed delta heartbeat", "Runtime does not exist" all fire on every cycle |
   | `runtime_service.bal` | 3 | "Heartbeat processed", "Delta heartbeat processed", "kid is unbound" — same heartbeat cycle noise |
   | `modules/sync/reconcile_dispatch.bal` | 1 | "Starting reconciliation from heartbeat" — fires on every heartbeat |
   | `observability_service.bal` | 7 | Log/metric query intake logs — fire on every dashboard query or log search |
   | `opensearch_adapter_service.bal` | 8 | Per-query adapter logs (receiving, deduplicating, returning results) |
   | `graphql_api.bal` | 25 | All "Fetching/fetched X from MI management API" and entity lookup logs — fire on every GraphQL query |
   | `modules/storage/environment_repository.bal` | 5 | Read operations (list, get-by-IDs, availability checks) called on every page load |
   | `modules/storage/project_repository.bal` | 3 | Same as above for projects |
   | `modules/storage/component_repository.bal` | 1 | "Retrieved deployment info" — called per component view |
   | `modules/storage/user_repository.bal` | 2 | "Successfully fetched user(s)" — called on every auth/RBAC check |

   #### Kept as `INFO`
   The following remain at `INFO` as they represent meaningful, infrequent lifecycle events:
   - Server startup & initialization
   - User/group/role **create, update, delete**
   - Login, logout, password change, account unlock, token revocation
   - New runtime **registration** (first-ever heartbeat from a runtime)
   - OIDC flow events
   - Hash mismatch causing a full heartbeat request (indicates a notable state change)

   ### MI user store error UX (`frontend/src/components/EntryPoints.tsx`)

   Previously, when an MI runtime has no user store configured, the UI would show a raw error message (`Failed to load users: ...`) and leave the "Add user" button enabled, leading to a confusing experience.

   | | Before | After |
   |---|---|---|
   | **Error message** | Generic red error: `Failed to load users: User management is not supported with the file-based user store...` | Friendly grey message explaining the user store is not configured, with a link to the [WSO2 user store configuration
 docs](https://mi.docs.wso2.com/en/latest/install-and-setup/setup/user-stores/setting-up-a-userstore-in-mi/) |
   | **Add user button** | Enabled (misleadingly) | Disabled with tooltip `"User store not configured"` |
   
 ### Related Issues
* https://github.com/wso2/product-integrator/issues/747