### PR TITLE
Fix session timeout issues

### DIFF
--- a/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/SecurityHeaderFilter.java
+++ b/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/SecurityHeaderFilter.java
@@ -43,8 +43,12 @@ public class SecurityHeaderFilter implements Filter {
             throws IOException, ServletException {
 
         final HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
-        httpResponse.addHeader("Content-Security-Policy", "frame-ancestors 'none'; object-src 'none';");
-        httpResponse.addHeader("X-Frame-Options", "DENY");
+        // Allow the dashboard to frame its own pages ('self'/SAMEORIGIN) while still blocking framing by other
+        // origins. Same-origin framing is required for the OIDC silent token renewal flow used with web worker
+        // storage: it loads the IdP's prompt=none response in a hidden iframe that navigates to the dashboard's own
+        // SSO redirect page. 'none'/DENY blocks that iframe and breaks session restore on a browser reload.
+        httpResponse.addHeader("Content-Security-Policy", "frame-ancestors 'self'; object-src 'none';");
+        httpResponse.addHeader("X-Frame-Options", "SAMEORIGIN");
         httpResponse.addHeader("X-Content-Type-Options", "nosniff");
         httpResponse.addHeader("Referrer-Policy", "same-origin");
         httpResponse.addHeader("X-XSS-Protection", "1; mode=block");

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
@@ -68,21 +68,30 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         }
 
         SSOConfig config = getSsoConfig();
-        if (!securityHandler.isAuthenticated(config, token)) {
-            abortWithUnauthorized(requestContext);
+        try {
+            if (!securityHandler.isAuthenticated(config, token)) {
+                // The token is missing, expired or otherwise invalid: the session is dead.
+                abortWithUnauthorized(requestContext);
+                return;
+            }
+        } catch (TokenValidationException e) {
+            // The token could not be validated because of a server/IdP side failure (e.g. the JWKS or introspection
+            // endpoint is unreachable or untrusted). The session may well be valid, so do not report it as a 401.
+            abortWithServiceUnavailable(requestContext);
             return;
         }
 
         boolean makeNonAdminUsersReadOnly = Boolean.parseBoolean(System.getProperty(MAKE_NON_ADMIN_USERS_READ_ONLY));
         if (isAdminResource(requestContext) && !securityHandler.isAuthorized(config, token)) {
-            abortWithUnauthorized(requestContext);
+            // The user is authenticated but not permitted to access this resource.
+            abortWithForbidden(requestContext);
             return;
         }
         if (!"GET".equalsIgnoreCase(httpMethod) && makeNonAdminUsersReadOnly
                 && !securityHandler.isAuthorized(config, token)) {
             // For non-admin resources, request except GET are blocked
             // if the 'makeNonAdminUsersReadOnly' is set to 'true'
-            abortWithUnauthorized(requestContext);
+            abortWithForbidden(requestContext);
             return;
         }
         String performedBy = extractPerformedBy(token);
@@ -101,11 +110,24 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     }
 
     private void abortWithUnauthorized(ContainerRequestContext requestContext) {
+        abortWith(requestContext, Response.Status.UNAUTHORIZED, "Unauthorized");
+    }
+
+    private void abortWithForbidden(ContainerRequestContext requestContext) {
+        abortWith(requestContext, Response.Status.FORBIDDEN, "Forbidden");
+    }
+
+    private void abortWithServiceUnavailable(ContainerRequestContext requestContext) {
+        abortWith(requestContext, Response.Status.SERVICE_UNAVAILABLE,
+                "Unable to validate the session with the identity provider");
+    }
+
+    private void abortWith(ContainerRequestContext requestContext, Response.Status status, String message) {
         Map<String, String> responseBody = new HashMap<>();
-        responseBody.put("message", "Unauthorized");
-        Response unauthorizedResponse = Response.status(Response.Status.UNAUTHORIZED).entity(responseBody)
+        responseBody.put("message", message);
+        Response response = Response.status(status).entity(responseBody)
                 .header("content-type", "application/json").build();
-        requestContext.abortWith(unauthorizedResponse);
+        requestContext.abortWith(response);
     }
 
     private String extractToken(ContainerRequestContext requestContext) {

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/JWTSecurityHandler.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/JWTSecurityHandler.java
@@ -60,8 +60,34 @@ public class JWTSecurityHandler implements SecurityHandler {
             IDTokenValidator validator = new IDTokenValidator(config.getOidcAgentConfig(), idTokenJWT);
             validator.validate(null);
             return true;
-        } catch (DashboardServerException | ParseException | SSOAgentServerException e) {
+        } catch (SSOAgentServerException e) {
+            if (isCausedByConnectivityFailure(e)) {
+                // The JWKS endpoint could not be reached (e.g. network failure or the IdP TLS certificate is not
+                // trusted by this server's truststore). This is a server/IdP side failure, not an invalid token, so
+                // surface it as such instead of reporting the token as unauthorized.
+                logger.error("Unable to retrieve the JWKS to validate the access token. Verify that the identity "
+                        + "provider's certificate is imported into the dashboard's client-truststore.jks.", e);
+                throw new TokenValidationException("Unable to retrieve the JWKS to validate the access token", e);
+            }
             logger.error("Error validating the access token", e);
+        } catch (DashboardServerException | ParseException e) {
+            logger.error("Error validating the access token", e);
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the given throwable was caused by a connectivity/TLS failure (an {@link IOException}, which
+     * includes SSL handshake failures). The OIDC SDK reports a failure to retrieve the JWKS as an
+     * {@link SSOAgentServerException} whose cause chain carries the underlying {@link IOException}, which lets us
+     * distinguish "could not reach the IdP to validate" from "the token is invalid".
+     */
+    private boolean isCausedByConnectivityFailure(Throwable throwable) {
+
+        for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+            if (cause instanceof IOException) {
+                return true;
+            }
         }
         return false;
     }

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/OpaqueTokenSecurityHandler.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/OpaqueTokenSecurityHandler.java
@@ -75,7 +75,12 @@ public class OpaqueTokenSecurityHandler implements SecurityHandler {
                 logger.error("Error validating the token using introspection endpoint. ",
                         httpResponse.getStatusLine().getReasonPhrase());
             }
-        } catch (IOException | DashboardServerException e) {
+        } catch (IOException e) {
+            // The introspection endpoint could not be reached. This is a server/IdP side failure, not an invalid
+            // token, so surface it as such instead of reporting the token as unauthorized.
+            logger.error("Unable to reach the introspection endpoint to validate the token.", e);
+            throw new TokenValidationException("Unable to reach the introspection endpoint to validate the token", e);
+        } catch (DashboardServerException e) {
             logger.error("Error validating the token using introspection endpoint. ", e);
         }
         return false;

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/TokenValidationException.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/TokenValidationException.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+/**
+ * Thrown by a {@link SecurityHandler} when a token cannot be validated because of a server or identity provider side
+ * failure (for example, the JWKS or introspection endpoint is unreachable or its TLS certificate is not trusted).
+ *
+ * This is deliberately distinct from a token that is simply invalid or expired: the request should be answered with a
+ * 503 (the server could not complete the validation) rather than a 401 (the caller's session is dead). Returning 401 in
+ * this case is misleading - it makes a server side misconfiguration look like a session timeout and sends the user into
+ * a login loop, because re-authenticating cannot fix it.
+ */
+public class TokenValidationException extends RuntimeException {
+
+    public TokenValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/components/org.wso2.ei.dashboard.core/src/main/resources/swagger.yaml
+++ b/components/org.wso2.ei.dashboard.core/src/main/resources/swagger.yaml
@@ -183,6 +183,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GroupList'
+        # The authentication filter applies to every secured resource; the
+        # responses below are representative of that behaviour for all of them.
+        401:
+          description: "The session is invalid or has expired"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+        403:
+          description: "The user is authenticated but not permitted to access this resource"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+        503:
+          description: "The session could not be validated because the identity provider was unreachable"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableError'
         default:
           description: Unexpected error
           content:
@@ -2781,6 +2801,20 @@ components:
       example:
         code: 401
         message: Unauthorized
+    ForbiddenError:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Forbidden
+    ServiceUnavailableError:
+      type: object
+      properties:
+        message:
+          type: string
+      example:
+        message: Unable to validate the session with the identity provider
     Token:
       type: object
       properties:

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/AuthManager.js
@@ -92,6 +92,24 @@ export default class AuthManager {
     }
 
     /**
+     * Discard the session and send the user back to the login page.
+     *
+     * This is used when an SSO session can no longer be authenticated, for
+     * example when the refresh token has expired or when the web worker tokens
+     * were lost after a browser reload. SSO API calls bypass the axios
+     * interceptor, so without this the UI would stay stuck on a loading state.
+     *
+     * @param {String} reason : (Optional) reason for the redirect, passed to the
+     *                          login page as the 'session' query parameter so it
+     *                          can explain why the user was signed out.
+     */
+    static redirectToLogin(reason) {
+        AuthManager.discardSession();
+        const query = reason ? '?session=' + encodeURIComponent(reason) : '';
+        window.location.href = (window.contextPath || '') + '/login' + query;
+    }
+
+    /**
      * Delete a browser cookie given its name
      * @param {String} name : Name of the cookie which need to be deleted
      */

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/auth/Login.js
@@ -40,6 +40,7 @@ import {useHistory} from "react-router-dom";
 import HTTPClient from '../utils/HTTPClient';
 import { useDispatch } from 'react-redux';
 import { setSuperAdmin } from '../redux/Actions';
+import { Constants } from '../utils/Constants';
 
 const styles = theme => ({
     paper: {
@@ -80,12 +81,17 @@ function Login(props){
     const [authenticated, setAuthenticated] = useState(false);
     const [loginErrorMessage, setLoginErrorMessage] = useState('')
     const [loginError, setLoginError] = useState(false)
+    const [sessionExpired, setSessionExpired] = useState(false)
     const { signIn } = useAuthContext();
     const dispatch = useDispatch();
 
     useEffect(() => {
         fetchCsrfToken();
         initAuthenticationFlow();
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('session') === Constants.SESSION_EXPIRED) {
+            setSessionExpired(true);
+        }
     }, [])
 
     /**
@@ -166,6 +172,14 @@ function Login(props){
                             Sign in
                         </Typography>
                     </Box>
+
+                    {sessionExpired &&
+                    <Box mt={2} className={classes.policyBox}>
+                        <Typography variant="body2" style={{fontSize:13}}>
+                            Your session has expired. Please sign in again.
+                        </Typography>
+                    </Box>
+                    }
 
                     <form className={classes.form} noValidate>
                         <TextField

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/home/Dashboard.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/home/Dashboard.js
@@ -18,14 +18,19 @@
  *
  */
 
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import { Switch, Route, BrowserRouter as Router, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Hidden from '@material-ui/core/Hidden';
 import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Snackbar from '@material-ui/core/Snackbar';
 import { useAuthContext } from "@asgardeo/auth-react";
+import { Constants } from '../utils/Constants';
+
 import Navigator from './layout/Navigator';
 import Content from './layout/Content';
 import Header from './layout/Header';
@@ -101,6 +106,14 @@ function Layout(props) {
     const { signIn } = useAuthContext();
     const dispatch = useDispatch();
 
+    const isSsoUser = AuthManager.getUser()?.sso;
+    const { state, trySignInSilently } = useAuthContext();
+    // For SSO users the session is only confirmed once the Asgardeo SDK holds
+    // valid tokens. Non-SSO users are considered checked from the start.
+    const [ssoSessionChecked, setSsoSessionChecked] = useState(!isSsoUser);
+    const [ssoSessionExpired, setSsoSessionExpired] = useState(false);
+    const [idpUnavailable, setIdpUnavailable] = useState(false);
+
     const handleDrawerToggle = () => {
         setMobileOpen(!mobileOpen);
     };
@@ -112,14 +125,79 @@ function Layout(props) {
         dispatch(setIsRefreshed(true))
     },[])
 
+    // Show a single banner when the identity provider cannot be reached to
+    // validate the session, instead of letting every page fail silently.
+    useEffect(() => {
+        const handler = () => setIdpUnavailable(true);
+        window.addEventListener(Constants.IDP_UNAVAILABLE_EVENT, handler);
+        return () => window.removeEventListener(Constants.IDP_UNAVAILABLE_EVENT, handler);
+    }, [])
+
+    // Reconcile the local session cookie with the Asgardeo session state. With
+    // web worker storage the tokens are lost on a browser reload while the
+    // session cookie survives, which previously left the UI stuck on a loading
+    // screen. Attempt to silently restore the session and fall back to the
+    // login page when it can no longer be authenticated.
+    useEffect(() => {
+        if (!isSsoUser || ssoSessionChecked) {
+            return;
+        }
+        if (state.isAuthenticated) {
+            setSsoSessionChecked(true);
+            return;
+        }
+        if (state.isLoading) {
+            // Wait until the SDK finishes initializing before deciding.
+            return;
+        }
+        let isActive = true;
+        trySignInSilently()
+            .then(response => {
+                if (!isActive) {
+                    return;
+                }
+                if (response) {
+                    setSsoSessionChecked(true);
+                } else {
+                    AuthManager.discardSession();
+                    setSsoSessionExpired(true);
+                }
+            })
+            .catch(() => {
+                if (isActive) {
+                    AuthManager.discardSession();
+                    setSsoSessionExpired(true);
+                }
+            });
+        return () => { isActive = false; };
+    }, [isSsoUser, ssoSessionChecked, state.isAuthenticated, state.isLoading, trySignInSilently]);
+
     // if the user is not logged in Redirect to login
-    if (!AuthManager.isLoggedIn()) {
+    if (!AuthManager.isLoggedIn() || ssoSessionExpired) {
         return (
             <Redirect to={{ pathname: '/login' }} />
         );
     }
 
+    // Hold rendering until the SSO session has been validated/restored so that
+    // child pages do not fire API calls without a valid token.
+    if (!ssoSessionChecked) {
+        return (
+            <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh">
+                <CircularProgress />
+            </Box>
+        );
+    }
+
     return (
+        <>
+        <Snackbar
+            open={idpUnavailable}
+            anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            autoHideDuration={10000}
+            onClose={() => setIdpUnavailable(false)}
+            message="Unable to verify your session with the identity provider. Please contact your administrator."
+        />
         <Router>
 
             <div className={classes.root}>
@@ -186,6 +264,7 @@ function Layout(props) {
                 </div>
             </div>
         </Router>
+        </>
     );
 }
 

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/home/Dashboard.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/home/Dashboard.js
@@ -172,10 +172,14 @@ function Layout(props) {
         return () => { isActive = false; };
     }, [isSsoUser, ssoSessionChecked, state.isAuthenticated, state.isLoading, trySignInSilently]);
 
-    // if the user is not logged in Redirect to login
+    // if the user is not logged in Redirect to login. When the SSO session
+    // expired during the silent-restore attempt, carry the reason so the login
+    // page can explain why the user was signed out (matching the handleSsoError
+    // path); a user who was simply never logged in gets no such notice.
     if (!AuthManager.isLoggedIn() || ssoSessionExpired) {
+        const search = ssoSessionExpired ? '?session=' + Constants.SESSION_EXPIRED : '';
         return (
-            <Redirect to={{ pathname: '/login' }} />
+            <Redirect to={{ pathname: '/login', search }} />
         );
     }
 

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/Constants.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/Constants.js
@@ -26,5 +26,9 @@ export const Constants = {
     PREFIX_LOG_CONFIGS: "log-configs",
     PREFIX_LOGS: "logs",
     PREFIX_RESOURCE_TYPE: "resource-type",
-    PREFIX_USER_PASSWORD: "user/password"
+    PREFIX_USER_PASSWORD: "user/password",
+    // Reason passed to the login page when a session can no longer be authenticated.
+    SESSION_EXPIRED: "expired",
+    // Window event dispatched when the identity provider cannot be reached to validate the session.
+    IDP_UNAVAILABLE_EVENT: "icp:idp-unavailable"
 };

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/HTTPClient.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/HTTPClient.js
@@ -36,9 +36,61 @@ export default class HTTPClient {
         };
 
         if (AuthManager.getUser().sso) {
-            return AsgardeoSPAClient.getInstance().httpRequest(requestConfig);
+            return AsgardeoSPAClient.getInstance().httpRequest(requestConfig)
+                .catch(error => HTTPClient.handleSsoError(error));
         } else {
             return axios.request(requestConfig)
+        }
+    }
+
+    /**
+     * Handle errors thrown by SSO (Asgardeo) API requests.
+     *
+     * SSO requests are made through the Asgardeo http client and therefore do
+     * not pass through the axios response interceptor, so we decide here what a
+     * failure means. We react based on the HTTP response (when there is one):
+     *
+     *  - 503: the server could not validate the token against the identity
+     *    provider (e.g. the JWKS endpoint is unreachable or its certificate is
+     *    not trusted). The session may well be valid, so we surface a notice
+     *    instead of logging the user out (re-authenticating would not help).
+     *  - 403: the user is authenticated but not permitted to access the
+     *    resource. Leave it to the caller to display; never log the user out.
+     *  - 401, or an error with no HTTP response: the session could not be
+     *    authenticated. On a 401 the Asgardeo SDK transparently attempts a
+     *    silent token refresh before rejecting; when that refresh also fails
+     *    (e.g. the refresh token has expired) it rejects with an exception that
+     *    carries no `response`. Either way the session cannot be recovered, so
+     *    send the user to the login page. This is the only case where we log
+     *    the user out.
+     *
+     * @param {Object} error Error thrown by the Asgardeo http client
+     * @returns {Promise} A rejected promise so callers can still handle the error
+     */
+    static handleSsoError(error) {
+        const response = error?.response;
+        const status = response?.status;
+        if (status === 503) {
+            HTTPClient.notifyIdpUnavailable();
+            return Promise.reject(error);
+        }
+        if (status === 403) {
+            return Promise.reject(error);
+        }
+        if (status === 401 || !response) {
+            AuthManager.redirectToLogin(Constants.SESSION_EXPIRED);
+        }
+        return Promise.reject(error);
+    }
+
+    /**
+     * Notify the application that the identity provider could not be reached to
+     * validate the session, so a single banner can be shown instead of each
+     * page failing silently.
+     */
+    static notifyIdpUnavailable() {
+        if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+            window.dispatchEvent(new CustomEvent(Constants.IDP_UNAVAILABLE_EVENT));
         }
     }
 


### PR DESCRIPTION
## Problem

With SSO enabled (per [ICP-1.2.0 #5034]), the dashboard got stuck on an infinite loading screen instead of redirecting to login in several cases: when the session timed out, on a browser reload with `webWorker` storage, and (more subtly) when the server couldn't validate the token.

The root cause was twofold:

- SSO API calls go through the Asgardeo SDK's HTTP client, which bypasses the axios interceptor — so their `401`s were never handled.
- The backend collapsed several distinct failure reasons into a single `401`, so the frontend couldn't tell a dead session from a server-side problem.

## Changes

### Backend — give `401` a precise meaning

- `AuthenticationFilter` now returns distinct codes:
  - **401** — session invalid/expired
  - **403** — authenticated but not permitted (was incorrectly `401`)
  - **503** — token could not be validated against the IdP
- `JWTSecurityHandler` / `OpaqueTokenSecurityHandler` now distinguish a genuinely bad/expired token (→ `401`) from an unreachable/untrusted JWKS or introspection endpoint (→ `503`) via the new `TokenValidationException`. This turns the misleading "expired session" symptom of an untrusted IdP cert into an actionable `503` (the log now points at importing the cert into `client-truststore.jks`).
- `swagger.yaml` documents the `401`/`403`/`503` responses.

### Frontend — react to the session state instead of hanging

- `HTTPClient` now interprets SSO request failures:
  - **503** → non-blocking "IdP unavailable" banner (no logout)
  - **403** → surfaced to the page (no logout)
  - **401, or an error with no HTTP response** (the Asgardeo SDK's failed-refresh exception) → redirect to login with a "session expired" notice

  This is the only path that logs the user out.
- `Dashboard` reconciles the local session cookie with the SDK auth state on load: for SSO users it waits for / silently restores the session before rendering, so pages don't fire calls without a token (fixes the `webWorker` reload hang).
- `Login` shows a "session expired" notice when redirected for that reason.

### webWorker reload support

- `SecurityHeaderFilter`: relaxed `X-Frame-Options: DENY` → `SAMEORIGIN` and CSP `frame-ancestors 'none'` → `'self'`. Same-origin framing is required for the OIDC silent-token-renewal iframe used by `webWorker` storage; `DENY`/`'none'` previously blocked it and forced a re-login on every reload. External framing is still blocked (clickjacking protection preserved).

## Notes / limitations

- `webWorker` reload restore relies on a `prompt=none` iframe and therefore needs third-party cookies allowed (or IS same-site). When third-party cookies are blocked, reload falls back to a clean re-login. `sessionStorage` avoids the iframe entirely and is the recommended option for locked-down-cookie environments. _(Docs update to follow.)_
- The untrusted-IdP-cert case still requires importing the IS certificate into `<ICP_HOME>/conf/security/client-truststore.jks`; this change just makes the failure diagnosable (`503` + log hint) instead of looking like a session bug.

## Testing

- Verified manually against WSO2 IS 7.2.0:
  - session timeout → redirect to login with notice
  - access-token-expired-but-refresh-valid → seamless
  - `webWorker` reload with third-party cookies allowed → stays logged in
  - untrusted cert → `503` + banner (no login loop)
- `dashboard.core` and `dashboard.bootstrap` Maven modules and the web-app production build all compile clean.

## Related Issue
- https://github.com/wso2-enterprise/wso2-integration-internal/issues/5053