### PR TITLE
Fix security vulnerabilities from Invicti scan

### DIFF
--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -102,7 +102,7 @@ export default function LoginForm(): JSX.Element {
   };
 
   return (
-    <form onSubmit={handleLogin}>
+    <form onSubmit={handleLogin} method="post">
       <Typography variant="h4" component="h2" sx={{ mb: 4, textAlign: 'center' }}>
         Sign In
       </Typography>

--- a/icp_server/auth_service.bal
+++ b/icp_server/auth_service.bal
@@ -30,7 +30,7 @@ final readonly & jwt:IssuerSignatureConfig jwtSignatureConfig;
 
 @http:ServiceConfig {
     cors: {
-        allowOrigins: ["*"]
+        allowOrigins: corsAllowedOrigins
     }
 }
 service /auth on httpListener {

--- a/icp_server/config.bal
+++ b/icp_server/config.bal
@@ -56,6 +56,22 @@ configurable decimal userServiceJwtClockSkewSeconds = 0;
 
 configurable int defaultTokenExpiryTime = 3600; // 1 hour (in seconds)
 
+// CORS configuration — restrict to known origins; default matches the local dev server
+configurable string[] corsAllowedOrigins = ["https://localhost:9446"];
+
+// TLS cipher suites — GCM and ChaCha20 only; CBC ciphers excluded (BEAST/POODLE/Lucky13)
+configurable string[] tlsCiphers = [
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256",
+    "TLS_AES_128_GCM_SHA256"
+];
+
 //Backend URLs for the frontend to call
 configurable string backendGraphqlEndpoint = "https://localhost:9446/graphql";
 configurable string backendAuthBaseUrl = "https://localhost:9446/auth";

--- a/icp_server/graphql_api.bal
+++ b/icp_server/graphql_api.bal
@@ -630,7 +630,7 @@ isolated function validateRegistryResourceAccess(
 @graphql:ServiceConfig {
     contextInit: utils:initGraphQLContext,
     cors: {
-        allowOrigins: ["*"]
+        allowOrigins: corsAllowedOrigins
     },
     auth: [
         {

--- a/icp_server/observability_service.bal
+++ b/icp_server/observability_service.bal
@@ -160,7 +160,7 @@ isolated function filterRuntimeIdsForUser(string userId, string[] runtimeIds) re
         }
     ],
     cors: {
-        allowOrigins: ["*"],
+        allowOrigins: corsAllowedOrigins,
         allowHeaders: ["Content-Type", "Authorization"]
     }
 }

--- a/icp_server/opensearch_adapter_service.bal
+++ b/icp_server/opensearch_adapter_service.bal
@@ -125,7 +125,7 @@ listener http:Listener openSerachObservabilityListener = new (defaultOpensearchA
         }
     ],
     cors: {
-        allowOrigins: ["*"],
+        allowOrigins: corsAllowedOrigins,
         allowHeaders: ["Content-Type", "Authorization"]
     }
 }

--- a/icp_server/runtime_service.bal
+++ b/icp_server/runtime_service.bal
@@ -30,7 +30,8 @@ listener http:Listener httpListener = new (serverPort,
             key: {
                 path: keystorePath,
                 password: resolvedKeystorePassword
-            }
+            },
+            ciphers: tlsCiphers
         }
     }
 );
@@ -43,7 +44,8 @@ listener http:Listener runtimeListener = new (runtimeListenerPort,
             key: {
                 path: keystorePath,
                 password: resolvedKeystorePassword
-            }
+            },
+            ciphers: tlsCiphers
         }
     }
 );

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -35,8 +35,17 @@ service / on httpListener {
     }
 
     // Serve static files from build directory
