### PR TITLE
Display ICP version in console footer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,28 @@ jobs:
           grep project.version gradle.properties
           echo "Version will be: ${VERSION}"
 
+      - name: Update version in config files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Escape special characters for sed (/, &, \)
+          ESCAPED_VERSION=$(echo "$VERSION" | sed 's/[\/&]/\\&/g')
+
+          # Update icpVersion default in icp_server/config.bal
+          sed -i "s/^configurable string icpVersion = \".*\";/configurable string icpVersion = \"${ESCAPED_VERSION}\";/" icp_server/config.bal
+
+          # Update VITE_ICP_VERSION in both config.json files (dev + bundled www)
+          jq --arg v "$VERSION" '.VITE_ICP_VERSION = $v' frontend/public/config.json > /tmp/config.json && mv /tmp/config.json frontend/public/config.json
+          jq --arg v "$VERSION" '.VITE_ICP_VERSION = $v' www/config.json > /tmp/config.json && mv /tmp/config.json www/config.json
+
+          # Verify changes
+          echo "=== icp_server/config.bal ==="
+          grep icpVersion icp_server/config.bal
+          echo "=== frontend/public/config.json ==="
+          jq .VITE_ICP_VERSION frontend/public/config.json
+          echo "=== www/config.json ==="
+          jq .VITE_ICP_VERSION www/config.json
+
       - name: Build distribution package
         run: ./gradlew clean build
         env:

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -2,5 +2,6 @@
   "VITE_GRAPHQL_URL": "https://localhost:9446/graphql",
   "VITE_AUTH_BASE_URL": "https://localhost:9446/auth",
   "VITE_OBSERVABILITY_URL": "https://localhost:9446/icp/observability",
