### PR TITLE
Add HikariCP JMX support for JDBC connection pool metrics

### DIFF
--- a/components/org.wso2.dashboard.security.user.core/src/main/java/org/wso2/dashboard/security/user/core/DatabaseUtil.java
+++ b/components/org.wso2.dashboard.security.user.core/src/main/java/org/wso2/dashboard/security/user/core/DatabaseUtil.java
@@ -30,6 +30,8 @@ import org.wso2.micro.integrator.security.user.core.UserStoreException;
 import org.wso2.micro.integrator.security.user.core.jdbc.JDBCRealmConstants;
 import org.wso2.micro.integrator.security.user.core.util.UserCoreUtil;
 
+import static org.wso2.dashboard.security.user.core.UserStoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME;
+
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
@@ -47,6 +49,8 @@ public class DatabaseUtil {
     private static final int DEFAULT_MAX_WAIT = 1000 * 60;
     private static final int DEFAULT_MIN_IDLE = 5;
     private static final int DEFAULT_MAX_IDLE = 6;
+    private static final String REALM_POOL_NAME = "WSO2CarbonDB";
+    private static final String USER_STORE_POOL_NAME = "WSO2UserStoreDB";
     private static Log log = LogFactory.getLog(org.wso2.micro.integrator.security.user.core.util.DatabaseUtil.class);
     private static DataSource dataSource = null;
     private static final String VALIDATION_INTERVAL = "validationInterval";
@@ -76,6 +80,9 @@ public class DatabaseUtil {
 
         String dataSourceName = realmConfig.getRealmProperty(JDBCRealmConstants.DATASOURCE);
         if (dataSourceName != null) {
+            if (Boolean.parseBoolean(realmConfig.getRealmProperty(JDBCRealmConstants.JMX_ENABLED))) {
+                log.warn("jmxEnabled has no effect on JNDI-backed realm datasources.");
+            }
             dataSourceName = resolveSystemProperty(dataSourceName);
             return lookupDataSource(dataSourceName);
         }
@@ -86,7 +93,9 @@ public class DatabaseUtil {
         config.setUsername(realmConfig.getRealmProperty(JDBCRealmConstants.USER_NAME));
         config.setPassword(realmConfig.getRealmProperty(JDBCRealmConstants.PASSWORD));
 
-        HikariDataSource dataSource = new HikariDataSource(config);
+        configureJmx(config, REALM_POOL_NAME, realmConfig.getRealmProperty(JDBCRealmConstants.JMX_ENABLED));
+
+        dataSource = new HikariDataSource(config);
         return dataSource;
     }
 
@@ -112,6 +121,9 @@ public class DatabaseUtil {
 
         String dataSourceName = realmConfig.getUserStoreProperty(JDBCRealmConstants.DATASOURCE);
         if (dataSourceName != null) {
+            if (Boolean.parseBoolean(realmConfig.getUserStoreProperty(JDBCRealmConstants.JMX_ENABLED))) {
+                log.warn("jmxEnabled has no effect on JNDI-backed user store datasources.");
+            }
             dataSourceName = resolveSystemProperty(dataSourceName);
             return lookupDataSource(dataSourceName);
         }
@@ -158,6 +170,19 @@ public class DatabaseUtil {
                     JDBCRealmConstants.MAX_WAIT)));
         } else {
             config.setConnectionTimeout(DEFAULT_MAX_WAIT);
+        }
+
+        String domainName = realmConfig.getUserStoreProperty(PROPERTY_DOMAIN_NAME);
+        String poolName = StringUtils.isNotBlank(domainName)
+                ? USER_STORE_POOL_NAME + "-" + domainName
+                : USER_STORE_POOL_NAME;
+        configureJmx(config, poolName, realmConfig.getUserStoreProperty(JDBCRealmConstants.JMX_ENABLED));
+    }
+
+    private static void configureJmx(HikariConfig config, String poolName, String jmxEnabled) {
+        if (Boolean.parseBoolean(jmxEnabled)) {
+            config.setPoolName(poolName);
+            config.setRegisterMbeans(true);
         }
     }
 


### PR DESCRIPTION
## Summary

ICP uses HikariCP for JDBC connection pooling but had no mechanism to expose pool metrics via JMX, regardless of what customers configured in `deployment.toml`. This change wires up `jmxEnabled` from `pool_options` to HikariCP's MBean registration.

- When `pool_options.jmxEnabled = true` is set, `HikariConfig.setRegisterMbeans(true)` is called and the pool is named — `WSO2UserStoreDB-<DomainName>` for the user store datasource (domain-qualified to prevent MBean collisions when multiple JDBC user stores are configured), and `WSO2CarbonDB` for the realm datasource
- A `WARN` log is emitted when `jmxEnabled=true` is set on a JNDI-backed datasource, since ICP does not own that pool
- Fixes a pre-existing static field shadow in `createRealmDataSource` where a local variable `HikariDataSource dataSource` was shadowing the static field, causing a new pool to be created on every call (and an `InstanceAlreadyExistsException` with JMX enabled)
- Extracts a shared `configureJmx(HikariConfig, String, String)` helper used by both code paths

## Customer configuration

```toml
[user_store]
class = "org.wso2.dashboard.security.user.core.jdbc.JDBCUserStoreManager"
# ... connection properties ...

[user_store.pool_options]
maxActive = 50
maxWait = 60000
jmxEnabled = true
```

Once enabled, HikariCP registers MBeans under:
- `com.zaxxer.hikari:type=Pool (WSO2UserStoreDB-PRIMARY)` — runtime metrics
- `com.zaxxer.hikari:type=PoolConfig (WSO2UserStoreDB-PRIMARY)` — configuration

These are scraped by the JMX Prometheus Java Agent using the standard `com.zaxxer.hikari` pattern.

## Test plan

- [x] Built on `1.2.x` base and confirmed clean compile
- [x] Started ICP with JDBC user store, `jmxEnabled=true` — MBeans registered under `WSO2UserStoreDB-PRIMARY`
- [x] Confirmed `jmxEnabled=false` produces no MBeans (negative test)
- [x] Confirmed domain-qualified name with `DomainName=CUSTOMERS` → `WSO2UserStoreDB-CUSTOMERS`
- [x] Confirmed JNDI warning fires when `jmxEnabled=true` + JNDI datasource configured
- [x] 5 concurrent logins — no `InstanceAlreadyExistsException`, single pool instance