### PR TITLE
Restructure distribution: add lib/, rename ciphertool-libs, switch server to classpath-based launch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,8 +279,15 @@ task packageICP {
                 logger.warning("Please ensure distribution/scripts folder exists with run.sh and run.bat")
             }
 
-            // Copy cipher tool JARs to lib/ directory
-            def libDir = file("${rootDir}/lib")
+            // Create lib/ directory for additional server-side JARs
+            def serverLibDir = file("${rootDir}/lib")
+            if (!serverLibDir.exists()) {
+                serverLibDir.mkdirs()
+            }
+            logger.info("Created lib/ directory")
+
+            // Copy cipher tool JARs to ciphertool-libs/ directory
+            def libDir = file("${rootDir}/ciphertool-libs")
             if (!libDir.exists()) {
                 libDir.mkdirs()
             }
@@ -288,7 +295,7 @@ task packageICP {
                 from configurations.cipherTool
                 into libDir
             }
-            logger.info("Added cipher tool JARs to lib/")
+            logger.info("Added cipher tool JARs to ciphertool-libs/")
 
             // Copy cipher tool config files from distribution/src/main/resources/conf/
             def cipherStandaloneConfig = file('distribution/src/main/resources/conf/cipher-standalone-config.properties')

--- a/distribution/scripts/ciphertool.bat
+++ b/distribution/scripts/ciphertool.bat
@@ -74,12 +74,12 @@ echo This environment variable is needed to run this program
 goto end
 
 :okHome
-REM Build classpath from lib directory
+REM Build classpath from ciphertool-libs directory
 setlocal EnableDelayedExpansion
 cd "%ICP_HOME%"
 
 set ICP_CLASSPATH=
