### PR TITLE
Fix optional component type GraphQL input crash

### DIFF
--- a/icp_server/modules/storage/component_repository.bal
+++ b/icp_server/modules/storage/component_repository.bal
@@ -24,7 +24,7 @@ import ballerina/uuid;
 // Create a new component
 public isolated function createComponent(types:ComponentInput component) returns types:Component|error? {
     string componentId = uuid:createType1AsString();
-    string componentTypeValue = component.componentType.toString();
+    string componentTypeValue = (component?.componentType ?: types:BI).toString();
 
     // Use displayName if provided, otherwise fall back to name
     string displayName = component?.displayName ?: component.name;

--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -1522,7 +1522,7 @@ public type ComponentInput record {
     string orgHandler?; // Organization handle
 
     // Component Classification (optional - can have defaults)
-    RuntimeType componentType?; // Runtime type: "BI" or "MI"
+    RuntimeType? componentType?; // Runtime type: "BI" or "MI"
     string technology?; // Technology: "WSO2MI", "Ballerina", etc.
 
     // Repository Integration (optional - for future use)
@@ -1544,7 +1544,7 @@ public type ComponentUpdateInput record {
     string name?;
     string displayName?;
     string description?;
-    RuntimeType componentType?;
+    RuntimeType? componentType?;
     string version?;
     string labels?;
     string serviceAccessMode?;

--- a/icp_server/tests/component_graphql_tests.bal
+++ b/icp_server/tests/component_graphql_tests.bal
@@ -280,7 +280,80 @@ function testCreateComponentSuccess() returns error? {
 }
 
 // =============================================================================
-// Test 8: Create component - Fails without manage permission
+// Test 8: Create component - Success without component type
+// =============================================================================
+
+@test:Config {
+    groups: ["component-graphql", "create-component"]
+}
+function testCreateComponentWithoutComponentType() returns error? {
+    string mutation = string `
+        mutation CreateComponent($component: ComponentInput!) {
+            createComponent(component: $component) {
+                id
+                name
+                componentType
+            }
+        }
+    `;
+
+    json variables = {
+        component: {
+            name: "test-integration-default-type",
+            displayName: "Test Integration Default Type",
+            description: "Test component without componentType",
+            projectId: PROJECT_1_ID
+        }
+    };
+
+    json response = check executeGraphQL(mutation, project1AdminToken, variables);
+
+    test:assertFalse(response.errors is json, "Mutation should not return errors");
+
+    json data = check response.data;
+    json component = check data.createComponent;
+    string componentType = check component.componentType;
+    test:assertEquals(componentType, "BI", "Should default component type to BI");
+}
+
+// =============================================================================
+// Test 9: Update component - Success without component type
+// =============================================================================
+
+@test:Config {
+    groups: ["component-graphql", "update-component"]
+}
+function testUpdateComponentWithoutComponentType() returns error? {
+    string mutation = string `
+        mutation UpdateComponent($component: ComponentUpdateInput!) {
+            updateComponent(component: $component) {
+                id
+                displayName
+                description
+            }
+        }
+    `;
+
+    json variables = {
+        component: {
+            id: COMPONENT_2_ID,
+            displayName: "Component Two Updated",
+            description: "Updated without componentType"
+        }
+    };
+
+    json response = check executeGraphQL(mutation, project1AdminToken, variables);
+
+    test:assertFalse(response.errors is json, "Mutation should not return errors");
+
+    json data = check response.data;
+    json component = check data.updateComponent;
+    string displayName = check component.displayName;
+    test:assertEquals(displayName, "Component Two Updated", "Should update component");
+}
+
+// =============================================================================
+// Test 10: Create component - Fails without manage permission
 // =============================================================================
 
 @test:Config {


### PR DESCRIPTION
## Purpose

Fixes wso2/product-integrator#1796.

`ComponentInput.componentType` and `ComponentUpdateInput.componentType` were optional enum fields. When omitted in GraphQL variables, the Ballerina GraphQL runtime panicked while converting the absent enum value before the resolver could handle the request.

## Changes

- Make optional component type fields nilable optional enum fields.
- Default omitted `componentType` to `BI` when creating components.
- Add GraphQL regression coverage for:
  - `createComponent` without `componentType`
  - `updateComponent` without `componentType`

## Verification

- `bal build` in `icp_server` succeeded.
- Verified `createComponent` and `updateComponent` mutations without `componentType` return `200` and the server remains reachable.
