### PR TITLE
Fix project/component level role assignment

### DIFF
--- a/frontend/src/api/authQueries.ts
+++ b/frontend/src/api/authQueries.ts
@@ -230,12 +230,12 @@ export function useGroupUsers(orgHandler: string, groupId: string, options?: { e
 export function useAddRolesToGroup(orgHandler: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: { groupId: string; roleIds: string[]; envUuid?: string; projectId?: string; componentId?: string }) => {
+    mutationFn: (input: { groupId: string; roleIds: string[]; envUuid?: string; projectId?: string; integrationId?: string }) => {
       const body = {
         roleIds: input.roleIds,
         envUuid: input.envUuid,
         ...(input.projectId ? { projectUuid: input.projectId } : {}),
-        ...(input.componentId ? { integrationUuid: input.componentId } : {}),
+        ...(input.integrationId ? { integrationUuid: input.integrationId } : {}),
       };
       return authPost(`/orgs/${orgHandler}/groups/${input.groupId}/roles`, body);
     },

--- a/frontend/src/api/authQueries.ts
+++ b/frontend/src/api/authQueries.ts
@@ -227,15 +227,15 @@ export function useGroupUsers(orgHandler: string, groupId: string, options?: { e
   });
 }
 
-export function useAddRolesToGroup(orgHandler: string, projectId?: string, componentId?: string) {
+export function useAddRolesToGroup(orgHandler: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: { groupId: string; roleIds: string[]; envUuid?: string }) => {
+    mutationFn: (input: { groupId: string; roleIds: string[]; envUuid?: string; projectId?: string; componentId?: string }) => {
       const body = {
         roleIds: input.roleIds,
         envUuid: input.envUuid,
-        ...(projectId ? { projectUuid: projectId } : {}),
-        ...(componentId ? { integrationUuid: componentId } : {}),
+        ...(input.projectId ? { projectUuid: input.projectId } : {}),
+        ...(input.componentId ? { integrationUuid: input.componentId } : {}),
       };
       return authPost(`/orgs/${orgHandler}/groups/${input.groupId}/roles`, body);
     },

--- a/frontend/src/pages/ComponentRoleDetail.tsx
+++ b/frontend/src/pages/ComponentRoleDetail.tsx
@@ -76,7 +76,7 @@ function AssignRoleToGroupsDialog({
 }) {
   const { data: allGroups = [] } = useGroups(orgHandler, projectId, componentId);
   const { data: allEnvironments = [] } = useAllEnvironments();
-  const mutation = useAddRolesToGroup(orgHandler, projectId, componentId);
+  const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Group[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
   const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
@@ -92,7 +92,7 @@ function AssignRoleToGroupsDialog({
     const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
 
     const promises = selected.map((g) =>
-      mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid }).then(
+      mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId, componentId }).then(
         () => ({ success: true, groupName: g.groupName }),
         (error) => ({ success: false, groupName: g.groupName, error }),
       ),

--- a/frontend/src/pages/ComponentRoleDetail.tsx
+++ b/frontend/src/pages/ComponentRoleDetail.tsx
@@ -92,7 +92,7 @@ function AssignRoleToGroupsDialog({
     const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
 
     const promises = selected.map((g) =>
-      mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId, componentId }).then(
+      mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId, integrationId: componentId }).then(
         () => ({ success: true, groupName: g.groupName }),
         (error) => ({ success: false, groupName: g.groupName, error }),
       ),

--- a/frontend/src/pages/EditGroup.tsx
+++ b/frontend/src/pages/EditGroup.tsx
@@ -89,7 +89,7 @@ function AddRolesToGroupDialog({
     setAssignError(null);
     const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
     mutation.mutate(
-      { groupId, roleIds: selected.map((r) => r.roleId), envUuid, projectId, componentId },
+      { groupId, roleIds: selected.map((r) => r.roleId), envUuid, projectId, integrationId: componentId },
       {
         onSuccess: () => {
           onAdded?.();

--- a/frontend/src/pages/EditGroup.tsx
+++ b/frontend/src/pages/EditGroup.tsx
@@ -57,8 +57,24 @@ import { orgAccessControlUrl } from '../paths';
 import { FormDialog } from './access-control/shared';
 import { useFiltered, mappingLevel, envLabel, getUserInitial } from './access-control/utils';
 
-function AddRolesToGroupDialog({ orgHandler, groupId, existingRoleIds, onClose, onAdded }: { orgHandler: string; groupId: string; existingRoleIds: string[]; onClose: () => void; onAdded?: () => void }) {
-  const { data: allRoles = [] } = useRoles(orgHandler);
+function AddRolesToGroupDialog({
+  orgHandler,
+  groupId,
+  existingRoleIds,
+  onClose,
+  onAdded,
+  projectId,
+  componentId,
+}: {
+  orgHandler: string;
+  groupId: string;
+  existingRoleIds: string[];
+  onClose: () => void;
+  onAdded?: () => void;
+  projectId?: string;
+  componentId?: string;
+}) {
+  const { data: allRoles = [] } = useRoles(orgHandler, projectId, componentId);
   const { data: allEnvironments = [] } = useAllEnvironments();
   const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Role[]>([]);
@@ -73,7 +89,7 @@ function AddRolesToGroupDialog({ orgHandler, groupId, existingRoleIds, onClose, 
     setAssignError(null);
     const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
     mutation.mutate(
-      { groupId, roleIds: selected.map((r) => r.roleId), envUuid },
+      { groupId, roleIds: selected.map((r) => r.roleId), envUuid, projectId, componentId },
       {
         onSuccess: () => {
           onAdded?.();
@@ -476,6 +492,8 @@ export function GroupDetailView({ orgHandler, group, onBack, projectId, componen
               existingRoleIds={groupRoles.map((r) => r.roleId)}
               onClose={() => setAddingRoles(false)}
               onAdded={() => setViewAlert({ type: 'success', message: 'Role(s) added to group successfully.' })}
+              projectId={projectId}
+              componentId={componentId}
             />
           )}
           {removingRole && (

--- a/frontend/src/pages/ProjectRoleDetail.tsx
+++ b/frontend/src/pages/ProjectRoleDetail.tsx
@@ -74,7 +74,7 @@ function AssignRoleToGroupsDialog({
 }) {
   const { data: allGroups = [] } = useGroups(orgHandler, projectId);
   const { data: allEnvironments = [] } = useAllEnvironments();
-  const mutation = useAddRolesToGroup(orgHandler, projectId);
+  const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Group[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
   const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
@@ -88,7 +88,7 @@ function AssignRoleToGroupsDialog({
     const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
     const results = await Promise.all(
       selected.map((g) =>
-        mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid }).then(
+        mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId }).then(
           () => ({ success: true, groupName: g.groupName }),
           (error) => ({ success: false, groupName: g.groupName, error }),
         ),


### PR DESCRIPTION
# Fix: Project and Component Level Role Assignment Missing Scope

## Problem
When assigning roles to a group from a project or component context, `projectUuid` and `integrationUuid` were missing from the request body, causing all assignments to be stored as org-level mappings in `group_role_mapping`.

## Root Cause
`useAddRolesToGroup` captured `projectId` and `componentId` via closure at hook initialisation time. If project/component data had not resolved yet, the closure captured an empty string (falsy), silently dropping the scope fields from the request body.

## Changes
- **`useAddRolesToGroup`** — removed `projectId`/`componentId` from hook parameters; moved them into the mutation input so scope is resolved at the time the user triggers the assignment, not at hook init time
- **`EditGroup.tsx` `AddRolesToGroupDialog`** — added `projectId`/`componentId` props; role list query now scoped to the current project/component context; scope fields forwarded into the mutation input
- **`ProjectRoleDetail.tsx`**, **`ComponentRoleDetail.tsx`** — updated to pass scope fields explicitly in the mutation input