-FOR %%c in ("%ICP_HOME%\lib\*.jar") DO (
+FOR %%c in ("%ICP_HOME%\ciphertool-libs\*.jar") DO (
     set ICP_CLASSPATH=!ICP_CLASSPATH!;"%%c"
 )
 

--- a/distribution/scripts/ciphertool.sh
+++ b/distribution/scripts/ciphertool.sh
@@ -98,9 +98,9 @@ if $mingw ; then
     JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
 fi
 
-# Build classpath from lib directory - all JARs in lib/ are included
+# Build classpath from ciphertool-libs directory - all JARs in ciphertool-libs/ are included
 ICP_CLASSPATH=""
-for f in "$ICP_HOME"/lib/*.jar
+for f in "$ICP_HOME"/ciphertool-libs/*.jar
 do
   ICP_CLASSPATH=$ICP_CLASSPATH:$f
 done

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -27,6 +27,14 @@ set PID_FILE=!PARENT_DIR!\icp.pid
 set LOG_DIR=!PARENT_DIR!\logs
 set LOG_FILE=!LOG_DIR!\icp.log
 set COMMAND=run
+set "JAVA_OPTS="
+if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" (
+    echo ARM Windows detected - disabling native Netty tcnative libraries
+    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+) else if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" (
+    echo ARM Windows detected - disabling native Netty tcnative libraries
+    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+)
 set "ARG=%~1"
 set "NORMALIZED_ARG=!ARG!"
 set "CANDIDATE="
@@ -172,7 +180,8 @@ set "ICP_JAR_FILE=!JAR_FILE!"
 set "ICP_LOG_FILE=!LOG_FILE!"
 set "ICP_ERR_LOG_FILE=!LOG_FILE!.err"
 set "ICP_SCRIPT_DIR=!SCRIPT_DIR!"
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$jar = $env:ICP_JAR_FILE; $log = $env:ICP_LOG_FILE; $errLog = $env:ICP_ERR_LOG_FILE; $wd = $env:ICP_SCRIPT_DIR; $appArgs = @(); if ($env:ICP_APP_ARGS_JSON -and $env:ICP_APP_ARGS_JSON -ne '[]') { $appArgs = @(ConvertFrom-Json -InputObject $env:ICP_APP_ARGS_JSON) }; $javaArgs = @('-jar', $jar) + $appArgs; $p = Start-Process -FilePath 'java' -ArgumentList $javaArgs -WorkingDirectory $wd -RedirectStandardOutput $log -RedirectStandardError $errLog -PassThru -WindowStyle Hidden; $p.Id" > "!PID_FILE!"
+set "ICP_JAVA_OPTS=!JAVA_OPTS!"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$jar = $env:ICP_JAR_FILE; $log = $env:ICP_LOG_FILE; $errLog = $env:ICP_ERR_LOG_FILE; $wd = $env:ICP_SCRIPT_DIR; $appArgs = @(); if ($env:ICP_APP_ARGS_JSON -and $env:ICP_APP_ARGS_JSON -ne '[]') { $appArgs = @(ConvertFrom-Json -InputObject $env:ICP_APP_ARGS_JSON) }; $javaOpts = @(); if ($env:ICP_JAVA_OPTS) { $javaOpts = $env:ICP_JAVA_OPTS -split '\s+' | Where-Object { $_ } }; $javaArgs = $javaOpts + @('-jar', $jar) + $appArgs; $p = Start-Process -FilePath 'java' -ArgumentList $javaArgs -WorkingDirectory $wd -RedirectStandardOutput $log -RedirectStandardError $errLog -PassThru -WindowStyle Hidden; $p.Id" > "!PID_FILE!"
 set /p SERVER_PID=<"!PID_FILE!"
 if not defined SERVER_PID (
     echo Failed to start ICP Server
@@ -265,7 +274,7 @@ goto end
 :runServer
 call :prepareRun
 if errorlevel 1 goto end
-java -jar "!JAR_FILE!" !FORWARD_ARGS!
+java !JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
 if exist "!PID_FILE!" del /f /q "!PID_FILE!" >nul 2>&1
 
 :end

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -274,11 +274,7 @@ goto end
 :runServer
 call :prepareRun
 if errorlevel 1 goto end
-set "QUOTED_JAVA_OPTS="
-if defined JAVA_OPTS (
-    for %%O in (%JAVA_OPTS%) do set "QUOTED_JAVA_OPTS=!QUOTED_JAVA_OPTS! "%%O""
-)
-java !QUOTED_JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
+java !JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
 if exist "!PID_FILE!" del /f /q "!PID_FILE!" >nul 2>&1
 
 :end

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -133,6 +133,9 @@ exit /b 1
 :prepareRun
 call :checkJar
 if errorlevel 1 goto end
+call :buildIcpClasspath
+call :resolveMainClass
+if errorlevel 1 goto end
 if not exist "!LOG_DIR!" mkdir "!LOG_DIR!"
 cd /d "!SCRIPT_DIR!"
 if exist "!CONFIG_FILE!" (
@@ -142,6 +145,25 @@ if exist "!CONFIG_FILE!" (
     echo Warning: Configuration file not found at !CONFIG_FILE!
     echo Starting ICP Server without custom configuration...
     set "BAL_CONFIG_FILES="
+)
+exit /b 0
+
+:buildIcpClasspath
+set "ICP_CLASSPATH=!JAR_FILE!"
+for %%c in ("!PARENT_DIR!\lib\*.jar") do set "ICP_CLASSPATH=!ICP_CLASSPATH!;%%~c"
+exit /b 0
+
+:resolveMainClass
+set "ICP_MAIN_CLASS="
+set "RESOLVE_JAR=!JAR_FILE!"
+if exist "%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" (
+    for /f "usebackq delims=" %%M in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$jar = $env:RESOLVE_JAR; Add-Type -AssemblyName System.IO.Compression.FileSystem; $zip = [System.IO.Compression.ZipFile]::OpenRead($jar); try { $entry = $zip.GetEntry('META-INF/MANIFEST.MF'); if ($entry) { $r = New-Object System.IO.StreamReader($entry.Open()); try { $m = $r.ReadToEnd() } finally { $r.Dispose() }; ([regex]::Match($m, '(?m)^Main-Class:\s*(.+)$')).Groups[1].Value.Trim() } } finally { $zip.Dispose() }"`) do (
+        set "ICP_MAIN_CLASS=%%M"
+    )
+)
+if not defined ICP_MAIN_CLASS (
+    echo Error: Cannot determine main class from !JAR_FILE!
+    exit /b 1
 )
 exit /b 0
 
@@ -176,12 +198,13 @@ if exist "!PID_FILE!" del /f /q "!PID_FILE!" >nul 2>&1
 call :prepareRun
 if errorlevel 1 goto end
 call :buildArgsJson !FORWARD_ARGS!
-set "ICP_JAR_FILE=!JAR_FILE!"
 set "ICP_LOG_FILE=!LOG_FILE!"
 set "ICP_ERR_LOG_FILE=!LOG_FILE!.err"
 set "ICP_SCRIPT_DIR=!SCRIPT_DIR!"
 set "ICP_JAVA_OPTS=!JAVA_OPTS!"
-powershell -NoProfile -ExecutionPolicy Bypass -Command "$jar = $env:ICP_JAR_FILE; $log = $env:ICP_LOG_FILE; $errLog = $env:ICP_ERR_LOG_FILE; $wd = $env:ICP_SCRIPT_DIR; $appArgs = @(); if ($env:ICP_APP_ARGS_JSON -and $env:ICP_APP_ARGS_JSON -ne '[]') { $appArgs = @(ConvertFrom-Json -InputObject $env:ICP_APP_ARGS_JSON) }; $javaOpts = @(); if ($env:ICP_JAVA_OPTS) { $javaOpts = $env:ICP_JAVA_OPTS -split '\s+' | Where-Object { $_ } }; $javaArgs = $javaOpts + @('-jar', $jar) + $appArgs; $p = Start-Process -FilePath 'java' -ArgumentList $javaArgs -WorkingDirectory $wd -RedirectStandardOutput $log -RedirectStandardError $errLog -PassThru -WindowStyle Hidden; $p.Id" > "!PID_FILE!"
+set "ICP_CLASSPATH_PS=!ICP_CLASSPATH!"
+set "ICP_MAIN_CLASS_PS=!ICP_MAIN_CLASS!"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$cp = $env:ICP_CLASSPATH_PS; $mc = $env:ICP_MAIN_CLASS_PS; $log = $env:ICP_LOG_FILE; $errLog = $env:ICP_ERR_LOG_FILE; $wd = $env:ICP_SCRIPT_DIR; $appArgs = @(); if ($env:ICP_APP_ARGS_JSON -and $env:ICP_APP_ARGS_JSON -ne '[]') { $appArgs = @(ConvertFrom-Json -InputObject $env:ICP_APP_ARGS_JSON) }; $javaOpts = @(); if ($env:ICP_JAVA_OPTS) { $javaOpts = $env:ICP_JAVA_OPTS -split '\s+' | Where-Object { $_ } }; $javaArgs = $javaOpts + @('-cp', $cp, $mc) + $appArgs; $p = Start-Process -FilePath 'java' -ArgumentList $javaArgs -WorkingDirectory $wd -RedirectStandardOutput $log -RedirectStandardError $errLog -PassThru -WindowStyle Hidden; $p.Id" > "!PID_FILE!"
 set /p SERVER_PID=<"!PID_FILE!"
 if not defined SERVER_PID (
     echo Failed to start ICP Server
@@ -274,7 +297,7 @@ goto end
 :runServer
 call :prepareRun
 if errorlevel 1 goto end
-java !JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
+java !JAVA_OPTS! -cp "!ICP_CLASSPATH!" !ICP_MAIN_CLASS! !FORWARD_ARGS!
 if exist "!PID_FILE!" del /f /q "!PID_FILE!" >nul 2>&1
 
 :end

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -28,13 +28,13 @@ set LOG_DIR=!PARENT_DIR!\logs
 set LOG_FILE=!LOG_DIR!\icp.log
 set COMMAND=run
 set "JAVA_OPTS="
-if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" goto set_arm_opts
-if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" goto set_arm_opts
-goto after_arm_opts
-:set_arm_opts
-echo ARM Windows detected - disabling native Netty tcnative libraries
-set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
-:after_arm_opts
+if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" (
+    echo ARM Windows detected - disabling native Netty tcnative libraries
+    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+) else if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" (
+    echo ARM Windows detected - disabling native Netty tcnative libraries
+    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+)
 set "ARG=%~1"
 set "NORMALIZED_ARG=!ARG!"
 set "CANDIDATE="

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -28,13 +28,13 @@ set LOG_DIR=!PARENT_DIR!\logs
 set LOG_FILE=!LOG_DIR!\icp.log
 set COMMAND=run
 set "JAVA_OPTS="
-if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" (
-    echo ARM Windows detected - disabling native Netty tcnative libraries
-    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
-) else if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" (
-    echo ARM Windows detected - disabling native Netty tcnative libraries
-    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
-)
+if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" goto set_arm_opts
+if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" goto set_arm_opts
+goto after_arm_opts
+:set_arm_opts
+echo ARM Windows detected - disabling native Netty tcnative libraries
+set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+:after_arm_opts
 set "ARG=%~1"
 set "NORMALIZED_ARG=!ARG!"
 set "CANDIDATE="
@@ -274,7 +274,11 @@ goto end
 :runServer
 call :prepareRun
 if errorlevel 1 goto end
-java !JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
+set "QUOTED_JAVA_OPTS="
+if defined JAVA_OPTS (
+    for %%O in (%JAVA_OPTS%) do set "QUOTED_JAVA_OPTS=!QUOTED_JAVA_OPTS! "%%O""
+)
+java !QUOTED_JAVA_OPTS! -jar "!JAR_FILE!" !FORWARD_ARGS!
 if exist "!PID_FILE!" del /f /q "!PID_FILE!" >nul 2>&1
 
 :end

--- a/distribution/scripts/icp.bat
+++ b/distribution/scripts/icp.bat
@@ -27,13 +27,12 @@ set PID_FILE=!PARENT_DIR!\icp.pid
 set LOG_DIR=!PARENT_DIR!\logs
 set LOG_FILE=!LOG_DIR!\icp.log
 set COMMAND=run
-set "JAVA_OPTS="
 if /I "!PROCESSOR_ARCHITECTURE!"=="ARM64" (
     echo ARM Windows detected - disabling native Netty tcnative libraries
-    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+    set "JAVA_OPTS=!JAVA_OPTS! -Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
 ) else if /I "!PROCESSOR_ARCHITEW6432!"=="ARM64" (
     echo ARM Windows detected - disabling native Netty tcnative libraries
-    set "JAVA_OPTS=-Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
+    set "JAVA_OPTS=!JAVA_OPTS! -Dio.netty.transport.noNative=true -Dio.netty.handler.ssl.noOpenSsl=true"
 )
 set "ARG=%~1"
 set "NORMALIZED_ARG=!ARG!"

--- a/distribution/scripts/icp.sh
+++ b/distribution/scripts/icp.sh
@@ -65,6 +65,23 @@ detect_java_opts() {
             "-Dio.netty.handler.ssl.noOpenSsl=true"
         )
     fi
+
+    local arch os
+    arch="$(uname -m 2>/dev/null)"
+    os="$(uname -s 2>/dev/null)"
+    case "$arch" in
+        aarch64|arm64)
+            case "$os" in
+                MINGW*|MSYS*|CYGWIN*)
+                    echo "ARM Windows detected - disabling native Netty tcnative libraries"
+                    JAVA_OPTS+=(
+                        "-Dio.netty.transport.noNative=true"
+                        "-Dio.netty.handler.ssl.noOpenSsl=true"
+                    )
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 is_running() {

--- a/distribution/scripts/icp.sh
+++ b/distribution/scripts/icp.sh
@@ -84,6 +84,24 @@ detect_java_opts() {
     esac
 }
 
+build_classpath() {
+    local cp="$JAR_FILE"
+    local lib_dir="$PARENT_DIR/lib"
+    if [ -d "$lib_dir" ]; then
+        for f in "$lib_dir"/*.jar; do
+            [ -f "$f" ] && cp="$cp:$f"
+        done
+    fi
+    echo "$cp"
+}
+
+get_main_class() {
+    if command -v unzip >/dev/null 2>&1 && [ -f "$JAR_FILE" ]; then
+        unzip -p "$JAR_FILE" META-INF/MANIFEST.MF 2>/dev/null | \
+            awk -F': ' '/^Main-Class:/ {gsub("\r", "", $2); print $2; exit}'
+    fi
+}
+
 is_running() {
     local pid
     if [ -f "$PID_FILE" ]; then
@@ -118,14 +136,22 @@ run_server() {
         unset BAL_CONFIG_FILES
     fi
 
+    local icp_classpath icp_main_class
+    icp_classpath="$(build_classpath)"
+    icp_main_class="$(get_main_class)"
+    if [ -z "$icp_main_class" ]; then
+        echo "Error: Cannot determine main class from $JAR_FILE. Ensure 'unzip' is installed."
+        exit 1
+    fi
+
     if [ "$mode" = "background" ]; then
-        nohup java "${JAVA_OPTS[@]}" -jar "$JAR_FILE" "$@" >> "$LOG_FILE" 2>&1 &
+        nohup java "${JAVA_OPTS[@]}" -cp "$icp_classpath" "$icp_main_class" "$@" >> "$LOG_FILE" 2>&1 &
         server_pid=$!
         echo "$server_pid" > "$PID_FILE"
         echo "ICP Server started with PID $server_pid"
         echo "Logs are available at $LOG_FILE"
     else
-        exec java "${JAVA_OPTS[@]}" -jar "$JAR_FILE" "$@"
+        exec java "${JAVA_OPTS[@]}" -cp "$icp_classpath" "$icp_main_class" "$@"
     fi
 }
 


### PR DESCRIPTION
## Summary

- Renames the cipher tool JAR directory from `lib/` to `ciphertool-libs/` to clearly distinguish cipher tool dependencies from server runtime dependencies. Updates `build.gradle`, `ciphertool.sh`, and `ciphertool.bat` accordingly.
- Adds an empty `lib/` directory to the distribution for additional server-side JARs that users or build steps can drop in.
- Switches `icp.sh` and `icp.bat` from `-jar` to `-cp`-based launch, building the classpath from `icp-server.jar` plus any JARs present in `lib/`.
- The main class is resolved dynamically from the JAR manifest at startup (`unzip` on Linux/macOS, PowerShell `ZipFile` on Windows) so it does not need to be hardcoded.

## Test plan

- [x] Server starts successfully with the new `-cp` launch mode on macOS (verified locally)
- [ ] Server starts successfully on Linux
- [ ] Server starts successfully on Windows (`icp.bat run` and `icp.bat start`)
- [ ] Cipher tool (`ciphertool.sh` / `ciphertool.bat`) works correctly with JARs in `ciphertool-libs/`
- [ ] JARs placed in `lib/` are picked up on the server classpath at startup