### PR TITLE
Fix IDOR: enforce RBAC and guard unscoped queries on observability endpoints

### DIFF
--- a/icp_server/observability_service.bal
+++ b/icp_server/observability_service.bal
@@ -199,6 +199,15 @@ service /icp/observability on httpListener {
             };
         }
 
+        // Guard: an empty runtimeIdList with no filters would produce an unscoped OpenSearch query
+        // returning data across all runtimes. Return empty instead.
+        if runtimeIdList.length() == 0 {
+            return {
+                columns: [],
+                rows: []
+            };
+        }
+
         // Check if observability client is available before any runtime-type lookups
         http:Client? httpClient = observabilityHttpClient;
         if httpClient is () {
@@ -269,6 +278,7 @@ service /icp/observability on httpListener {
                                                          });
 
         types:UserContextV2 userContext = check extractUserFromObservabilityRequest(request);
+        log:printInfo("Processing metrics request", userId = userContext.userId);
         runtimeIdList = check filterRuntimeIdsForUser(userContext.userId, runtimeIdList);
 
         // If component/environment filters were provided but no runtimes found, return empty result
@@ -279,6 +289,15 @@ service /icp/observability on httpListener {
 
         if (hasFilters && runtimeIdList.length() == 0) {
             log:printDebug("No runtimes found for the given component/environment filters. Returning empty result.");
+            return {
+                inboundMetrics: [],
+                outboundMetrics: []
+            };
+        }
+
+        // Guard: an empty runtimeIdList with no filters would produce an unscoped OpenSearch query
+        // returning data across all runtimes. Return empty instead.
+        if runtimeIdList.length() == 0 {
             return {
                 inboundMetrics: [],
                 outboundMetrics: []


### PR DESCRIPTION
## Summary

Closes two access control gaps in `/icp/observability/logs` and `/icp/observability/metrics` identified.

- **IDOR via filtered request**: runtime IDs resolved from `componentId`/`environmentId` filters were forwarded to the OpenSearch adapter without checking whether the authenticated caller has access to those runtimes. Any valid token holder could read another user's logs or metrics by supplying a foreign component/environment ID.
- **IDOR via no-filter request**: when no component/environment filters are supplied, `resolveRuntimeIds()` returns `[]`. The OpenSearch adapter omits the `icp_runtimeId` filter when the list is empty, so the query returns data across **all runtimes**. The existing `hasFilters` guard did not cover this path.

## Changes

- Added `extractUserFromObservabilityRequest` — extracts the authenticated user context from the already-validated JWT in the `Authorization` header.
- Added `filterRuntimeIdsForUser` — filters a runtime ID list to only those the caller has access to, using the existing `storage:hasAccessToRuntime` check.
- Both endpoints now filter resolved runtime IDs by RBAC before forwarding to OpenSearch.
- Added an explicit early-return guard: if `runtimeIdList` is empty after RBAC filtering (regardless of whether filters were supplied), return an empty result instead of forwarding an unscoped query.

## Test plan

- [ ] Authenticated user requests logs/metrics for a component they own — data returned as normal
- [ ] Authenticated user requests logs/metrics for a component belonging to another user — empty result returned
- [ ] Authenticated user sends request with no component/environment filters — empty result returned (previously would have returned all runtime data)
- [ ] Existing test suite passes (`bal test`)