### PR TITLE
[Devant Migration] Fetch build & runtime logs solely from obs-proxy with correct scope

### DIFF
--- a/ipaas/src/api/cloud/builds.ts
+++ b/ipaas/src/api/cloud/builds.ts
@@ -25,9 +25,7 @@
  * BuildRunLogs (init/build/deploy) from its task phases.
  *
  * The log text itself comes from the wso2cloud observability proxy, queried by
- * WorkflowRun name (see cloud/logs.ts). The BFF logs route
- * (GET /components/{name}/builds/{runId}/logs) is kept as a fallback for
- * deployments without the proxy.
+ * WorkflowRun name (see cloud/logs.ts) — the same source as runtime logs.
  */
 
 import type { BuildRunLogs, BuildStage, BuildStep } from '../../types/build';
@@ -49,9 +47,6 @@ interface BffBuildRun {
   startedAt?: string;
   completedAt?: string;
   tasks?: BffWorkflowTask[];
-  // The run's K8s namespace (the org namespace); the observability proxy filters
-  // log queries on it.
-  namespace?: string;
 }
 
 type StageKey = 'init' | 'build' | 'deploy';
@@ -122,7 +117,7 @@ async function fetchObsBuildLogText(runId: string, run: BffBuildRun): Promise<st
   const endTime = run.completedAt ? new Date(new Date(run.completedAt).getTime() + 10 * 60_000).toISOString() : new Date().toISOString();
   try {
     const rows = await queryObsLogs({
-      searchScope: { ...(run.namespace ? { namespace: run.namespace } : {}), workflowRunName: runId },
+      searchScope: { workflowRunName: runId },
       startTime,
       endTime,
       limit: 500,
@@ -138,16 +133,12 @@ async function fetchObsBuildLogText(runId: string, run: BffBuildRun): Promise<st
 
 // Fetch the run (for task phases → steps) and its log text (best-effort) and
 // synthesize the BuildRunLogs the stepper consumes. The build run is required;
-// the log text is sourced from the observability proxy, with the BFF logs
-// route as fallback when the proxy is unavailable or has nothing for the run.
+// the log text is sourced solely from the observability proxy (a null result
+// just leaves the stage log empty and the card shows the live step list).
 async function loadBuildRunLogs(componentId: string, runId: string, projectQuery: string): Promise<BuildRunLogs | null> {
   const run = await bff.get<BffBuildRun | null>(`/components/${seg(componentId)}/builds/${seg(runId)}${projectQuery}`).catch(() => null);
   if (!run) return null;
-  let rawLog = await fetchObsBuildLogText(runId, run);
-  if (rawLog === null) {
-    const bffLogs = await bff.get<BuildRunLogs | null>(`/components/${seg(componentId)}/builds/${seg(runId)}/logs${projectQuery}`).catch(() => null);
-    rawLog = bffLogs?.build?.log ?? null;
-  }
+  const rawLog = await fetchObsBuildLogText(runId, run);
   return buildRunLogsFromTasks(run, rawLog);
 }
 

--- a/ipaas/src/api/cloud/logs.ts
+++ b/ipaas/src/api/cloud/logs.ts
@@ -38,7 +38,6 @@ export const DEFAULT_LOG_LEVELS = ['INFO', 'DEBUG', 'ERROR', 'WARN'];
 // Scope fields are independent label filters — any subset narrows the query
 // (e.g. build logs filter on workflowRunName alone).
 export interface ObsLogsScope {
-  namespace?: string;
   project?: string;
   component?: string;
   environment?: string;
@@ -95,53 +94,34 @@ export async function queryObsLogs(query: ObsLogsQuery): Promise<LogRow[]> {
   return (json?.logs ?? []).map(toLogRow);
 }
 
-// The proxy filters on searchScope.namespace, which is the org's K8s namespace
-// (e.g. wc-019ecb37-a8449032). The BFF only
-// surfaces it as metadata on a WorkflowRun (build.namespace) or a Project
-// (project.namespaceName). Resolve it from there and memoize — runtime logs
-// poll on an interval, and the value is stable for the lookup target.
-const namespaceCache = new Map<string, Promise<string | undefined>>();
+// Runtime-log queries must carry the owning project, but ComponentLogsRequest
+// has no project field. The BFF surfaces it as WorkflowRun metadata
+// (build.projectName), so resolve it from the component's latest build and
+// memoize — runtime logs poll on an interval and the value is stable per
+// component.
+const projectByComponent = new Map<string, Promise<string | undefined>>();
 
-async function resolveNamespace(opts: { componentId?: string; projectId?: string }): Promise<string | undefined> {
-  const key = opts.componentId ? `c:${opts.componentId}` : opts.projectId ? `p:${opts.projectId}` : '';
-  if (!key) return undefined;
-  let pending = namespaceCache.get(key);
+async function resolveProject(componentId: string): Promise<string | undefined> {
+  let pending = projectByComponent.get(componentId);
   if (!pending) {
-    pending = (async () => {
-      // Prefer a build's namespace (matches how the obs-proxy indexes build/
-      // runtime logs); fall back to the project's namespaceName when the target
-      // has no builds yet. projectName is optional on the builds route.
-      if (opts.componentId) {
-        const ns = await bff
-          .get<ListResponse<{ namespace?: string }>>(`/components/${seg(opts.componentId)}/builds`)
-          .then((r) => items(r)[0]?.namespace)
-          .catch(() => undefined);
-        if (ns) return ns;
-      }
-      if (opts.projectId) {
-        return bff
-          .get<{ namespaceName?: string }>(`/projects/${seg(opts.projectId)}`)
-          .then((p) => p?.namespaceName)
-          .catch(() => undefined);
-      }
-      return undefined;
-    })();
-    namespaceCache.set(key, pending);
+    pending = bff
+      .get<ListResponse<{ projectName?: string }>>(`/components/${seg(componentId)}/builds`)
+      .then((r) => items(r)[0]?.projectName)
+      .catch(() => undefined);
+    projectByComponent.set(componentId, pending);
   }
-  const namespace = await pending;
+  const project = await pending;
   // Don't cache an empty result — let a later call retry once builds exist.
-  if (!namespace) namespaceCache.delete(key);
-  return namespace;
+  if (!project) projectByComponent.delete(componentId);
+  return project;
 }
 
-export async function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
+export function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
   // A single entry means a specific integration was selected; multiple entries
   // mean "all in project", which the project scope already covers.
   const selectedComponent = req.componentIdList.length === 1 ? req.componentIdList[0] : undefined;
-  const namespace = await resolveNamespace({ componentId: selectedComponent, projectId: req.projectId });
   return queryObsLogs({
     searchScope: {
-      ...(namespace ? { namespace } : {}),
       project: req.projectId,
       ...(selectedComponent ? { component: selectedComponent } : {}),
       environment: req.environmentId.toLowerCase(),
@@ -156,12 +136,12 @@ export async function fetchLogs(req: LogsRequest, _logsApiUrl: string): Promise<
 }
 
 export async function fetchComponentLogs(req: ComponentLogsRequest, _logsApiUrl: string): Promise<LogRow[]> {
-  // ComponentLogsRequest carries no project field; the scope filters on
-  // component + environment within the org namespace.
-  const namespace = await resolveNamespace({ componentId: req.componentId });
+  // ComponentLogsRequest carries no project field, but the proxy requires it;
+  // resolve the owning project from the component's builds.
+  const project = await resolveProject(req.componentId);
   return queryObsLogs({
     searchScope: {
-      ...(namespace ? { namespace } : {}),
+      ...(project ? { project } : {}),
       component: req.componentId,
       environment: req.environmentId.toLowerCase(),
     },


### PR DESCRIPTION
## Purpose
- Drop the BFF /components/{name}/builds/{runId}/logs fallback; build log text now comes only from the observability proxy (queried by workflowRunName).
- Remove the namespace field from every obs-proxy searchScope (build and runtime), and from the ObsLogsScope/BffBuildRun types.
- Runtime logs require the owning project in scope: fetchLogs uses the request's projectId; fetchComponentLogs resolves it from the component's latest build (memoized), since ComponentLogsRequest carries no project field.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.