-  "VITE_SSO_ENABLED": false
+  "VITE_SSO_ENABLED": false,
+  "VITE_ICP_VERSION": "2.0.0-SNAPSHOT"
 }

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -27,6 +27,7 @@ interface RuntimeConfig {
   VITE_AUTH_BASE_URL?: string;
   VITE_OBSERVABILITY_URL?: string;
   VITE_SSO_ENABLED?: boolean;
+  VITE_ICP_VERSION?: string;
 }
 
 export interface ApiConfig {
@@ -34,6 +35,7 @@ export interface ApiConfig {
   authBaseUrl: string;
   observabilityUrl: string;
   ssoEnabled: boolean;
+  version: string;
 }
 
 // Extend window interface
@@ -49,6 +51,7 @@ const DEFAULT_CONFIG: ApiConfig = {
   authBaseUrl: 'https://localhost:9446/auth',
   observabilityUrl: 'https://localhost:9446/icp/observability',
   ssoEnabled: false,
+  version: '',
 };
 
 /**
@@ -69,6 +72,7 @@ export async function loadConfig(): Promise<void> {
       authBaseUrl: config.VITE_AUTH_BASE_URL || DEFAULT_CONFIG.authBaseUrl,
       observabilityUrl: config.VITE_OBSERVABILITY_URL || DEFAULT_CONFIG.observabilityUrl,
       ssoEnabled: config.VITE_SSO_ENABLED ?? DEFAULT_CONFIG.ssoEnabled,
+      version: config.VITE_ICP_VERSION || DEFAULT_CONFIG.version,
     };
 
     console.info('✓ Runtime configuration loaded from config.json');
@@ -101,3 +105,4 @@ export const oidcCallbackApiUrl = (): string => `${window.API_CONFIG.authBaseUrl
 export const changePasswordApiUrl = (): string => `${window.API_CONFIG.authBaseUrl}/change-password`;
 export const forceChangePasswordApiUrl = (): string => `${window.API_CONFIG.authBaseUrl}/force-change-password`;
 export const isSsoEnabled = (): boolean => window.API_CONFIG.ssoEnabled;
+export const getIcpVersion = (): string => window.API_CONFIG.version;

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -57,6 +57,7 @@ import { cookiePolicyUrl, loginUrl, orgUrl, privacyPolicyUrl, profileUrl } from 
 import { useAuth } from '../auth/AuthContext';
 import { useAccessControl } from '../contexts/AccessControlContext';
 import { ALL_USER_MGT_PERMISSIONS, Permissions } from '../constants/permissions';
+import { getIcpVersion } from '../config/api';
 
 const SIDEBAR_ICONS: Record<Resource, JSX.Element> = {
   overview: <LayoutDashboard size={20} />,
@@ -592,6 +593,7 @@ export default function AppLayout(): JSX.Element {
           <Footer.Link href="https://wso2.com/support" target="_blank" rel="noreferrer">
             Support
           </Footer.Link>
+          {getIcpVersion() && <Footer.Version>v{getIcpVersion()}</Footer.Version>}
           <Footer.Copyright>&copy; {new Date().getFullYear()}, WSO2 LLC.</Footer.Copyright>
         </Footer>
       </AppShell.Footer>

--- a/icp_server/config.bal
+++ b/icp_server/config.bal
@@ -18,6 +18,9 @@ import icp_server.types;
 
 import ballerina/file;
 
+// ICP version
+configurable string icpVersion = "2.0.0-SNAPSHOT";
+
 // Server configuration
 configurable int serverPort = 9446;
 configurable int defaultOpensearchAdaptorPort = 9449;

--- a/icp_server/graphql_api.bal
+++ b/icp_server/graphql_api.bal
@@ -3578,5 +3578,11 @@ service /graphql on graphqlListener {
         log:printInfo("Successfully deleted MI user on runtime", username = username, runtimeId = runtimeId);
         return {username, status: "Deleted"};
     }
+
+    // Returns ICP server version information
+    isolated resource function get systemInfo(graphql:Context context) returns types:SystemInfo|error {
+        _ = check extractUserContext(context);
+        return {version: icpVersion};
+    }
 }
 

--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -2416,3 +2416,7 @@ public type ValidatedRuntime record {|
     string componentId;
     Runtime runtime;
 |};
+
+public type SystemInfo record {|
+    string version;
+|};

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -147,7 +147,8 @@ function updateFrontendConfig() returns error? {
         "VITE_GRAPHQL_URL": backendGraphqlEndpoint,
         "VITE_AUTH_BASE_URL": backendAuthBaseUrl,
         "VITE_OBSERVABILITY_URL": backendObservabilityEndpoint,
-        "VITE_SSO_ENABLED": ssoEnabled
+        "VITE_SSO_ENABLED": ssoEnabled,
+        "VITE_ICP_VERSION": icpVersion
     };
 
     // Write to config.json


### PR DESCRIPTION
## Summary
- Add `icpVersion` as a configurable in `icp_server/config.bal` (defaults to `2.0.0-SNAPSHOT`, overridable via `Config.toml` or env var)
- Inject the version into `www/config.json` at server startup via `updateFrontendConfig()`
- Wire it through `frontend/src/config/api.ts` (`VITE_ICP_VERSION` → `window.API_CONFIG.version` → `getIcpVersion()`)
- Render `v<version>` in the app footer in `AppLayout.tsx` (hidden when version is empty)
- Add `systemInfo` GraphQL resource and `SystemInfo` type for exposing version via the API
- Update `release.yml` to stamp the release version into `icp_server/config.bal`, `frontend/public/config.json`, and `www/config.json` before building the distribution
- https://github.com/wso2/product-integrator/issues/924

## Test plan
- [ ] Start the ICP server and verify `www/config.json` is written with `VITE_ICP_VERSION`
- [ ] Open the console and confirm the version appears in the bottom footer (e.g. `v2.0.0-SNAPSHOT`)
- [ ] Override `icpVersion` in `Config.toml` and verify the footer reflects the new value
- [ ] Query `systemInfo { version }` via GraphQL and confirm it returns the correct version
- [ ] Remove `VITE_ICP_VERSION` from config and confirm the footer version label is hidden
- [ ] Trigger the release workflow with a version (e.g. `2.0.0`) and verify all three config files are updated before the build