### PR TITLE
Display AutomationExecutions timestamp in user's local timezone

### DIFF
--- a/frontend/src/components/ArtifactTabs.tsx
+++ b/frontend/src/components/ArtifactTabs.tsx
@@ -835,7 +835,7 @@ export function AutomationExecutions({ artifact }: TabProps) {
             sorted.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((exec, i) => (
               <ListingTable.Row key={i}>
                 <ListingTable.Cell>
-                  <Typography variant="body2">{exec.timestamp}</Typography>
+                  <Typography variant="body2">{new Date(exec.timestamp.replace(' ', 'T') + 'Z').toLocaleString()}</Typography>
                 </ListingTable.Cell>
                 <ListingTable.Cell>
                   <Typography sx={{ fontFamily: 'monospace', fontSize: 12 }}>{exec.runtimeName || exec.runtimeId}</Typography>

--- a/frontend/src/components/ArtifactTabs.tsx
+++ b/frontend/src/components/ArtifactTabs.tsx
@@ -835,7 +835,7 @@ export function AutomationExecutions({ artifact }: TabProps) {
             sorted.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((exec, i) => (
               <ListingTable.Row key={i}>
                 <ListingTable.Cell>
-                  <Typography variant="body2">{new Date(exec.timestamp.replace(' ', 'T') + 'Z').toLocaleString()}</Typography>
+                  <Typography variant="body2">{new Date(exec.timestamp).toLocaleString()}</Typography>
                 </ListingTable.Cell>
                 <ListingTable.Cell>
                   <Typography sx={{ fontFamily: 'monospace', fontSize: 12 }}>{exec.runtimeName || exec.runtimeId}</Typography>

--- a/icp_server/modules/storage/artifact_repository.bal
+++ b/icp_server/modules/storage/artifact_repository.bal
@@ -317,7 +317,7 @@ public isolated function getAutomationsByEnvironmentAndComponent(string environm
                     packageOrg: row.package_org,
                     packageName: row.package_name,
                     packageVersion: row.package_version,
-                    executionTimestamp: row.execution_timestamp
+                    executionTimestamp: convertDbDateTimeToISO8601(row.execution_timestamp)
                 };
                 automationRuntimeExecutions[key] = {};
             }
@@ -325,8 +325,9 @@ public isolated function getAutomationsByEnvironmentAndComponent(string environm
             // Get or create the runtime executions map for this automation
             map<string[]> runtimeExecs = automationRuntimeExecutions[key] ?: {};
             string[] existingTimestamps = runtimeExecs[row.runtime_id] ?: [];
-            if existingTimestamps.indexOf(row.execution_timestamp) is () {
-                existingTimestamps.push(row.execution_timestamp);
+            string isoTimestamp = convertDbDateTimeToISO8601(row.execution_timestamp);
+            if existingTimestamps.indexOf(isoTimestamp) is () {
+                existingTimestamps.push(isoTimestamp);
             }
             runtimeExecs[row.runtime_id] = existingTimestamps;
             automationRuntimeExecutions[key] = runtimeExecs;
@@ -339,8 +340,9 @@ public isolated function getAutomationsByEnvironmentAndComponent(string environm
             if automationMap.hasKey(key) {
                 map<string[]> runtimeExecs = automationRuntimeExecutions[key] ?: {};
                 string[] existingTimestamps = runtimeExecs[row.runtime_id] ?: [];
-                if existingTimestamps.indexOf(row.execution_timestamp) is () {
-                    existingTimestamps.push(row.execution_timestamp);
+                string isoTimestamp = convertDbDateTimeToISO8601(row.execution_timestamp);
+                if existingTimestamps.indexOf(isoTimestamp) is () {
+                    existingTimestamps.push(isoTimestamp);
                 }
                 runtimeExecs[row.runtime_id] = existingTimestamps;
                 automationRuntimeExecutions[key] = runtimeExecs;

--- a/icp_server/modules/storage/database_dialect.bal
+++ b/icp_server/modules/storage/database_dialect.bal
@@ -161,6 +161,15 @@ public isolated function appendLimitClause(sql:ParameterizedQuery query, int row
     }
 }
 
+// Convert a DB timestamp string (UTC, no timezone marker) to ISO 8601 UTC.
+// Input:  "2026-04-30 10:30:00" or "2026-04-30 10:30:00.000000"
+// Output: "2026-04-30T10:30:00Z"
+public isolated function convertDbDateTimeToISO8601(string dbTimestamp) returns string {
+    string normalized = dbTimestamp.substring(0, 10) + "T" + dbTimestamp.substring(11);
+    int dotIndex = normalized.indexOf(".") ?: normalized.length();
+    return normalized.substring(0, dotIndex) + "Z";
+}
+
 // Cast string to timestamp for PostgreSQL (no-op for other databases)
 // PostgreSQL requires explicit ::timestamp cast, others handle it automatically
 public isolated function timestampCast(string timestampStr) returns string {

--- a/icp_server/modules/storage/database_dialect.bal
+++ b/icp_server/modules/storage/database_dialect.bal
@@ -162,12 +162,16 @@ public isolated function appendLimitClause(sql:ParameterizedQuery query, int row
 }
 
 // Convert a DB timestamp string (UTC, no timezone marker) to ISO 8601 UTC.
-// Input:  "2026-04-30 10:30:00" or "2026-04-30 10:30:00.000000"
+// Handles space separator (MySQL/H2/PostgreSQL) and T separator (MSSQL DATETIME2).
+// Input:  "2026-04-30 10:30:00", "2026-04-30 10:30:00.000000", "2026-04-30T10:30:00.0000000"
 // Output: "2026-04-30T10:30:00Z"
 public isolated function convertDbDateTimeToISO8601(string dbTimestamp) returns string {
-    string normalized = dbTimestamp.substring(0, 10) + "T" + dbTimestamp.substring(11);
-    int dotIndex = normalized.indexOf(".") ?: normalized.length();
-    return normalized.substring(0, dotIndex) + "Z";
+    int dotIndex = dbTimestamp.indexOf(".") ?: dbTimestamp.length();
+    string base = dbTimestamp.substring(0, int:min(dotIndex, 19));
+    if base.length() > 10 && base.substring(10, 11) == " " {
+        return base.substring(0, 10) + "T" + base.substring(11) + "Z";
+    }
+    return base + "Z";
 }
 
 // Cast string to timestamp for PostgreSQL (no-op for other databases)


### PR DESCRIPTION
## Summary
- Adds `convertDbDateTimeToISO8601()` in `database_dialect.bal` to convert DB-stored UTC timestamps (`YYYY-MM-DD HH:MM:SS[.ffffff]`) to ISO 8601 UTC (`YYYY-MM-DDTHH:MM:SSZ`) before they leave the storage layer
- Applies the conversion to all three `execution_timestamp` fields in `artifact_repository.bal` (snapshot stream, history stream, and the top-level `executionTimestamp` field)
- Simplifies `ArtifactTabs.tsx` to a plain `new Date(exec.timestamp).toLocaleString()` — no frontend workaround needed now that the API returns unambiguous UTC strings

**Root cause:** The backend stored and returned timestamps without a timezone marker. `new Date("2026-04-30 10:30:00")` is parsed as local time by browsers, showing the wrong time for users in non-UTC timezones.

## Test plan
- [ ] Open the Automations tab for an artifact with execution history
- [ ] Verify timestamps are displayed in the browser's local timezone
- [ ] Verify timestamps still sort correctly
- [ ] Verify against MySQL, H2, and PostgreSQL backends (all produce the same `YYYY-MM-DD HH:MM:SS` format that is now normalized)