### PR TITLE
Rename BI to Default in UI display

### DIFF
--- a/frontend/src/pages/CreateComponent.tsx
+++ b/frontend/src/pages/CreateComponent.tsx
@@ -140,7 +140,7 @@ export default function CreateComponent(scope: ProjectScope): JSX.Element {
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <TextField label="Integration Type" select value={componentType} onChange={(e) => setComponentType(e.target.value as 'BI' | 'MI')} fullWidth slotProps={{ htmlInput: { 'aria-label': 'Integration Type' } }}>
-            <MenuItem value="BI">BI</MenuItem>
+            <MenuItem value="BI">Default</MenuItem>
             <MenuItem value="MI">MI</MenuItem>
           </TextField>
         </Grid>

--- a/frontend/src/pages/OrgRuntimes.tsx
+++ b/frontend/src/pages/OrgRuntimes.tsx
@@ -214,7 +214,7 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
               Copy this secret now. It will not be shown again.
             </Alert>
             <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
-              <Tab label="BI" />
+              <Tab label="Default" />
               <Tab label="MI" />
             </Tabs>
             <DialogContentText sx={{ mb: 1 }}>
@@ -233,7 +233,7 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
                 </DialogContentText>
                 <CodeBoxWithCopy code={`import wso2/icp.runtime.bridge as _;`} />
                 <Alert severity="info" sx={{ mt: 2 }}>
-                  The above configuration is for runtimes using the <strong>BI</strong> integration. If you're using the <strong>MI</strong> integration, switch to the MI tab to see the correct configuration.
+                  The above configuration is for runtimes using the <strong>Default</strong> integration. If you're using the <strong>MI</strong> integration, switch to the MI tab to see the correct configuration.
                 </Alert>
               </>
             )}
@@ -451,7 +451,7 @@ function EnvironmentRuntimeCard({
                     <ListingTable.Row key={r.runtimeId}>
                       <ListingTable.Cell>{r.runtimeName || r.runtimeId}</ListingTable.Cell>
                       <ListingTable.Cell>{r.runtimeId}</ListingTable.Cell>
-                      <ListingTable.Cell>{r.runtimeType}</ListingTable.Cell>
+                      <ListingTable.Cell>{r.runtimeType === 'BI' ? 'Default' : r.runtimeType}</ListingTable.Cell>
                       <ListingTable.Cell>{r.component?.displayName ?? '—'}</ListingTable.Cell>
                       <ListingTable.Cell>
                         <Chip label={r.status} size="small" color={r.status === 'RUNNING' ? 'success' : 'default'} />

--- a/frontend/src/pages/Runtime.tsx
+++ b/frontend/src/pages/Runtime.tsx
@@ -492,7 +492,7 @@ function EnvironmentRuntimeCard({
                     <ListingTable.Row key={r.runtimeId}>
                       <ListingTable.Cell>{r.runtimeName || r.runtimeId}</ListingTable.Cell>
                       <ListingTable.Cell>{r.runtimeId}</ListingTable.Cell>
-                      <ListingTable.Cell>{r.runtimeType}</ListingTable.Cell>
+                      <ListingTable.Cell>{r.runtimeType === 'BI' ? 'Default' : r.runtimeType}</ListingTable.Cell>
                       <ListingTable.Cell>
                         <Chip label={r.status} size="small" color={r.status === 'RUNNING' ? 'success' : 'default'} />
                       </ListingTable.Cell>


### PR DESCRIPTION
Change display label from **BI** to **Default** across the UI:

- Runtime type table cells (OrgRuntimes, Runtime)
- Config tab label and help text (OrgRuntimes)
- Integration type dropdown (CreateComponent)

Internal value `BI` remains unchanged in API calls and logic.