### PR TITLE
Fix project delete error in MSSQL due to multiple cascade paths

### DIFF
--- a/icp_server/auth_service.bal
+++ b/icp_server/auth_service.bal
@@ -133,7 +133,7 @@ service /auth on httpListener {
                 log:printInfo(string `User ${username} authenticated but not found in users table, creating user record`);
 
                 // If the auth backend signals that this user should be a super-admin
-                // (e.g. because of an LDAP admin role), add them to the built-in
+                // (e.g. because of an external admin role), add them to the built-in
                 // "Super Admins" group on first login.
                 string[] initialGroupIds = [];
                 if authResult?.isSuperAdmin == true {
@@ -144,7 +144,7 @@ service /auth on httpListener {
                         return utils:createInternalServerError("Could not resolve Super Admins group");
                     }
                     initialGroupIds = [superAdminsGroupId];
-                    log:printInfo("Assigning new LDAP user to Super Admins group on first login", username = username);
+                    log:printInfo("Assigning new user to Super Admins group on first login", username = username);
                 }
 
                 json|error? createResult = storage:createUserV2(userId, username, displayName, initialGroupIds);

--- a/icp_server/modules/storage/component_repository.bal
+++ b/icp_server/modules/storage/component_repository.bal
@@ -301,6 +301,17 @@ public isolated function deleteComponent(string componentId) returns error? {
         return error("An unexpected error occurred. Please contact your administrator.", cmdResult);
     }
 
+    // Explicitly delete group_role_mapping rows scoped to this integration (component).
+    // Required for MSSQL where fk_grp_role_integration is ON DELETE NO ACTION (multiple
+    // cascade path restriction); safe to do unconditionally for all other dialects as well.
+    sql:ParameterizedQuery deleteRoleMappingQuery = `DELETE FROM group_role_mapping WHERE integration_uuid = ${componentId}`;
+    var roleMappingResult = dbClient->execute(deleteRoleMappingQuery);
+    if roleMappingResult is sql:Error {
+        log:printError(string `Failed to delete group role mappings for component ${componentId}`, 'error = roleMappingResult);
+        return error("An unexpected error occurred. Please contact your administrator.", roleMappingResult);
+    }
+    log:printInfo(string `Removed all role mappings scoped to component`, componentId = componentId);
+
     sql:ParameterizedQuery deleteQuery = `DELETE FROM components WHERE component_id = ${componentId}`;
     var result = dbClient->execute(deleteQuery);
     if result is sql:Error {

--- a/icp_server/modules/storage/database_dialect.bal
+++ b/icp_server/modules/storage/database_dialect.bal
@@ -153,11 +153,12 @@ public isolated function getLimitClause(int rowCount) returns string {
 }
 
 // Append database-specific LIMIT clause to a query
+// Note: MSSQL requires an ORDER BY clause in the query before calling this function.
 public isolated function appendLimitClause(sql:ParameterizedQuery query, int rowCount) returns sql:ParameterizedQuery {
     if dbType == MSSQL {
-        return sql:queryConcat(query, ` OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY`);
+        return sql:queryConcat(query, ` OFFSET 0 ROWS FETCH NEXT ${rowCount} ROWS ONLY`);
     } else {
-        return sql:queryConcat(query, ` LIMIT 1`);
+        return sql:queryConcat(query, ` LIMIT ${rowCount}`);
     }
 }
 

--- a/icp_server/modules/storage/project_repository.bal
+++ b/icp_server/modules/storage/project_repository.bal
@@ -22,7 +22,7 @@ import ballerina/uuid;
 
 // Helper function to get Project Admin role ID
 isolated function getProjectAdminRoleId() returns string|error {
-    sql:ParameterizedQuery query = `SELECT role_id FROM roles_v2 WHERE role_name = 'Project Admin'`;
+    sql:ParameterizedQuery query = `SELECT role_id FROM roles_v2 WHERE role_name = 'Project Admin' ORDER BY role_id`;
     query = appendLimitClause(query, 1);
 
     stream<record {|string role_id;|}, sql:Error?> roleStream = dbClient->query(query);
@@ -391,6 +391,19 @@ public isolated function deleteProject(string projectId) returns error? {
             if groupDeleteResult is sql:Error {
                 fail groupDeleteResult;
             }
+
+            // Explicitly remove all remaining group_role_mapping rows scoped to this project.
+            // On MySQL/H2/PostgreSQL these would be cascade-deleted when the project row is removed,
+            // but MSSQL defines fk_grp_role_project as ON DELETE NO ACTION (to avoid multiple cascade
+            // path errors), so it does not cascade and instead leaves orphaned records silently.
+            // Deleting them here makes the cleanup correct and explicit on all database engines.
+            sql:ExecutionResult|sql:Error roleMappingDeleteResult = dbClient->execute(
+                `DELETE FROM group_role_mapping WHERE project_uuid = ${projectId}`
+            );
+            if roleMappingDeleteResult is sql:Error {
+                fail roleMappingDeleteResult;
+            }
+            log:printInfo(string `Removed all role mappings scoped to project`, projectId = projectId);
 
             sql:ExecutionResult|sql:Error projectDeleteResult = dbClient->execute(
                 `DELETE FROM projects WHERE project_id = ${projectId}`


### PR DESCRIPTION
## Problem
Deleting a project or component that had group-role mappings scoped to it failed in MSSQL with a foreign key constraint error. On MSSQL, `fk_grp_role_project` and `fk_grp_role_integration` are defined as `ON DELETE NO ACTION` (a workaround for MSSQL's multiple cascade path restriction), so deleting the parent row does not cascade to `group_role_mapping` as it does on MySQL/H2/PostgreSQL. Instead, MSSQL blocks the delete or silently leaves orphaned records.

## Changes

- **`project_repository.bal` `deleteProject`** — explicitly deletes all `group_role_mapping` rows with `project_uuid = projectId` inside the transaction before deleting the project row, ensuring correct cleanup on all database engines
- **`component_repository.bal` `deleteComponent`** — same fix: explicitly deletes all `group_role_mapping` rows with `integration_uuid = componentId` before deleting the component row
- **`project_repository.bal` `getProjectAdminRoleId`** — added `ORDER BY role_id` to the query; required because MSSQL's `OFFSET/FETCH` syntax (used by `appendLimitClause`) mandates an `ORDER BY` clause, causing a syntax error on project creation
- **`database_dialect.bal` `appendLimitClause`** — fixed the `rowCount` parameter being ignored in the MSSQL branch (was hardcoded to `1`); added a comment that callers must include `ORDER BY` before using this on MSSQL
- **`auth_service.bal`** — removed LDAP-specific wording from two log messages to reflect that super-admin promotion on first login applies to any auth backend