### PR TITLE
Reject empty or whitespace-only roleName on role create/update

### DIFF
--- a/icp_server/Dependencies.toml
+++ b/icp_server/Dependencies.toml
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.1"
+version = "2.16.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -498,7 +498,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/icp_server/auth_service.bal
+++ b/icp_server/auth_service.bal
@@ -2442,6 +2442,11 @@ service /auth on httpListener {
             };
         }
 
+        // Validate roleName is not blank
+        if roleInput.roleName.trim().length() == 0 {
+            return utils:createBadRequestError("roleName must not be empty or whitespace");
+        }
+
         // Resolve org handle to org ID
         // TODO: use when multiple tenants are supported
         // int|error orgId = storage:getOrgIdByHandle(orgHandle);
@@ -2584,7 +2589,7 @@ service /auth on httpListener {
             }
         ]
     }
-    isolated resource function put orgs/[string orgHandle]/roles/[string roleId](@http:Payload types:RoleV2Input roleInput, http:Request req) returns http:Ok|http:NotFound|http:Unauthorized|http:Forbidden|http:InternalServerError|error {
+    isolated resource function put orgs/[string orgHandle]/roles/[string roleId](@http:Payload types:RoleV2Input roleInput, http:Request req) returns http:Ok|http:BadRequest|http:NotFound|http:Unauthorized|http:Forbidden|http:InternalServerError|error {
         log:printInfo("Updating role", orgHandle = orgHandle, roleId = roleId);
 
         // Permission check: org-level role management
@@ -2604,6 +2609,11 @@ service /auth on httpListener {
                     message: "Insufficient permissions to update roles"
                 }
             };
+        }
+
+        // Validate roleName is not blank
+        if roleInput.roleName.trim().length() == 0 {
+            return utils:createBadRequestError("roleName must not be empty or whitespace");
         }
 
         // Update the role (name, description)


### PR DESCRIPTION
## Summary
- Resolves https://github.com/wso2/product-integrator/issues/250
- `POST /auth/orgs/{orgHandle}/roles` now returns `400 Bad Request` when `roleName` is an empty string or whitespace-only, preventing invalid roles from being persisted
- `PUT /auth/orgs/{orgHandle}/roles/{roleId}` has the same guard applied for consistency
- Added `http:BadRequest` to the PUT handler's return type union, which was missing and caused a compile error

## Test plan
- [ ] `POST` with `roleName: ""` → 400 with `"roleName must not be empty or whitespace"`
- [ ] `POST` with `roleName: "   "` → 400 with `"roleName must not be empty or whitespace"`
- [ ] `POST` with a valid `roleName` → 201 Created (no regression)
- [ ] `PUT` with `roleName: ""` → 400 with `"roleName must not be empty or whitespace"`
- [ ] `PUT` with a valid `roleName` → 200 Ok (no regression)