### PR TITLE
Fix session timeout: redirect to login when SSO refresh token expires

### DIFF
--- a/frontend/src/api/graphql.ts
+++ b/frontend/src/api/graphql.ts
@@ -1,11 +1,22 @@
 import { authenticatedFetch } from '../auth/tokenManager';
 
+export class AuthError extends Error {
+  readonly status: number;
+  constructor(status: number) {
+    super(`Authentication failed (${status})`);
+    this.status = status;
+  }
+}
+
 export async function gql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
   const res = await authenticatedFetch(window.API_CONFIG.graphqlUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables }),
   });
+  if (res.status === 401) {
+    throw new AuthError(401);
+  }
   const json = await res.json();
   if (json.errors) throw new Error(json.errors[0].message);
   return json.data as T;

--- a/frontend/src/auth/tokenManager.ts
+++ b/frontend/src/auth/tokenManager.ts
@@ -52,6 +52,12 @@ export function isAccessTokenExpired(): boolean {
   return Date.now() >= Number(expiresAt) - EXPIRY_BUFFER_MS;
 }
 
+export function isRefreshTokenExpired(): boolean {
+  const expiresAt = localStorage.getItem(REFRESH_TOKEN_EXPIRES_AT_KEY);
+  if (!expiresAt) return true;
+  return Date.now() >= Number(expiresAt) - EXPIRY_BUFFER_MS;
+}
+
 export async function refreshAccessToken(): Promise<void> {
   if (refreshPromise) {
     await refreshPromise;
@@ -60,7 +66,7 @@ export async function refreshAccessToken(): Promise<void> {
 
   refreshPromise = (async () => {
     const refreshToken = getRefreshToken();
-    if (!refreshToken) {
+    if (!refreshToken || isRefreshTokenExpired()) {
       clearTokens();
       onAuthFailure?.();
       return;
@@ -113,10 +119,14 @@ export async function authenticatedFetch(url: string, options: RequestInit = {})
   if (res.status === 401) {
     await refreshAccessToken();
     const retryToken = getAccessToken();
-    const retryHeaders = new Headers(options.headers);
-    if (retryToken) {
-      retryHeaders.set('Authorization', `Bearer ${retryToken}`);
+    if (!retryToken) {
+      // Refresh failed — onAuthFailure already triggered navigation to login.
+      // Return the original 401 so callers receive a clean non-ok response
+      // instead of an unauthenticated retry that keeps the UI stuck loading.
+      return res;
     }
+    const retryHeaders = new Headers(options.headers);
+    retryHeaders.set('Authorization', `Bearer ${retryToken}`);
     return fetch(url, { ...options, headers: retryHeaders });
   }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,9 +27,18 @@ import { AuthProvider } from './auth/AuthContext';
 import { loadConfig } from './config/api';
 import { AccessControlProvider } from './contexts/AccessControlContext';
 import { NotificationsProvider } from './contexts/NotificationsContext';
+import { AuthError } from './api/graphql';
 import './index.css';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Never retry auth failures — the token is gone and navigation to login has already
+      // been triggered. Retrying only keeps the UI stuck in a loading state.
+      retry: (failureCount, error) => !(error instanceof AuthError) && failureCount < 3,
+    },
+  },
+});
 
 // Load runtime configuration before rendering the app
 loadConfig().then(() => {


### PR DESCRIPTION
## Problem

When ICP is configured with SSO (IS 7.2.0) and short token lifetimes (e.g. 60 s), after both the access token and refresh token expire the page keeps loading indefinitely instead of redirecting to the login page.

Reported in wso2/product-integrator-mi#4924.

Three bugs in the frontend combine to produce the symptom:

### Bug 1 — `authenticatedFetch` fires an unauthenticated retry after auth failure

When a 401 is received, `authenticatedFetch` calls `refreshAccessToken()`. If the refresh also fails, `onAuthFailure()` is called (which triggers `navigate(loginUrl())`). But the code then **continued** unconditionally:

```ts
// before — always ran even after onAuthFailure
const retryHeaders = new Headers(options.headers);
if (retryToken) { retryHeaders.set('Authorization', ...) }
return fetch(url, { ...options, headers: retryHeaders }); // fired with no token
```

React Query received the pending unauthenticated fetch and kept the UI in a loading state while navigation was simultaneously trying to happen.

**Fix:** return the original `401` response immediately when `getAccessToken()` is null after a failed refresh.

### Bug 2 — No local expiry check for the refresh token

`isAccessTokenExpired()` existed but there was no equivalent for the refresh token. `refreshAccessToken()` always made a network round-trip even when `icp_refresh_token_expires_at` in `localStorage` clearly showed the refresh token was already expired.

**Fix:** add `isRefreshTokenExpired()` and short-circuit in `refreshAccessToken()` when the refresh token is locally known to be expired.

### Bug 3 — QueryClient retried auth errors 3 times

`new QueryClient()` uses React Query's default retry policy (3 retries). Each 401 response was retried 3 more times before React Query surfaced an error, extending the visible loading state by several seconds.

**Fix:** configure `retry` to bail immediately for `AuthError` instances; non-auth failures still retry up to 3 times.

## Changes

| File | Change |
|---|---|
| `frontend/src/auth/tokenManager.ts` | Add `isRefreshTokenExpired()`. Short-circuit `refreshAccessToken()` on local expiry. Return original 401 from `authenticatedFetch` instead of unauthenticated retry. |
| `frontend/src/api/graphql.ts` | Add `AuthError` class; throw it on 401 before attempting `res.json()`. |
| `frontend/src/main.tsx` | Configure `QueryClient` to skip retries on `AuthError`. |

## Test plan

- [ ] SSO login → wait for both tokens to expire → confirm automatic redirect to login (no manual action required)
- [ ] SSO login → wait for access token to expire only (refresh token still valid) → confirm silent re-authentication continues working
- [ ] Non-SSO login → normal session expiry → confirm redirect to login unchanged
- [ ] Network error on a GraphQL query (non-auth) → confirm React Query still retries up to 3 times

Fixes wso2/product-integrator-mi#4924