### PR TITLE
Fix env select dropdown for group role mappings

### DIFF
--- a/frontend/src/pages/ComponentRoleDetail.tsx
+++ b/frontend/src/pages/ComponentRoleDetail.tsx
@@ -79,17 +79,17 @@ function AssignRoleToGroupsDialog({
   const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Group[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
-  const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
+  const [selectedEnv, setSelectedEnv] = useState<string>('');
   const [errorMsg, setErrorMsg] = useState<string>('');
   const available = allGroups.filter((g) => !existingGroupIds.includes(g.groupId));
   const pending = mutation.isPending;
 
   const assign = async () => {
-    if (envMode === 'selected' && selectedEnvs.length === 0) {
+    if (envMode === 'selected' && !selectedEnv) {
       return;
     }
     setErrorMsg('');
-    const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
+    const envUuid = envMode === 'selected' && selectedEnv ? selectedEnv : undefined;
 
     const promises = selected.map((g) =>
       mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId, integrationId: componentId }).then(
@@ -138,10 +138,10 @@ function AssignRoleToGroupsDialog({
             </Typography>
             <RadioGroup value={envMode} onChange={(e) => setEnvMode(e.target.value as 'all' | 'selected')}>
               <FormControlLabel value="all" control={<Radio />} label="All Environments" />
-              <FormControlLabel value="selected" control={<Radio />} label="Selected Environments" />
+              <FormControlLabel value="selected" control={<Radio />} label="Selected Environment" />
             </RadioGroup>
             {envMode === 'selected' && (
-              <TextField select fullWidth label="Select applicable environments" value={selectedEnvs[0] || ''} onChange={(e) => setSelectedEnvs(e.target.value ? [e.target.value] : [])} sx={{ mt: 2 }}>
+              <TextField select fullWidth label="Select applicable environment" value={selectedEnv} onChange={(e) => setSelectedEnv(e.target.value)} sx={{ mt: 2 }}>
                 {allEnvironments.map((env) => (
                   <MenuItem key={env.id} value={env.id}>
                     {env.name}
@@ -154,7 +154,7 @@ function AssignRoleToGroupsDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && selectedEnvs.length === 0)} onClick={assign}>
+        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && !selectedEnv)} onClick={assign}>
           Assign
         </Button>
       </DialogActions>

--- a/frontend/src/pages/EditGroup.tsx
+++ b/frontend/src/pages/EditGroup.tsx
@@ -79,15 +79,15 @@ function AddRolesToGroupDialog({
   const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Role[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
-  const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
+  const [selectedEnv, setSelectedEnv] = useState<string>('');
   const [assignError, setAssignError] = useState<string | null>(null);
   const available = allRoles.filter((r) => !existingRoleIds.includes(r.roleId));
   const pending = mutation.isPending;
 
   const assign = () => {
-    if (envMode === 'selected' && selectedEnvs.length === 0) return;
+    if (envMode === 'selected' && !selectedEnv) return;
     setAssignError(null);
-    const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
+    const envUuid = envMode === 'selected' && selectedEnv ? selectedEnv : undefined;
     mutation.mutate(
       { groupId, roleIds: selected.map((r) => r.roleId), envUuid, projectId, integrationId: componentId },
       {
@@ -125,10 +125,10 @@ function AddRolesToGroupDialog({
             </Typography>
             <RadioGroup value={envMode} onChange={(e) => setEnvMode(e.target.value as 'all' | 'selected')}>
               <FormControlLabel value="all" control={<Radio />} label="All Environments" />
-              <FormControlLabel value="selected" control={<Radio />} label="Selected Environments" />
+              <FormControlLabel value="selected" control={<Radio />} label="Selected Environment" />
             </RadioGroup>
             {envMode === 'selected' && (
-              <TextField select fullWidth label="Select applicable environments" value={selectedEnvs[0] || ''} onChange={(e) => setSelectedEnvs(e.target.value ? [e.target.value] : [])} sx={{ mt: 2 }}>
+              <TextField select fullWidth label="Select applicable environment" value={selectedEnv} onChange={(e) => setSelectedEnv(e.target.value)} sx={{ mt: 2 }}>
                 {allEnvironments.map((env) => (
                   <MenuItem key={env.id} value={env.id}>
                     {env.name}
@@ -141,7 +141,7 @@ function AddRolesToGroupDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && selectedEnvs.length === 0)} onClick={assign}>
+        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && !selectedEnv)} onClick={assign}>
           Add
         </Button>
       </DialogActions>

--- a/frontend/src/pages/ProjectRoleDetail.tsx
+++ b/frontend/src/pages/ProjectRoleDetail.tsx
@@ -77,15 +77,15 @@ function AssignRoleToGroupsDialog({
   const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Group[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
-  const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
+  const [selectedEnv, setSelectedEnv] = useState<string>('');
   const [errorMsg, setErrorMsg] = useState('');
   const available = allGroups.filter((g) => !existingGroupIds.includes(g.groupId));
   const pending = mutation.isPending;
 
   const assign = async () => {
-    if (envMode === 'selected' && selectedEnvs.length === 0) return;
+    if (envMode === 'selected' && !selectedEnv) return;
     setErrorMsg('');
-    const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
+    const envUuid = envMode === 'selected' && selectedEnv ? selectedEnv : undefined;
     const results = await Promise.all(
       selected.map((g) =>
         mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid, projectId }).then(
@@ -131,10 +131,10 @@ function AssignRoleToGroupsDialog({
             </Typography>
             <RadioGroup value={envMode} onChange={(e) => setEnvMode(e.target.value as 'all' | 'selected')}>
               <FormControlLabel value="all" control={<Radio />} label="All Environments" />
-              <FormControlLabel value="selected" control={<Radio />} label="Selected Environments" />
+              <FormControlLabel value="selected" control={<Radio />} label="Selected Environment" />
             </RadioGroup>
             {envMode === 'selected' && (
-              <TextField select fullWidth label="Select applicable environments" value={selectedEnvs[0] || ''} onChange={(e) => setSelectedEnvs(e.target.value ? [e.target.value] : [])} sx={{ mt: 2 }}>
+              <TextField select fullWidth label="Select applicable environment" value={selectedEnv} onChange={(e) => setSelectedEnv(e.target.value)} sx={{ mt: 2 }}>
                 {allEnvironments.map((env) => (
                   <MenuItem key={env.id} value={env.id}>
                     {env.name}
@@ -147,7 +147,7 @@ function AssignRoleToGroupsDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && selectedEnvs.length === 0)} onClick={assign}>
+        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && !selectedEnv)} onClick={assign}>
           Assign
         </Button>
       </DialogActions>

--- a/frontend/src/pages/RoleDetail.tsx
+++ b/frontend/src/pages/RoleDetail.tsx
@@ -115,16 +115,16 @@ function AssignRoleToGroupsDialog({ orgHandler, roleId, roleName, existingGroupI
   const mutation = useAddRolesToGroup(orgHandler);
   const [selected, setSelected] = useState<Group[]>([]);
   const [envMode, setEnvMode] = useState<'all' | 'selected'>('all');
-  const [selectedEnvs, setSelectedEnvs] = useState<string[]>([]);
+  const [selectedEnv, setSelectedEnv] = useState<string>('');
   const [errorMsg, setErrorMsg] = useState('');
   const available = allGroups.filter((g) => !existingGroupIds.includes(g.groupId));
   const pending = mutation.isPending;
   const assign = async () => {
-    if (envMode === 'selected' && selectedEnvs.length === 0) {
+    if (envMode === 'selected' && !selectedEnv) {
       return;
     }
     setErrorMsg('');
-    const envUuid = envMode === 'selected' && selectedEnvs.length > 0 ? selectedEnvs[0] : undefined;
+    const envUuid = envMode === 'selected' && selectedEnv ? selectedEnv : undefined;
     const results = await Promise.all(
       selected.map((g) =>
         mutation.mutateAsync({ groupId: g.groupId, roleIds: [roleId], envUuid }).then(
@@ -169,10 +169,10 @@ function AssignRoleToGroupsDialog({ orgHandler, roleId, roleName, existingGroupI
             </Typography>
             <RadioGroup value={envMode} onChange={(e) => setEnvMode(e.target.value as 'all' | 'selected')}>
               <FormControlLabel value="all" control={<Radio />} label="All Environments" />
-              <FormControlLabel value="selected" control={<Radio />} label="Selected Environments" />
+              <FormControlLabel value="selected" control={<Radio />} label="Selected Environment" />
             </RadioGroup>
             {envMode === 'selected' && (
-              <TextField select fullWidth label="Select applicable environments" value={selectedEnvs[0] || ''} onChange={(e) => setSelectedEnvs(e.target.value ? [e.target.value] : [])} sx={{ mt: 2 }}>
+              <TextField select fullWidth label="Select applicable environment" value={selectedEnv} onChange={(e) => setSelectedEnv(e.target.value)} sx={{ mt: 2 }}>
                 {allEnvironments.map((env) => (
                   <MenuItem key={env.id} value={env.id}>
                     {env.name}
@@ -185,7 +185,7 @@ function AssignRoleToGroupsDialog({ orgHandler, roleId, roleName, existingGroupI
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && selectedEnvs.length === 0)} onClick={assign}>
+        <Button variant="contained" disabled={selected.length === 0 || pending || (envMode === 'selected' && !selectedEnv)} onClick={assign}>
           Assign
         </Button>
       </DialogActions>


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/435

  ### Problem
  The "Applicable Environments" radio option and dropdown in the assign-roles/assign-groups
  dialogs implied multi-select (plural labels, `string[]` state), but the control was always
  single-select — only `selectedEnvs[0]` was ever sent. The backend and DB also only support
  a single `envUuid` per mapping, so multi-select was never a valid option.

  ### Changes
  Updated the four affected pages to reflect the true single-selection behaviour:
  - `RoleDetail.tsx`
  - `ProjectRoleDetail.tsx`
  - `ComponentRoleDetail.tsx`
  - `EditGroup.tsx`

  In each file:
  - State simplified from `string[]` to `string`
  - Radio label: "Selected Environments" → "Selected Environment"
  - Dropdown label: "Select applicable environments" → "Select applicable environment"
  - Value/onChange/guard logic cleaned up accordingly

  No backend or API changes — the scalar `envUuid` contract was already correct.