### PR TITLE
Fix dashboard.sh crash when installation path contains spaces

### DIFF
--- a/distribution/src/main/resources/bin/dashboard.sh
+++ b/distribution/src/main/resources/bin/dashboard.sh
@@ -19,10 +19,10 @@ PRGDIR=`dirname "$PRG"`
 
 # Only set DASHBOARD_HOME if not already set
 [ -z "$DASHBOARD_HOME" ] && DASHBOARD_HOME=`cd "$PRGDIR/.." ; pwd`
-export DASHBOARD_HOME=$DASHBOARD_HOME
+export DASHBOARD_HOME="$DASHBOARD_HOME"
 for t in "$DASHBOARD_HOME"/lib/*.jar
 do
-    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":"$t"
 done
 if [ -z "$JAVACMD" ] ; then
    if [ -n "$JAVA_HOME"  ] ; then
@@ -84,15 +84,15 @@ elif [ "$CMD" = "start" ]; then
     fi
   fi
 # using nohup bash to avoid errors in solaris OS
-  nohup bash $DASHBOARD_HOME/bin/dashboard.sh $args > /dev/null 2>&1 &
+  nohup bash "$DASHBOARD_HOME/bin/dashboard.sh" $args > /dev/null 2>&1 &
   exit 0
 elif [ "$CMD" = "stop" ]; then
-  kill -term `cat $DASHBOARD_HOME/runtime.pid`
+  kill -term `cat "$DASHBOARD_HOME/runtime.pid"`
   exit 0
 elif [ "$CMD" = "restart" ]; then
-  kill -term `cat $DASHBOARD_HOME/runtime.pid`
+  kill -term `cat "$DASHBOARD_HOME/runtime.pid"`
   process_status=0
-  pid=`cat $DASHBOARD_HOME/runtime.pid`
+  pid=`cat "$DASHBOARD_HOME/runtime.pid"`
   while [ "$process_status" -eq "0" ]
   do
         sleep 1;
@@ -100,10 +100,10 @@ elif [ "$CMD" = "restart" ]; then
         process_status=$?
   done
 # using nohup bash to avoid errors in solaris OS
-  nohup bash $DASHBOARD_HOME/bin/dashboard.sh $args > /dev/null 2>&1 &
+  nohup bash "$DASHBOARD_HOME/bin/dashboard.sh" $args > /dev/null 2>&1 &
   exit 0
 elif [ "$CMD" = "version" ]; then
-  cat $DASHBOARD_HOME/bin/version.txt
+  cat "$DASHBOARD_HOME/bin/version.txt"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- `export DASHBOARD_HOME=$DASHBOARD_HOME` in `dashboard.sh` line 22 was unquoted, causing `sh` to word-split the value on spaces before passing it to `export`. When the path contains a space (e.g. Jenkins workspace `integration-control-plane 1.2.x`), the shell sees the portion after the space as a separate argument and rejects it as a bad variable name.
- Quoted `DASHBOARD_HOME` on the `export` line (root fix) and all other unquoted `$DASHBOARD_HOME` and `$t` expansions in the script for consistency.

## Root cause log

```
dashboard.sh: 22: export: 1.2.x/.../wso2-integration-control-plane-1.2.1-SNAPSHOT: bad variable name
```

## Test plan

- [x] Reproduced the failure: `sh -c "export DASHBOARD_HOME=/path with space"` errors with "not a valid identifier"
- [x] Confirmed the fix: running `dashboard.sh version` from a directory whose path contains spaces prints the version and exits 0
- [ ] CI integration tests pass in the Jenkins pipeline