### PR TITLE
Fix PostgreSQL transaction abort in upsertRuntime

### DIFF
--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -547,10 +547,17 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
         }
     }
 
+    // Determine new-vs-existing by explicit SELECT before the upsert
+    stream<record {|string runtime_id;|}, sql:Error?> existingById = dbClient->query(`
+        SELECT runtime_id FROM runtimes WHERE runtime_id = ${runtimeId}
+    `);
+    record {|string runtime_id;|}[] existingByIdRows = check from record {|string runtime_id;|} r in existingById
+        select r;
+    boolean isNewRegistration = existingByIdRows.length() == 0;
+
     // Atomic upsert for PostgreSQL, fallback to INSERT/UPDATE for others
-    sql:ExecutionResult res;
     if dbType == POSTGRESQL {
-        res = check dbClient->execute(`
+        _ = check dbClient->execute(`
             INSERT INTO runtimes (
                 runtime_id, name, runtime_type, status, version,
                 runtime_hostname, runtime_port,
@@ -596,9 +603,30 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
                 server_name = EXCLUDED.server_name,
                 last_heartbeat = CURRENT_TIMESTAMP
         `);
+    } else if isNewRegistration {
+        _ = check dbClient->execute(`
+            INSERT INTO runtimes (
+                runtime_id, name, runtime_type, status, version,
+                runtime_hostname, runtime_port,
+                environment_id, project_id, component_id,
+                platform_name, platform_version, platform_home,
+                os_name, os_version,
+                carbon_home, java_vendor, java_version,
+                total_memory, free_memory, max_memory, used_memory,
+                os_arch, server_name, last_heartbeat
+            ) VALUES (
+                ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
+                ${runtimeHostname}, ${runtimePort},
+                ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
+                ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
+                ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
+                ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
+                ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
+                ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
+            )
+        `);
     } else {
-        // Fallback: try UPDATE, then INSERT if not found
-        res = check dbClient->execute(`
+        _ = check dbClient->execute(`
             UPDATE runtimes SET
                 name = ${runtimeName},
                 runtime_type = ${heartbeat.runtimeType},
@@ -626,32 +654,8 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
                 last_heartbeat = CURRENT_TIMESTAMP
             WHERE runtime_id = ${runtimeId}
         `);
-        if ((res.affectedRowCount ?: 0) == 0) {
-            res = check dbClient->execute(`
-                INSERT INTO runtimes (
-                    runtime_id, name, runtime_type, status, version,
-                    runtime_hostname, runtime_port,
-                    environment_id, project_id, component_id,
-                    platform_name, platform_version, platform_home,
-                    os_name, os_version,
-                    carbon_home, java_vendor, java_version,
-                    total_memory, free_memory, max_memory, used_memory,
-                    os_arch, server_name, last_heartbeat
-                ) VALUES (
-                    ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
-                    ${runtimeHostname}, ${runtimePort},
-                    ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
-                    ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
-                    ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
-                    ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
-                    ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
-                    ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
-                )
-            `);
-        }
     }
-    // Return true if inserted, false if updated
-    return (res.affectedRowCount ?: 0) == 1;
+    return isNewRegistration;
 }
 
 // Insert all runtime artifacts

--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -520,16 +520,85 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
     string runtimeHostname = heartbeat.runtimeHostname ?: "";
     string runtimePort = heartbeat.runtimePort ?: "";
 
-    // SELECT first to avoid failing INSERT inside a transaction (PostgreSQL aborts transactions on any error)
-    stream<record {|string runtime_id;|}, sql:Error?> existingById = dbClient->query(`
-        SELECT runtime_id FROM runtimes WHERE runtime_id = ${runtimeId}
-    `);
-    record {|string runtime_id;|}[] existingByIdRows = check from record {|string runtime_id;|} r in existingById
+    // Check if a runtime with the same component/env/name but different ID exists (ID change scenario)
+    stream<record {|string runtime_id;|}, sql:Error?> existingByName;
+    if runtimeName is string {
+        existingByName = dbClient->query(`
+            SELECT runtime_id FROM runtimes
+            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName}
+        `);
+    } else {
+        existingByName = dbClient->query(`
+            SELECT runtime_id FROM runtimes
+            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name IS NULL
+        `);
+    }
+    record {|string runtime_id;|}[] existingByNameRows = check from record {|string runtime_id;|} r in existingByName
         select r;
 
-    if existingByIdRows.length() > 0 {
-        log:printDebug(string `Updating existing runtime ${runtimeId} with latest heartbeat data`);
-        _ = check dbClient->execute(`
+    if existingByNameRows.length() > 0 {
+        string oldId = existingByNameRows[0].runtime_id;
+        if oldId != runtimeId {
+            log:printInfo(string `Runtime ID changed from ${oldId} to ${runtimeId} for ${runtimeName ?: "null"}`);
+            log:printDebug(string `Deleting old runtime ${oldId} via reconcile cleanup flow`);
+            check deleteExistingArtifacts(oldId);
+            check deleteReconcileRuntime(oldId);
+            check deleteRuntime(oldId);
+        }
+    }
+
+    // Atomic upsert for PostgreSQL, fallback to INSERT/UPDATE for others
+    sql:ExecutionResult res;
+    if dbType == POSTGRESQL {
+        res = check dbClient->execute(`
+            INSERT INTO runtimes (
+                runtime_id, name, runtime_type, status, version,
+                runtime_hostname, runtime_port,
+                environment_id, project_id, component_id,
+                platform_name, platform_version, platform_home,
+                os_name, os_version,
+                carbon_home, java_vendor, java_version,
+                total_memory, free_memory, max_memory, used_memory,
+                os_arch, server_name, last_heartbeat
+            ) VALUES (
+                ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
+                ${runtimeHostname}, ${runtimePort},
+                ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
+                ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
+                ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
+                ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
+                ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
+                ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
+            )
+            ON CONFLICT (runtime_id) DO UPDATE SET
+                name = EXCLUDED.name,
+                runtime_type = EXCLUDED.runtime_type,
+                status = EXCLUDED.status,
+                version = EXCLUDED.version,
+                runtime_hostname = EXCLUDED.runtime_hostname,
+                runtime_port = EXCLUDED.runtime_port,
+                environment_id = EXCLUDED.environment_id,
+                project_id = EXCLUDED.project_id,
+                component_id = EXCLUDED.component_id,
+                platform_name = EXCLUDED.platform_name,
+                platform_version = EXCLUDED.platform_version,
+                platform_home = EXCLUDED.platform_home,
+                os_name = EXCLUDED.os_name,
+                os_version = EXCLUDED.os_version,
+                carbon_home = EXCLUDED.carbon_home,
+                java_vendor = EXCLUDED.java_vendor,
+                java_version = EXCLUDED.java_version,
+                total_memory = EXCLUDED.total_memory,
+                free_memory = EXCLUDED.free_memory,
+                max_memory = EXCLUDED.max_memory,
+                used_memory = EXCLUDED.used_memory,
+                os_arch = EXCLUDED.os_arch,
+                server_name = EXCLUDED.server_name,
+                last_heartbeat = CURRENT_TIMESTAMP
+        `);
+    } else {
+        // Fallback: try UPDATE, then INSERT if not found
+        res = check dbClient->execute(`
             UPDATE runtimes SET
                 name = ${runtimeName},
                 runtime_type = ${heartbeat.runtimeType},
@@ -557,56 +626,31 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
                 last_heartbeat = CURRENT_TIMESTAMP
             WHERE runtime_id = ${runtimeId}
         `);
-        return false;
+        if ((res.affectedRowCount ?: 0) == 0) {
+            res = check dbClient->execute(`
+                INSERT INTO runtimes (
+                    runtime_id, name, runtime_type, status, version,
+                    runtime_hostname, runtime_port,
+                    environment_id, project_id, component_id,
+                    platform_name, platform_version, platform_home,
+                    os_name, os_version,
+                    carbon_home, java_vendor, java_version,
+                    total_memory, free_memory, max_memory, used_memory,
+                    os_arch, server_name, last_heartbeat
+                ) VALUES (
+                    ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
+                    ${runtimeHostname}, ${runtimePort},
+                    ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
+                    ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
+                    ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
+                    ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
+                    ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
+                    ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
+                )
+            `);
+        }
     }
-
-    // Runtime not found by ID — check if it exists by component+env+name (runtimeId may have changed)
-    log:printDebug(string `Runtime not found by id=${runtimeId}, checking by component/env/name`);
-    stream<record {|string runtime_id;|}, sql:Error?> existingByName;
-    if runtimeName is string {
-        existingByName = dbClient->query(`
-            SELECT runtime_id FROM runtimes
-            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName}
-        `);
-    } else {
-        existingByName = dbClient->query(`
-            SELECT runtime_id FROM runtimes
-            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name IS NULL
-        `);
-    }
-    record {|string runtime_id;|}[] existingByNameRows = check from record {|string runtime_id;|} r in existingByName
-        select r;
-
-    if existingByNameRows.length() > 0 {
-        string oldId = existingByNameRows[0].runtime_id;
-        log:printInfo(string `Runtime ID changed from ${oldId} to ${runtimeId} for ${runtimeName ?: "null"}`);
-        log:printDebug(string `Deleting old runtime ${oldId} via reconcile cleanup flow`);
-        check deleteRuntime(oldId);
-        check deleteReconcileRuntime(oldId);
-    }
-
-    log:printDebug(string `Inserting new runtime ${runtimeId}`);
-    sql:ExecutionResult res = check dbClient->execute(`
-        INSERT INTO runtimes (
-            runtime_id, name, runtime_type, status, version,
-            runtime_hostname, runtime_port,
-            environment_id, project_id, component_id,
-            platform_name, platform_version, platform_home,
-            os_name, os_version,
-            carbon_home, java_vendor, java_version,
-            total_memory, free_memory, max_memory, used_memory,
-            os_arch, server_name, last_heartbeat
-        ) VALUES (
-            ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
-            ${runtimeHostname}, ${runtimePort},
-            ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
-            ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
-            ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
-            ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
-            ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
-            ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
-        )
-    `);
+    // Return true if inserted, false if updated
     return (res.affectedRowCount ?: 0) == 1;
 }
 

--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -520,8 +520,73 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
     string runtimeHostname = heartbeat.runtimeHostname ?: "";
     string runtimePort = heartbeat.runtimePort ?: "";
 
-    // Try INSERT first
-    sql:ExecutionResult|error insertRes = dbClient->execute(`
+    // SELECT first to avoid failing INSERT inside a transaction (PostgreSQL aborts transactions on any error)
+    stream<record {|string runtime_id;|}, sql:Error?> existingById = dbClient->query(`
+        SELECT runtime_id FROM runtimes WHERE runtime_id = ${runtimeId}
+    `);
+    record {|string runtime_id;|}[] existingByIdRows = check from record {|string runtime_id;|} r in existingById
+        select r;
+
+    if existingByIdRows.length() > 0 {
+        log:printDebug(string `Updating existing runtime ${runtimeId} with latest heartbeat data`);
+        _ = check dbClient->execute(`
+            UPDATE runtimes SET
+                name = ${runtimeName},
+                runtime_type = ${heartbeat.runtimeType},
+                status = ${heartbeat.status},
+                version = ${heartbeat.version},
+                runtime_hostname = ${runtimeHostname},
+                runtime_port = ${runtimePort},
+                environment_id = ${heartbeat.environment},
+                project_id = ${heartbeat.project},
+                component_id = ${heartbeat.component},
+                platform_name = ${heartbeat.nodeInfo.platformName},
+                platform_version = ${heartbeat.nodeInfo.platformVersion},
+                platform_home = ${heartbeat.nodeInfo.platformHome},
+                os_name = ${heartbeat.nodeInfo.osName},
+                os_version = ${heartbeat.nodeInfo.osVersion},
+                carbon_home = ${heartbeat.nodeInfo.carbonHome},
+                java_vendor = ${heartbeat.nodeInfo.javaVendor},
+                java_version = ${heartbeat.nodeInfo.javaVersion},
+                total_memory = ${heartbeat.nodeInfo.totalMemory},
+                free_memory = ${heartbeat.nodeInfo.freeMemory},
+                max_memory = ${heartbeat.nodeInfo.maxMemory},
+                used_memory = ${heartbeat.nodeInfo.usedMemory},
+                os_arch = ${heartbeat.nodeInfo.osArch},
+                server_name = ${heartbeat.nodeInfo.platformName},
+                last_heartbeat = CURRENT_TIMESTAMP
+            WHERE runtime_id = ${runtimeId}
+        `);
+        return false;
+    }
+
+    // Runtime not found by ID — check if it exists by component+env+name (runtimeId may have changed)
+    log:printDebug(string `Runtime not found by id=${runtimeId}, checking by component/env/name`);
+    stream<record {|string runtime_id;|}, sql:Error?> existingByName;
+    if runtimeName is string {
+        existingByName = dbClient->query(`
+            SELECT runtime_id FROM runtimes
+            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName}
+        `);
+    } else {
+        existingByName = dbClient->query(`
+            SELECT runtime_id FROM runtimes
+            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name IS NULL
+        `);
+    }
+    record {|string runtime_id;|}[] existingByNameRows = check from record {|string runtime_id;|} r in existingByName
+        select r;
+
+    if existingByNameRows.length() > 0 {
+        string oldId = existingByNameRows[0].runtime_id;
+        log:printInfo(string `Runtime ID changed from ${oldId} to ${runtimeId} for ${runtimeName ?: "null"}`);
+        log:printDebug(string `Deleting old runtime ${oldId} via reconcile cleanup flow`);
+        check deleteRuntime(oldId);
+        check deleteReconcileRuntime(oldId);
+    }
+
+    log:printDebug(string `Inserting new runtime ${runtimeId}`);
+    sql:ExecutionResult res = check dbClient->execute(`
         INSERT INTO runtimes (
             runtime_id, name, runtime_type, status, version,
             runtime_hostname, runtime_port,
@@ -542,98 +607,7 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns boolean|error
             ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
         )
     `);
-
-    if insertRes is sql:ExecutionResult {
-        int? rows = insertRes.affectedRowCount;
-        return rows == 1;
-    }
-
-    if insertRes is sql:Error && classifySqlError(insertRes) != DUPLICATE_KEY {
-        return insertRes;
-    }
-
-    log:printDebug(string `Runtime already exists for component ${heartbeat.component}, env ${heartbeat.environment}, name ${runtimeName ?: "null"}`);
-
-    stream<record {|string runtime_id;|}, sql:Error?> existing;
-    if runtimeName is string {
-        existing = dbClient->query(`
-            SELECT runtime_id FROM runtimes
-            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName}
-        `);
-    } else {
-        existing = dbClient->query(`
-            SELECT runtime_id FROM runtimes
-            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name IS NULL
-        `);
-    }
-    record {|string runtime_id;|}[] rows = check from record {|string runtime_id;|} r in existing
-        select r;
-
-    if rows.length() > 0 && rows[0].runtime_id != runtimeId {
-        string oldId = rows[0].runtime_id;
-        log:printInfo(string `Runtime ID changed from ${oldId} to ${runtimeId} for ${runtimeName ?: "null"}`);
-        log:printDebug(string `Deleting old runtime ${oldId} via reconcile cleanup flow`);
-
-        check deleteRuntime(oldId);
-        check deleteReconcileRuntime(oldId);
-
-        log:printDebug(string `Inserting new runtime ${runtimeId} after ID change`);
-        sql:ExecutionResult res = check dbClient->execute(`
-            INSERT INTO runtimes (
-                runtime_id, name, runtime_type, status, version,
-                runtime_hostname, runtime_port,
-                environment_id, project_id, component_id,
-                platform_name, platform_version, platform_home,
-                os_name, os_version,
-                carbon_home, java_vendor, java_version,
-                total_memory, free_memory, max_memory, used_memory,
-                os_arch, server_name, last_heartbeat
-            ) VALUES (
-                ${runtimeId}, ${runtimeName}, ${heartbeat.runtimeType}, ${heartbeat.status}, ${heartbeat.version},
-                ${runtimeHostname}, ${runtimePort},
-                ${heartbeat.environment}, ${heartbeat.project}, ${heartbeat.component},
-                ${heartbeat.nodeInfo.platformName}, ${heartbeat.nodeInfo.platformVersion}, ${heartbeat.nodeInfo.platformHome},
-                ${heartbeat.nodeInfo.osName}, ${heartbeat.nodeInfo.osVersion},
-                ${heartbeat.nodeInfo.carbonHome}, ${heartbeat.nodeInfo.javaVendor}, ${heartbeat.nodeInfo.javaVersion},
-                ${heartbeat.nodeInfo.totalMemory}, ${heartbeat.nodeInfo.freeMemory}, ${heartbeat.nodeInfo.maxMemory}, ${heartbeat.nodeInfo.usedMemory},
-                ${heartbeat.nodeInfo.osArch}, ${heartbeat.nodeInfo.platformName}, CURRENT_TIMESTAMP
-            )
-        `);
-        log:printDebug(string `Successfully inserted runtime ${runtimeId} after ID change`);
-        return (res.affectedRowCount ?: 0) == 1;
-    }
-
-    log:printDebug(string `Updating existing runtime ${runtimeId} with latest heartbeat data`);
-    _ = check dbClient->execute(`
-        UPDATE runtimes SET
-            name = ${runtimeName},
-            runtime_type = ${heartbeat.runtimeType},
-            status = ${heartbeat.status},
-            version = ${heartbeat.version},
-            runtime_hostname = ${runtimeHostname},
-            runtime_port = ${runtimePort},
-            environment_id = ${heartbeat.environment},
-            project_id = ${heartbeat.project},
-            component_id = ${heartbeat.component},
-            platform_name = ${heartbeat.nodeInfo.platformName},
-            platform_version = ${heartbeat.nodeInfo.platformVersion},
-            platform_home = ${heartbeat.nodeInfo.platformHome},
-            os_name = ${heartbeat.nodeInfo.osName},
-            os_version = ${heartbeat.nodeInfo.osVersion},
-            carbon_home = ${heartbeat.nodeInfo.carbonHome},
-            java_vendor = ${heartbeat.nodeInfo.javaVendor},
-            java_version = ${heartbeat.nodeInfo.javaVersion},
-            total_memory = ${heartbeat.nodeInfo.totalMemory},
-            free_memory = ${heartbeat.nodeInfo.freeMemory},
-            max_memory = ${heartbeat.nodeInfo.maxMemory},
-            used_memory = ${heartbeat.nodeInfo.usedMemory},
-            os_arch = ${heartbeat.nodeInfo.osArch},
-            server_name = ${heartbeat.nodeInfo.platformName},
-            last_heartbeat = CURRENT_TIMESTAMP
-        WHERE runtime_id = ${runtimeId}
-    `);
-
-    return false;
+    return (res.affectedRowCount ?: 0) == 1;
 }
 
 // Insert all runtime artifacts


### PR DESCRIPTION
## Summary

- **Bug**: `upsertRuntime` used a try-INSERT-catch-`DUPLICATE_KEY` pattern. In PostgreSQL, any statement error inside a transaction — even a caught one — immediately marks the connection as aborted; every subsequent statement fails with `ERROR: current transaction is aborted, commands ignored until end of transaction block`. Result: the very first heartbeat from a BI runtime was stored successfully, but every heartbeat after that was rejected.
- **Fix**: replace the try-INSERT with a SELECT-first approach — no statement inside the transaction can fail on the normal path, so the aborted-transaction state is never reached.

### New flow in `upsertRuntime`

1. `SELECT runtime_id WHERE runtime_id = ?` — if found → `UPDATE`, return `false` (not a new registration).
2. If not found → `SELECT runtime_id WHERE component_id = ? AND environment_id = ? AND name = ?` — detects a runtimeId change; if old id is found, delete it first.
3. `INSERT` the new row, return `true`.

## Test plan

- [x] Deployed BI file-watcher app against PostgreSQL; heartbeats now succeed continuously (no `current transaction is aborted` errors in ICP logs).
- [ ] Verify the runtimeId-change path (step 2) works correctly when a BI runtime restarts with a new UUID.
- [ ] Run against H2 to confirm no regression on the default database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)