### PR TITLE
Display BI as Default in remaining UI locations

### DIFF
--- a/frontend/src/components/IntegrationTypesCard.tsx
+++ b/frontend/src/components/IntegrationTypesCard.tsx
@@ -37,7 +37,7 @@ export default function IntegrationTypesCard({ components }: { components: GqlCo
         <Stack>
           {Object.entries(counts).map(([type, count]) => (
             <Stack key={type} direction="row" justifyContent="space-between" sx={{ py: 0.5 }}>
-              <Typography variant="body2">{type}</Typography>
+              <Typography variant="body2">{type === 'BI' ? 'Default' : type}</Typography>
               <Typography variant="body2">{count}</Typography>
             </Stack>
           ))}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -475,7 +475,7 @@ export default function AppLayout(): JSX.Element {
                   label="Integrations">
                   {components.map((c) => (
                     <ComplexSelect.MenuItem key={c.id} value={c.handler}>
-                      <ComplexSelect.MenuItem.Text primary={c.displayName} secondary={c.componentType} />
+                      <ComplexSelect.MenuItem.Text primary={c.displayName} secondary={c.componentType === 'BI' ? 'Default' : c.componentType} />
                     </ComplexSelect.MenuItem>
                   ))}
                 </ComplexSelect>

--- a/frontend/src/pages/EditComponent.tsx
+++ b/frontend/src/pages/EditComponent.tsx
@@ -114,7 +114,7 @@ export default function EditComponent(scope: ProjectScope | ComponentScope): JSX
           <TextField label="Name" value={component.handler} fullWidth disabled slotProps={{ htmlInput: { 'aria-label': 'Name' } }} helperText="Name cannot be changed" />
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
-          <TextField label="Integration Type" value={component.componentType} fullWidth disabled slotProps={{ htmlInput: { 'aria-label': 'Integration Type' } }} helperText="Type cannot be changed" />
+          <TextField label="Integration Type" value={component.componentType === 'BI' ? 'Default' : component.componentType} fullWidth disabled slotProps={{ htmlInput: { 'aria-label': 'Integration Type' } }} helperText="Type cannot be changed" />
         </Grid>
       </Grid>
 

--- a/frontend/src/pages/Project.tsx
+++ b/frontend/src/pages/Project.tsx
@@ -128,7 +128,7 @@ function IntegrationsTable({
                       {c.description || ''}
                     </Typography>
                   </ListingTable.Cell>
-                  <ListingTable.Cell>{c.componentType}</ListingTable.Cell>
+                  <ListingTable.Cell>{c.componentType === 'BI' ? 'Default' : c.componentType}</ListingTable.Cell>
                   <ListingTable.Cell>
                     <Typography variant="body2" color="text.secondary">
                       {formatDistanceToNow(c.lastBuildDate)}


### PR DESCRIPTION
Follow-up to #644. Covers the places missed in the first PR:

- **Project.tsx** — integrations table Type column
- **IntegrationTypesCard.tsx** — integration types summary card
- **AppLayout.tsx** — component selector dropdown
- **EditComponent.tsx** — disabled type field in edit form

Same approach: display-only, `value="BI"` and `=== 'BI'` logic untouched.