### PR TITLE
[Devant Migration] Pass real org namespace to obs-proxy log queries for cloud

### DIFF
--- a/ipaas/src/api/cloud/builds.ts
+++ b/ipaas/src/api/cloud/builds.ts
@@ -49,6 +49,9 @@ interface BffBuildRun {
   startedAt?: string;
   completedAt?: string;
   tasks?: BffWorkflowTask[];
+  // The run's K8s namespace (the org namespace); the observability proxy filters
+  // log queries on it.
+  namespace?: string;
 }
 
 type StageKey = 'init' | 'build' | 'deploy';
@@ -119,7 +122,7 @@ async function fetchObsBuildLogText(runId: string, run: BffBuildRun): Promise<st
   const endTime = run.completedAt ? new Date(new Date(run.completedAt).getTime() + 10 * 60_000).toISOString() : new Date().toISOString();
   try {
     const rows = await queryObsLogs({
-      searchScope: { workflowRunName: runId },
+      searchScope: { ...(run.namespace ? { namespace: run.namespace } : {}), workflowRunName: runId },
       startTime,
       endTime,
       limit: 500,

--- a/ipaas/src/api/cloud/logs.ts
+++ b/ipaas/src/api/cloud/logs.ts
@@ -26,7 +26,7 @@
  * resource names, so request ids map straight onto the proxy search scope.
  */
 
-import { obsClient } from './_client';
+import { bff, items, obsClient, seg, type ListResponse } from './_client';
 import type { LogsRequest, ComponentLogsRequest, LogRow } from '../../types/logs';
 
 const LOGS_QUERY_PATH = '/wso2cloud-obs/api/v1/logs/query';
@@ -34,10 +34,6 @@ const LOGS_QUERY_PATH = '/wso2cloud-obs/api/v1/logs/query';
 // Levels the proxy indexes; sent when the caller does not filter, since the
 // proxy treats an empty logLevels list as "match nothing".
 export const DEFAULT_LOG_LEVELS = ['INFO', 'DEBUG', 'ERROR', 'WARN'];
-
-// The proxy resolves the org namespace from the access token; the field is
-// required by the request schema but its value is not used.
-const NAMESPACE_PLACEHOLDER = 'ignored-by-proxy';
 
 // Scope fields are independent label filters — any subset narrows the query
 // (e.g. build logs filter on workflowRunName alone).
@@ -93,20 +89,61 @@ const toLogRow = (e: ObsLogEntry): LogRow => ({
 export async function queryObsLogs(query: ObsLogsQuery): Promise<LogRow[]> {
   const body: ObsLogsQuery = {
     ...query,
-    searchScope: { namespace: NAMESPACE_PLACEHOLDER, ...query.searchScope },
     logLevels: query.logLevels.length > 0 ? query.logLevels : DEFAULT_LOG_LEVELS,
   };
   const json = await obsClient.post<{ logs?: ObsLogEntry[] }>(LOGS_QUERY_PATH, body);
   return (json?.logs ?? []).map(toLogRow);
 }
 
-export function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
+// The proxy filters on searchScope.namespace, which is the org's K8s namespace
+// (e.g. wc-019ecb37-a8449032). The BFF only
+// surfaces it as metadata on a WorkflowRun (build.namespace) or a Project
+// (project.namespaceName). Resolve it from there and memoize — runtime logs
+// poll on an interval, and the value is stable for the lookup target.
+const namespaceCache = new Map<string, Promise<string | undefined>>();
+
+async function resolveNamespace(opts: { componentId?: string; projectId?: string }): Promise<string | undefined> {
+  const key = opts.componentId ? `c:${opts.componentId}` : opts.projectId ? `p:${opts.projectId}` : '';
+  if (!key) return undefined;
+  let pending = namespaceCache.get(key);
+  if (!pending) {
+    pending = (async () => {
+      // Prefer a build's namespace (matches how the obs-proxy indexes build/
+      // runtime logs); fall back to the project's namespaceName when the target
+      // has no builds yet. projectName is optional on the builds route.
+      if (opts.componentId) {
+        const ns = await bff
+          .get<ListResponse<{ namespace?: string }>>(`/components/${seg(opts.componentId)}/builds`)
+          .then((r) => items(r)[0]?.namespace)
+          .catch(() => undefined);
+        if (ns) return ns;
+      }
+      if (opts.projectId) {
+        return bff
+          .get<{ namespaceName?: string }>(`/projects/${seg(opts.projectId)}`)
+          .then((p) => p?.namespaceName)
+          .catch(() => undefined);
+      }
+      return undefined;
+    })();
+    namespaceCache.set(key, pending);
+  }
+  const namespace = await pending;
+  // Don't cache an empty result — let a later call retry once builds exist.
+  if (!namespace) namespaceCache.delete(key);
+  return namespace;
+}
+
+export async function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
+  // A single entry means a specific integration was selected; multiple entries
+  // mean "all in project", which the project scope already covers.
+  const selectedComponent = req.componentIdList.length === 1 ? req.componentIdList[0] : undefined;
+  const namespace = await resolveNamespace({ componentId: selectedComponent, projectId: req.projectId });
   return queryObsLogs({
     searchScope: {
+      ...(namespace ? { namespace } : {}),
       project: req.projectId,
-      // A single entry means a specific integration was selected; multiple
-      // entries mean "all in project", which the project scope already covers.
-      ...(req.componentIdList.length === 1 ? { component: req.componentIdList[0] } : {}),
+      ...(selectedComponent ? { component: selectedComponent } : {}),
       environment: req.environmentId.toLowerCase(),
     },
     startTime: req.startTime,
@@ -118,11 +155,13 @@ export function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<LogRow
   });
 }
 
-export function fetchComponentLogs(req: ComponentLogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
+export async function fetchComponentLogs(req: ComponentLogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
+  // ComponentLogsRequest carries no project field; the scope filters on
+  // component + environment within the org namespace.
+  const namespace = await resolveNamespace({ componentId: req.componentId });
   return queryObsLogs({
-    // ComponentLogsRequest carries no project field; the scope filters on
-    // component + environment within the token's org.
     searchScope: {
+      ...(namespace ? { namespace } : {}),
       component: req.componentId,
       environment: req.environmentId.toLowerCase(),
     },


### PR DESCRIPTION
## Purpose
Build and runtime log queries sent searchScope.namespace="ignored-by-proxy", assuming the proxy resolves the org from the token. The proxy filters on that field, so the placeholder matched nothing: runtime logs returned empty and build logs silently fell back to the BFF /logs route.

Source the org's K8s namespace from BFF metadata (WorkflowRun.namespace / Project.namespaceName), and thread it into the proxy scope:
- builds.ts reads run.namespace and passes it with the workflowRunName.
- logs.ts resolves the namespace per lookup target (memoized) and includes it in the runtime-log scope.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.