### PR TITLE
Fix MessageProcessor query requesting non-existent tracing field

### DIFF
--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -462,7 +462,7 @@ const ARTIFACT_QUERY_MAP: Record<string, { queryName: string; field: string; fie
     queryName: 'messageProcessorsByEnvironmentAndComponent',
     field: 'messageProcessorsByEnvironmentAndComponent',
     fields: 'name, type, state',
-    gqlFields: 'name, type, state, stateInSync, tracing, carbonApp, runtimes { runtimeId, runtimeName, status }',
+    gqlFields: 'name, type, state, stateInSync, carbonApp, runtimes { runtimeId, runtimeName, status }',
   },
   Template: {
     queryName: 'templatesByEnvironmentAndComponent',


### PR DESCRIPTION
## Problem

The Message Processor list in the Supporting Artifacts view always shows empty/loading, despite MI correctly reporting the artifact via its management API.

## Root Cause

The frontend GraphQL query for `MessageProcessor` includes a `tracing` field that does not exist on the backend `MessageProcessor` type, causing a 400 response:

```
Cannot query field "tracing" on type "MessageProcessor".
```

The `tracing` field was likely copied from artifact types like `Sequence` and `Template` that do support it.

## Fix

Remove the `tracing` field from the `MessageProcessor` `gqlFields` in the artifact query map.

## Testing

Verified with a bare lab (ICP + MI with preloaded artifacts). Before the fix, the Message Processor tab shows a loading spinner indefinitely. After the fix, `SampleMessageProcessor` (ScheduledMessageForwardingProcessor) displays correctly with name, type, and status toggle.