-    resource function get [string... path](http:Request req) returns http:Response|error {
-        http:Response response = check serveStaticFile(path);
+    resource function get [string... path](http:Request req) returns http:Response {
+        http:Response|error result = serveStaticFile(path);
+        http:Response response;
+        if result is error {
+            log:printError("Error serving static file", result);
+            response = new;
+            response.statusCode = 500;
+            response.setTextPayload("Internal server error");
+        } else {
+            response = result;
+        }
         response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
         response.setHeader("X-Content-Type-Options", "nosniff");
         return response;

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -36,71 +36,87 @@ service / on httpListener {
 
     // Serve static files from build directory
     resource function get [string... path](http:Request req) returns http:Response|error {
-        http:Response response = new;
-
-        // Build file path
-        string filePath = path.length() == 0 ? "index.html" : string:'join("/", ...path);
-
-        // Security: Reject paths containing ".." to prevent path traversal attacks
-        if filePath.includes("..") {
-            response.statusCode = 400;
-            response.setTextPayload("Invalid path");
-            log:printWarn("Path traversal attempt detected: " + filePath);
-            return response;
-        }
-
-        // If path is a directory, serve index.html
-        if filePath.endsWith("/") {
-            filePath = filePath + "index.html";
-        }
-
-        // Security: Normalize paths and ensure they stay within the base directory
-        string baseDir = check file:getAbsolutePath("../www");
-        string fullPath = check file:getAbsolutePath("../www/" + filePath);
-
-        // Ensure resolved path is within base directory
-        if !fullPath.startsWith(baseDir) {
-            response.statusCode = 403;
-            response.setTextPayload("Access denied");
-            log:printWarn("Directory traversal attempt blocked: " + fullPath);
-            return response;
-        }
-
-        // Check if file exists
-        boolean fileExists = check file:test(fullPath, file:EXISTS);
-
-        if !fileExists {
-            // For SPA routing: if file doesn't exist and path doesn't have an extension,
-            // serve index.html to let client-side router handle it
-            if filePath.indexOf(".") is () {
-                string indexPath = "../www/index.html";
-                boolean indexExists = check file:test(indexPath, file:EXISTS);
-
-                if indexExists {
-                    byte[] fileContent = check io:fileReadBytes(indexPath);
-                    response.setHeader("Content-Type", "text/html; charset=utf-8");
-                    response.setBinaryPayload(fileContent);
-                    return response;
-                }
-            }
-
-            response.statusCode = 404;
-            response.setTextPayload("File not found: " + filePath);
-            log:printError("File not found: " + fullPath);
-            return response;
-        }
-
-        // Read file content
-        byte[] fileContent = check io:fileReadBytes(fullPath);
-
-        // Set content type based on file extension
-        string contentType = getContentType(filePath);
-        response.setHeader("Content-Type", contentType);
-        response.setBinaryPayload(fileContent);
-
+        http:Response response = check serveStaticFile(path);
+        response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
         return response;
     }
 
+}
+
+function serveStaticFile(string[] path) returns http:Response|error {
+    http:Response response = new;
+
+    // Build file path
+    string filePath = path.length() == 0 ? "index.html" : string:'join("/", ...path);
+
+    // Security: Reject paths containing ".." to prevent path traversal attacks
+    if filePath.includes("..") {
+        response.statusCode = 400;
+        response.setTextPayload("Invalid path");
+        log:printWarn("Path traversal attempt detected: " + filePath);
+        return response;
+    }
+
+    // If path is a directory, serve index.html
+    if filePath.endsWith("/") {
+        filePath = filePath + "index.html";
+    }
+
+    // Security: Normalize paths and ensure they stay within the base directory
+    string baseDir = check file:getAbsolutePath("../www");
+    string fullPath = check file:getAbsolutePath("../www/" + filePath);
+
+    // Ensure resolved path is within base directory
+    if !fullPath.startsWith(baseDir) {
+        response.statusCode = 403;
+        response.setTextPayload("Access denied");
+        log:printWarn("Directory traversal attempt blocked: " + fullPath);
+        return response;
+    }
+
+    // Check if file exists
+    boolean fileExists = check file:test(fullPath, file:EXISTS);
+
+    // Reject directory paths — io:fileReadBytes would return a 500 "Is a directory" error
+    if fileExists {
+        boolean isDirectory = check file:test(fullPath, file:IS_DIR);
+        if isDirectory {
+            response.statusCode = 404;
+            response.setTextPayload("Not found");
+            return response;
+        }
+    }
+
+    if !fileExists {
+        // For SPA routing: if file doesn't exist and path doesn't have an extension,
+        // serve index.html to let client-side router handle it
+        if filePath.indexOf(".") is () {
+            string indexPath = "../www/index.html";
+            boolean indexExists = check file:test(indexPath, file:EXISTS);
+
+            if indexExists {
+                byte[] fileContent = check io:fileReadBytes(indexPath);
+                response.setHeader("Content-Type", "text/html; charset=utf-8");
+                response.setBinaryPayload(fileContent);
+                return response;
+            }
+        }
+
+        response.statusCode = 404;
+        response.setTextPayload("File not found: " + filePath);
+        log:printError("File not found: " + fullPath);
+        return response;
+    }
+
+    // Read file content
+    byte[] fileContent = check io:fileReadBytes(fullPath);
+
+    // Set content type based on file extension
+    string contentType = getContentType(filePath);
+    response.setHeader("Content-Type", contentType);
+    response.setBinaryPayload(fileContent);
+
+    return response;
 }
 
 // Helper function to determine content type

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -38,6 +38,7 @@ service / on httpListener {
     resource function get [string... path](http:Request req) returns http:Response|error {
         http:Response response = check serveStaticFile(path);
         response.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        response.setHeader("X-Content-Type-Options", "nosniff");
         return response;
     }
 
@@ -104,7 +105,7 @@ function serveStaticFile(string[] path) returns http:Response|error {
 
         response.statusCode = 404;
         response.setTextPayload("File not found: " + filePath);
-        log:printError("File not found: " + fullPath);
+        log:printWarn("File not found: " + fullPath);
         return response;
     }
 


### PR DESCRIPTION
## Summary

- https://github.com/wso2-enterprise/integration-engineering/issues/1534
- **Weak Ciphers (Medium/Confirmed):** Restrict TLS cipher suites on both `httpListener` and `runtimeListener` to GCM and ChaCha20 only. All CBC ciphers (`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` and five others from Ballerina's defaults) are removed, eliminating BEAST/POODLE/Lucky13 attack vectors. The list is a `configurable string[]` (`tlsCiphers`) in `config.bal`.

- **HSTS Not Enabled (Medium):** Add `Strict-Transport-Security: max-age=31536000; includeSubDomains` to all webserver responses. Ballerina HTTP 2.16.x does not invoke response interceptors when a resource function returns `http:Response` directly, so the fix extracts the file-serving logic into a `serveStaticFile()` helper — the resource function adds the header once before returning.

- **Misconfigured CORS (Low):** Replace `allowOrigins: ["*"]` with `corsAllowedOrigins` (a `configurable string[]` defaulting to `["https://localhost:9446"]`) across all four services: `/graphql`, `/icp/observability`, `/auth`, and `/observability` (OpenSearch adapter). Arbitrary origins are no longer reflected.

- **Directory Listing / Internal Server Error (Low/Confirmed):** `GET /assets/` was returning HTTP 500 with a Ballerina internal error message (`"Is a directory"`) because `io:fileReadBytes` was called on a directory path. Added a `file:IS_DIR` check after the existence check — directory paths now return 404.

- **Password in Query String (Medium):** The login form had no `method` attribute, defaulting to `GET` per the HTML spec. Added `method="post"` to `<form>` in `LoginForm.tsx` so the browser's native fallback (if JS is disabled) never puts credentials in the URL.

## Test plan

- [ ] Build passes: `./gradlew build`
- [ ] `GET /assets/` returns 404 (not 500)
- [ ] `GET /` response includes `Strict-Transport-Security: max-age=31536000; includeSubDomains`
- [ ] `POST /graphql` with `Origin: http://evil.com` does not reflect the origin in `Access-Control-Allow-Origin`
- [ ] `POST /graphql` with `Origin: https://<configured-host>` returns correct `Access-Control-Allow-Origin`
- [ ] TLS handshake with `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA` fails (cipher rejected)
- [ ] TLS handshake with `ECDHE-RSA-AES256-GCM-SHA384` succeeds
- [ ] Login form HTML contains `method="post"`
- [ ] Deploy to staging and re-run Invicti scan to confirm findings are resolved