### PR TITLE
[Devant migration] Render branded split-screen sign-in for cloud variant

### DIFF
--- a/ipaas/Dockerfile
+++ b/ipaas/Dockerfile
@@ -14,6 +14,9 @@ RUN corepack enable pnpm && corepack install -g pnpm@10
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# patchedDependencies in package.json reference these files; pnpm reads them
+# during install, so they must be present before `pnpm install` runs.
+COPY patches/ ./patches/
 
 # Cache mount: pnpm's content-addressable store persists across builds.
 # First build still does the cold download; subsequent installs just re-link.

--- a/ipaas/src/pages/Login.tsx
+++ b/ipaas/src/pages/Login.tsx
@@ -24,6 +24,7 @@ import { Link as NavLink, useSearchParams } from 'react-router';
 import { useAuth } from '../auth/AuthContext';
 import { privacyPolicyUrl, signupUrl } from '../paths';
 import AuthMarketingPanel from '../components/AuthMarketingPanel';
+import { IS_CLOUD } from '../features';
 
 function MicrosoftIcon() {
   return (
@@ -51,11 +52,15 @@ export default function Login(): JSX.Element {
   const [provider, setProvider] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // After email signup, Asgardeo redirects here with method=basic. Auto-trigger
+  // Cloud variant: the branded split-screen sign-in is hosted by Thunder (the IdP),
+  // so we don't render our own marketing + provider page. Hand off immediately to
+  // Thunder's authorize endpoint with no fidp, which renders its choose-auth screen.
+  //
+  // Non-cloud: after email signup, Asgardeo redirects here with method=basic. Auto-trigger
   // login without fidp so Asgardeo reuses the active session from org creation
   // rather than requiring LOCAL (password) auth which new accounts don't have.
   useEffect(() => {
-    if (searchParams.get('method') === 'basic') {
+    if (IS_CLOUD || searchParams.get('method') === 'basic') {
       setLoading(true);
       loginWithOIDC().catch((err) => {
         setLoading(false);
@@ -76,6 +81,23 @@ export default function Login(): JSX.Element {
       setProvider(null);
     }
   };
+
+  // Cloud variant renders no in-app sign-in UI — just a spinner while redirecting
+  // to Thunder's hosted branded split-screen page.
+  if (IS_CLOUD) {
+    return (
+      <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+        {error ? (
+          <Alert severity="error">{error}</Alert>
+        ) : (
+          <>
+            <CircularProgress />
+            <Typography variant="body1" color="text.secondary">Redirecting to sign in…</Typography>
+          </>
+        )}
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ height: '100vh', display: 'flex' }}>

--- a/ipaas/src/pages/Signup.tsx
+++ b/ipaas/src/pages/Signup.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { JSX } from 'react';
 import { Alert, Box, Button, CircularProgress, ColorSchemeImage, Divider, Grid, Link, Stack, Typography } from '@wso2/oxygen-ui';
 import { GitHub, Google, Mail } from '@wso2/oxygen-ui-icons-react';
@@ -24,6 +24,7 @@ import { Link as NavLink } from 'react-router';
 import { useAuth } from '../auth/AuthContext';
 import { loginUrl, privacyPolicyUrl } from '../paths';
 import AuthMarketingPanel from '../components/AuthMarketingPanel';
+import { IS_CLOUD } from '../features';
 
 function MicrosoftIcon() {
   return (
@@ -50,6 +51,16 @@ export default function Signup(): JSX.Element {
   const [provider, setProvider] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Cloud variant: sign-up is handled on Thunder's hosted branded split-screen page.
+  // Hand off immediately to Thunder's authorize endpoint (no fidp) instead of
+  // rendering our own marketing + provider page.
+  useEffect(() => {
+    if (IS_CLOUD) {
+      setLoading(true);
+      loginWithOIDC().catch((err) => { setLoading(false); setError(friendlyError(err)); });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const handleEmailSignup = () => {
     const origin = window.location.origin;
     const postRegisterCallback = `${origin}/login?method=basic&returnToUrl=%2F`;
@@ -75,6 +86,23 @@ export default function Signup(): JSX.Element {
       setProvider(null);
     }
   };
+
+  // Cloud variant renders no in-app sign-up UI — just a spinner while redirecting
+  // to Thunder's hosted branded split-screen page.
+  if (IS_CLOUD) {
+    return (
+      <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 2 }}>
+        {error ? (
+          <Alert severity="error">{error}</Alert>
+        ) : (
+          <>
+            <CircularProgress />
+            <Typography variant="body1" color="text.secondary">Redirecting to sign in…</Typography>
+          </>
+        )}
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ height: '100vh', display: 'flex' }}>


### PR DESCRIPTION
## Purpose
In the cloud (PRODUCT=cloud) build, the sign-in/sign-up pages no longer render the in-app AuthMarketingPanel + provider buttons. Instead they redirect via loginWithOIDC() with no fidp, so Thunder (the IdP) renders its hosted branded split-screen choose-auth page. A spinner is shown during the redirect.
    
Non-cloud (wip/icp) behavior is unchanged.

This screenshot shows the rendered split-screen ThunderId signin page layout with a temporary SVG file with marketing contents. 
<img width="1728" height="1044" alt="Screenshot 2026-07-02 at 11 29 32" src="https://github.com/user-attachments/assets/f745d5af-ba34-453e-9a49-8d6125a98dc2" />

<img width="1728" height="1043" alt="Screenshot 2026-07-02 at 11 29 56" src="https://github.com/user-attachments/assets/01620eaa-d9b0-4483-9611-af5dd81d0772" />


Proper SVG with marketing contents should be generated and hosted with the help of marketing team. 


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.