### PR TITLE
Make icp.sh POSIX-compatible (dash/sh safe)

### DIFF
--- a/distribution/scripts/icp.sh
+++ b/distribution/scripts/icp.sh
@@ -26,7 +26,7 @@ CONFIG_FILE="$PARENT_DIR/conf/deployment.toml"
 PID_FILE="$PARENT_DIR/icp.pid"
 LOG_DIR="$PARENT_DIR/logs"
 LOG_FILE="$LOG_DIR/icp.log"
-JAVA_OPTS=()
+JAVA_OPTS=""
 
 resolve_version() {
     if [ -f "$PARENT_DIR/version.txt" ]; then
@@ -56,14 +56,10 @@ resolve_version() {
 }
 
 detect_java_opts() {
-    JAVA_OPTS=()
+    JAVA_OPTS=""
     if [ -f /etc/alpine-release ] || (command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl); then
         echo "Alpine Linux detected - disabling native Netty tcnative libraries"
-        JAVA_OPTS+=(
-            "-Dio.netty.native.workdir=/tmp/netty-native"
-            "-Dio.netty.transport.noNative=true"
-            "-Dio.netty.handler.ssl.noOpenSsl=true"
-        )
+        JAVA_OPTS="-Dio.netty.native.workdir=/tmp/netty-native -Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
     fi
 }
 
@@ -102,13 +98,13 @@ run_server() {
     fi
 
     if [ "$mode" = "background" ]; then
-        nohup java "${JAVA_OPTS[@]}" -jar "$JAR_FILE" "$@" >> "$LOG_FILE" 2>&1 &
+        nohup java $JAVA_OPTS -jar "$JAR_FILE" "$@" >> "$LOG_FILE" 2>&1 &
         server_pid=$!
         echo "$server_pid" > "$PID_FILE"
         echo "ICP Server started with PID $server_pid"
         echo "Logs are available at $LOG_FILE"
     else
-        exec java "${JAVA_OPTS[@]}" -jar "$JAR_FILE" "$@"
+        exec java $JAVA_OPTS -jar "$JAR_FILE" "$@"
     fi
 }
 


### PR DESCRIPTION
## Problem

The WSO2 Integrator extension launches `icp.sh` via:

```js
l.spawn("sh", [e], {detached: true, env: ...})
```

On Ubuntu/Debian, `/bin/sh` is `dash`. The shebang (`#!/bin/bash`) is ignored since the extension invokes the script explicitly with `sh`. The script uses bash-only array syntax that `dash` cannot parse:

- `JAVA_OPTS=()` — bash array initialization
- `JAVA_OPTS+=()` — bash array append
- `"${JAVA_OPTS[@]}"` — bash array expansion

`dash` fails with a hard syntax error at parse time:

```
/path/to/icp.sh: Syntax error: "(" unexpected
```

This prevents ICP from starting when launched from the extension on Ubuntu/Debian.

It works on macOS and Fedora/RHEL because `/bin/sh` is `bash` on those platforms:

| Platform | `/bin/sh` | Works? |
|---|---|---|
| macOS | bash | ✅ |
| Fedora/RHEL | bash | ✅ |
| Ubuntu/Debian | dash | ❌ |

## Fix

Replace bash arrays with a plain string variable — the only construct that `dash` cannot handle. The shebang stays as `#!/bin/bash` (the script uses `local` and may add other bash features in the future).

When `JAVA_OPTS` is empty, the unquoted `$JAVA_OPTS` expands to nothing (no spurious empty argument passed to `java`).

Verified: `dash -n icp.sh` passes.