### PR TITLE
Add support to start authentication services conditionally

### DIFF
--- a/icp_server/config.bal
+++ b/icp_server/config.bal
@@ -138,8 +138,6 @@ final string resolvedObservabilityJwtHMACSecret = check resolveSecret(observabil
 final string resolvedObservabilityTruststorePassword = check resolveSecret(observabilityTruststorePassword);
 final string resolvedOpensearchUsername = check resolveSecret(opensearchUsername);
 final string resolvedOpensearchPassword = check resolveSecret(opensearchPassword);
-final string resolvedCredDbUser = check resolveSecret(credentialsDbUser);
-final string resolvedCredDbPassword = check resolveSecret(credentialsDbPassword);
 
 // Build SSO configuration from configurable values
 public isolated function getSSOConfig() returns types:SSOConfig => {

--- a/icp_server/default_user_service.bal
+++ b/icp_server/default_user_service.bal
@@ -50,9 +50,13 @@ configurable int lockoutBaseMinutes = 15;
 configurable int lockoutMaxMinutes = 60;
 
 
-// Initialized in init() with resolved (decrypted) credentials
-final storage:DatabaseConnectionManager credentialsDbManager;
-final sql:Client credentialsDbClient;
+final string resolvedCredDbUser = check resolveSecret(credentialsDbUser);
+final string resolvedCredDbPassword = check resolveSecret(credentialsDbPassword);
+final storage:DatabaseConnectionManager credentialsDbManager = check new storage:DatabaseConnectionManager(
+    credentialsDbType, credentialsDbHost, credentialsDbPort,
+    credentialsDbName, resolvedCredDbUser, resolvedCredDbPassword
+);
+final sql:Client credentialsDbClient = credentialsDbManager.getClient();
 
 listener http:Listener defaultAuthServiceListener = new (authServicePort,
     config = {
@@ -66,6 +70,7 @@ listener http:Listener defaultAuthServiceListener = new (authServicePort,
     }
 );
 
+http:Service defaultUserService =
 @http:ServiceConfig {
     auth: [
         {
@@ -80,12 +85,9 @@ listener http:Listener defaultAuthServiceListener = new (authServicePort,
         }
     ]
 }
-service / on defaultAuthServiceListener {
+service object {
 
-    function init() {
-        log:printInfo("Authentication service started at " + authServiceHost + ":" + authServicePort.toString());
-    }
-    resource function post authenticate(types:Credentials request) returns http:Ok|http:BadRequest|http:Unauthorized|http:TooManyRequests|http:InternalServerError|error {
+    resource function post authenticate(@http:Payload types:Credentials request) returns http:Ok|http:BadRequest|http:Unauthorized|http:TooManyRequests|http:InternalServerError|error {
         log:printDebug("Authenticate request", username = request.username);
 
         types:UserCredentials|sql:Error credentials = credentialsDbClient->queryRow(
@@ -152,7 +154,7 @@ service / on defaultAuthServiceListener {
 
     }
 
-    resource function post unlock\-account(record {string username;} request) returns http:Ok|http:BadRequest|http:InternalServerError|error {
+    resource function post unlock\-account(@http:Payload record {string username;} request) returns http:Ok|http:BadRequest|http:InternalServerError|error {
         log:printDebug("Unlock account request", username = request.username);
         types:UserCredentials|sql:Error credentials = credentialsDbClient->queryRow(
             `SELECT user_id as userId, username, display_name as displayName,
@@ -172,7 +174,7 @@ service / on defaultAuthServiceListener {
         return <http:Ok>{body: {message: "Account unlocked"}};
     }
 
-    resource function post change\-password(types:ChangePasswordRequest request) returns http:Ok|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
+    resource function post change\-password(@http:Payload types:ChangePasswordRequest request) returns http:Ok|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
 
         // Validate request
         if request.currentPassword.trim().length() == 0 {
@@ -231,7 +233,7 @@ service / on defaultAuthServiceListener {
         };
     }
 
-    resource function post 'reset\-password(types:ResetPasswordRequest request) returns http:Ok|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
+    resource function post 'reset\-password(@http:Payload types:ResetPasswordRequest request) returns http:Ok|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
         // Verify user exists
         types:UserCredentials|error credentials = getUserCredentialsById(request.userId);
         if credentials is error {
@@ -267,7 +269,7 @@ service / on defaultAuthServiceListener {
         };
     }
 
-    resource function post 'force\-change\-password(types:ForceChangePasswordRequest request, string userId) returns http:Ok|http:BadRequest|http:InternalServerError|error {
+    resource function post 'force\-change\-password(@http:Payload types:ForceChangePasswordRequest request, string userId) returns http:Ok|http:BadRequest|http:InternalServerError|error {
         if request.newPassword.trim().length() == 0 {
             return utils:createBadRequestError("New password is required");
         }
@@ -294,7 +296,7 @@ service / on defaultAuthServiceListener {
         };
     }
 
-    resource function post users(types:CreateUserInput request) returns http:Created|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
+    resource function post users(@http:Payload types:CreateUserInput request) returns http:Created|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
 
         // Validate input
         if request.username.trim().length() == 0 {
@@ -349,7 +351,7 @@ service / on defaultAuthServiceListener {
             }
         };
     }
-}
+};
 
 isolated function parseIntOrZero(string? s) returns int {
     if s is () { return 0; }

--- a/icp_server/default_user_service.bal
+++ b/icp_server/default_user_service.bal
@@ -298,6 +298,7 @@ service object {
 
     resource function post users(@http:Payload types:CreateUserInput request) returns http:Created|http:BadRequest|http:Unauthorized|http:InternalServerError|error {
 
+        log:printDebug("Received request to create new user", username = request.username);
         // Validate input
         if request.username.trim().length() == 0 {
             return utils:createBadRequestError("Username is required");

--- a/icp_server/init.bal
+++ b/icp_server/init.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import icp_server.storage;
 import icp_server.utils;
 
 import ballerina/http;
@@ -72,13 +71,6 @@ function init() returns error? {
         opensearchClient = opensearchClientResult;
         log:printInfo("OpenSearch client initialized successfully");
     }
-
-    // Initialize DB connection manager and DB client with resolved credentials
-    credentialsDbManager = check new storage:DatabaseConnectionManager(
-        credentialsDbType, credentialsDbHost, credentialsDbPort,
-        credentialsDbName, resolvedCredDbUser, resolvedCredDbPassword
-    );
-    credentialsDbClient = credentialsDbManager.getClient();
 
     // Initialize the runtime scheduler
     check initRuntimeScheduler();

--- a/icp_server/ldap_user_service.bal
+++ b/icp_server/ldap_user_service.bal
@@ -149,12 +149,6 @@ http:Service ldapUserService =
 }
 service object {
 
-    function init() {
-        log:printInfo("LDAP authentication adapter started",
-                host = ldapAuthServiceHost, port = ldapAuthServicePort,
-                ldapServer = ldapHostName + ":" + ldapPort.toString());
-    }
-
     resource function post authenticate(@http:Payload types:Credentials request) returns http:Ok|http:Unauthorized|http:InternalServerError|error {
 
         log:printDebug("LDAP authenticate request", username = request.username);

--- a/icp_server/main.bal
+++ b/icp_server/main.bal
@@ -1,9 +1,18 @@
 import ballerina/lang.runtime;
+import ballerina/log;
 
 public function main() returns error? {
     if ldapUserStoreEnabled {
         check ldapAuthServiceListener.attach(ldapUserService, "/");
         check ldapAuthServiceListener.'start();
         runtime:registerListener(ldapAuthServiceListener);
+        log:printInfo("LDAP authentication adapter started",
+                host = ldapAuthServiceHost, port = ldapAuthServicePort,
+                ldapServer = ldapHostName + ":" + ldapPort.toString());
+    } else {
+        check defaultAuthServiceListener.attach(defaultUserService, "/");
+        check defaultAuthServiceListener.'start();
+        runtime:registerListener(defaultAuthServiceListener);
+        log:printInfo("Authentication service started", host = authServiceHost, port = authServicePort);
     }
 }


### PR DESCRIPTION
## Purpose
ICP uses different authentication services according to the type of user store connected (DB/LDAP). These services currently always run when the ICP starts. We need to start them conditionally depending on the user store being used. 

Resolves https://github.com/wso2-enterprise/integration-engineering/issues/740