### PR TITLE
[Devant migration] feat(cloud): env-var configs/secrets + env id/deploy fix

### DIFF
--- a/ipaas/src/api/cloud/devopsConfigs.ts
+++ b/ipaas/src/api/cloud/devopsConfigs.ts
@@ -87,9 +87,34 @@ const componentDeferred = (env: string) => {
   return d;
 };
 const setComponentForEnv = (env: string, componentId: string): void => componentDeferred(env).resolve(componentId);
-const componentForEnv = (env: string): Promise<string> => componentDeferred(env).promise;
+
+// Bound the wait: an env whose component is never deployed never resolves the
+// deferred, so cap it and yield '' (→ empty list) instead of a query that pends
+// forever. Per-call and non-poisoning — the deferred stays unresolved, so a later
+// call still sees the real component once the release read runs.
+const COMPONENT_WAIT_MS = 8000;
+const componentForEnv = (env: string): Promise<string> =>
+  Promise.race([componentDeferred(env).promise, new Promise<string>((resolve) => setTimeout(() => resolve(''), COMPONENT_WAIT_MS))]);
 
 const filesBase = (componentId: string, env: string): string => `/components/${seg(componentId)}/environments/${seg(env)}`;
+
+// Coalesce the concurrent env-group reads a page load fires (getContainerConfig-
+// Mounts + getConfigMaps + getSecrets all read the same list): share the in-flight
+// request per (component, env). Dropped on settle, so a refetch after a mutation
+// reloads fresh. Errors degrade to [] (matches the file-mount read).
+const inflightEnvGroups = new Map<string, Promise<BffEnvGroup[]>>();
+const fetchEnvGroups = (componentId: string, projectId: string, env: string): Promise<BffEnvGroup[]> => {
+  const key = `${componentId} ${env}`;
+  const existing = inflightEnvGroups.get(key);
+  if (existing) return existing;
+  const promise = bff
+    .get<{ groups?: BffEnvGroup[] }>(`${filesBase(componentId, env)}/env-groups${q({ projectName: projectId })}`)
+    .then((r) => r?.groups ?? [])
+    .catch(() => [] as BffEnvGroup[])
+    .finally(() => inflightEnvGroups.delete(key));
+  inflightEnvGroups.set(key, promise);
+  return promise;
+};
 
 // File mount → config-mount. GET /files returns content-free metadata.
 const toFileMount = (f: BffFileMount, env: string, releaseId: string): DevopsConfigMount => ({
@@ -165,8 +190,7 @@ const putEnvGroup = async (projectId: string, env: string, name: string, sensiti
 const listEnvGroups = async (projectId: string, env: string): Promise<BffEnvGroup[]> => {
   const componentId = await componentForEnv(env);
   if (!componentId) return [];
-  const r = await bff.get<{ groups?: BffEnvGroup[] }>(`${filesBase(componentId, env)}/env-groups${q({ projectName: projectId })}`).catch(() => null);
-  return r?.groups ?? [];
+  return fetchEnvGroups(componentId, projectId, env);
 };
 
 // ── release (synthetic container carrying the resolved env) ────────────────────
@@ -252,11 +276,11 @@ export const getContainerConfigMounts = async (_orgUuid: string, projectId: stri
   const env = containerId; // carried through from getReleaseById
   if (!env) return [];
   setComponentForEnv(env, componentId);
-  const [filesR, groupsR] = await Promise.all([
+  const [filesR, groups] = await Promise.all([
     bff.get<{ files?: BffFileMount[] }>(`${filesBase(componentId, env)}/files${q({ projectName: projectId })}`).catch(() => null),
-    bff.get<{ groups?: BffEnvGroup[] }>(`${filesBase(componentId, env)}/env-groups${q({ projectName: projectId })}`).catch(() => null),
+    fetchEnvGroups(componentId, projectId, env),
   ]);
-  return [...(filesR?.files ?? []).map((f) => toFileMount(f, env, releaseId)), ...(groupsR?.groups ?? []).map((g) => toEnvMount(g, env, releaseId))];
+  return [...(filesR?.files ?? []).map((f) => toFileMount(f, env, releaseId)), ...groups.map((g) => toEnvMount(g, env, releaseId))];
 };
 
 // On create, the hook mounts the config after creating it. Env-var groups are

--- a/ipaas/src/api/cloud/devopsConfigs.ts
+++ b/ipaas/src/api/cloud/devopsConfigs.ts
@@ -69,32 +69,39 @@ interface BffEnvGroup {
   data?: Record<string, string>;
 }
 
-// Per-env promise of the component id, resolved by the release/mounts reads (the
-// only reads carrying the component). Env-scoped reads await it. It only ever
-// resolves once per env; not-deployed envs never render the list, so a pending
-// promise there is benign (no network, data defaults to []).
-const componentPromises = new Map<string, { promise: Promise<string>; resolve: (id: string) => void }>();
-const componentDeferred = (env: string) => {
-  let d = componentPromises.get(env);
-  if (!d) {
-    let resolve!: (id: string) => void;
-    const promise = new Promise<string>((r) => {
-      resolve = r;
-    });
-    d = { promise, resolve };
-    componentPromises.set(env, d);
+// The env-scoped reads (getConfigMaps/getSecrets/getConfigMapDetails) receive an
+// env + name but not the component, while the endpoints are component-scoped. The
+// release/mounts reads (which DO carry the component) publish the latest component
+// per env here; the env-scoped reads read it. It is a LATEST-WINS value, not a
+// one-shot promise, so navigating between components that share an environment
+// re-points to the current component instead of pinning the first one seen.
+const componentByEnv = new Map<string, string>();
+const componentWaiters = new Map<string, Array<(id: string) => void>>();
+const setComponentForEnv = (env: string, componentId: string): void => {
+  if (!componentId) return;
+  componentByEnv.set(env, componentId);
+  const waiters = componentWaiters.get(env);
+  if (waiters) {
+    componentWaiters.delete(env);
+    waiters.forEach((w) => w(componentId));
   }
-  return d;
 };
-const setComponentForEnv = (env: string, componentId: string): void => componentDeferred(env).resolve(componentId);
 
-// Bound the wait: an env whose component is never deployed never resolves the
-// deferred, so cap it and yield '' (→ empty list) instead of a query that pends
-// forever. Per-call and non-poisoning — the deferred stays unresolved, so a later
-// call still sees the real component once the release read runs.
+// Resolve the current component for an env. Returns the latest known value
+// immediately; otherwise waits for the first publish, bounded by COMPONENT_WAIT_MS
+// so an env whose component is never deployed yields '' (→ empty list) rather than
+// a query that pends forever.
 const COMPONENT_WAIT_MS = 8000;
-const componentForEnv = (env: string): Promise<string> =>
-  Promise.race([componentDeferred(env).promise, new Promise<string>((resolve) => setTimeout(() => resolve(''), COMPONENT_WAIT_MS))]);
+const componentForEnv = (env: string): Promise<string> => {
+  const known = componentByEnv.get(env);
+  if (known) return Promise.resolve(known);
+  return new Promise<string>((resolve) => {
+    const waiters = componentWaiters.get(env) ?? [];
+    waiters.push(resolve);
+    componentWaiters.set(env, waiters);
+    setTimeout(() => resolve(componentByEnv.get(env) ?? ''), COMPONENT_WAIT_MS);
+  });
+};
 
 const filesBase = (componentId: string, env: string): string => `/components/${seg(componentId)}/environments/${seg(env)}`;
 

--- a/ipaas/src/api/cloud/devopsConfigs.ts
+++ b/ipaas/src/api/cloud/devopsConfigs.ts
@@ -20,26 +20,29 @@
  * Cloud (OpenChoreo) devops config API. Calls the ipaas-service BFF.
  *
  * The Configs & Secrets page speaks devant's ConfigMap/Secret + config-mount
- * model, but OpenChoreo exposes only a flat per-(component, environment) file
- * mount surface:
- *   GET    /components/{c}/environments/{e}/files
- *   PUT    /components/{c}/environments/{e}/files/{fileName}
- *   DELETE /components/{c}/environments/{e}/files/{fileName}?mountPath=…
- * so this layer maps every file mount onto the devant shapes it expects:
- *   - `fileName` is the shared id (ConfigMap/Secret `ID` == config-mount `ID`),
- *     so `buildConfigRows` joins mounts to sources and the editor's mount/config
- *     ids round-trip.
- *   - the `sensitive` flag distinguishes a Secret (secret_id set) from a
- *     ConfigMap (configmap_id set).
- *   - env-scoped ConfigMap/Secret lists have no counterpart, so getConfigMaps/
- *     getSecrets return []; the mounts call is the sole source of rows.
- *   - getConfigMapDetails fetches a single non-secret file's content on edit so
- *     the editor prefills it; secret content is secret-backed and unreadable, so
- *     it stays empty (re-entered).
+ * model. OpenChoreo exposes two flat per-(component, environment) surfaces the
+ * BFF fronts:
+ *   - File mounts:  GET/PUT/DELETE  /components/{c}/environments/{e}/files[/{fileName}]
+ *   - Env-var groups: GET/PUT/DELETE /components/{c}/environments/{e}/env-groups[/{name}]
+ *     (a named bundle of KEY=value pairs; the BFF's workaround for the config
+ *     groups OpenChoreo lacks natively — Ballerina bundles them into Config.toml,
+ *     others get raw env vars).
+ * This layer maps both onto the devant shapes the page expects:
+ *   - the shared id is the file name (file mounts) or the group name (env vars),
+ *     used as both the ConfigMap/Secret `ID` and the config-mount `ID`/`mountId`,
+ *     so `buildConfigRows` joins mounts to sources and the editor ids round-trip.
+ *   - `sensitive` distinguishes a Secret (secret_id set) from a ConfigMap.
+ *   - file mounts are `mount_type:'File'`; env-var groups are `'ENVFile'`, which
+ *     `mountKind` classifies as the "envVars" editor kind.
+ *   - getConfigMaps/getSecrets list env-var groups (with their keys); file mounts
+ *     have no env-scoped source and surface only via getContainerConfigMounts.
+ *   - getConfigMapDetails fetches a group's values / a file's content on edit so
+ *     the editor prefills; secret values are write-only (re-entered).
  *
- * Only File Mounts are backed. The Environment Variables kind has no BFF route
- * (that surface is the schema-driven config-schema wired in configuration.ts),
- * so mount operations reject a non-File mount type.
+ * Env-scoped reads (getConfigMaps/getSecrets/getConfigMapDetails) receive an env
+ * + name but not the component, while the endpoints are component-scoped. The
+ * release/mounts reads (which carry the component and run first) publish the
+ * component per env via `componentForEnv`; the env-scoped readers await it.
  */
 
 import { bff, items, q, seg, type ListResponse } from './_client';
@@ -58,15 +61,38 @@ interface BffFileMount {
   content?: string;
 }
 
-// getConfigMapDetails (which prefills the editor) receives the env + fileName but
-// not the component, yet the file endpoint is component-scoped. The Configs page
-// always lists a component+environment's files (getContainerConfigMounts) before
-// any edit is possible, so record that exact scope here and reuse it verbatim to
-// fetch one file's content.
-let lastFileScope: { componentId: string; env: string } | null = null;
+interface BffEnvGroup {
+  name: string;
+  sensitive: boolean;
+  keys?: string[];
+  /** KEY→value map; only on the single-group GET, redacted for secret groups. */
+  data?: Record<string, string>;
+}
 
-// GET /files returns content-free metadata; the file's identity is its name.
-const toMount = (f: BffFileMount, env: string, releaseId: string): DevopsConfigMount => ({
+// Per-env promise of the component id, resolved by the release/mounts reads (the
+// only reads carrying the component). Env-scoped reads await it. It only ever
+// resolves once per env; not-deployed envs never render the list, so a pending
+// promise there is benign (no network, data defaults to []).
+const componentPromises = new Map<string, { promise: Promise<string>; resolve: (id: string) => void }>();
+const componentDeferred = (env: string) => {
+  let d = componentPromises.get(env);
+  if (!d) {
+    let resolve!: (id: string) => void;
+    const promise = new Promise<string>((r) => {
+      resolve = r;
+    });
+    d = { promise, resolve };
+    componentPromises.set(env, d);
+  }
+  return d;
+};
+const setComponentForEnv = (env: string, componentId: string): void => componentDeferred(env).resolve(componentId);
+const componentForEnv = (env: string): Promise<string> => componentDeferred(env).promise;
+
+const filesBase = (componentId: string, env: string): string => `/components/${seg(componentId)}/environments/${seg(env)}`;
+
+// File mount → config-mount. GET /files returns content-free metadata.
+const toFileMount = (f: BffFileMount, env: string, releaseId: string): DevopsConfigMount => ({
   ID: f.fileName,
   configmap_id: f.sensitive ? null : f.fileName,
   secret_id: f.sensitive ? f.fileName : null,
@@ -78,16 +104,30 @@ const toMount = (f: BffFileMount, env: string, releaseId: string): DevopsConfigM
   mount_permissions: '0644',
 });
 
+// Env-var group → an ENVFile config-mount (mountKind → "envVars").
+const toEnvMount = (g: BffEnvGroup, env: string, releaseId: string): DevopsConfigMount => ({
+  ID: g.name,
+  configmap_id: g.sensitive ? null : g.name,
+  secret_id: g.sensitive ? g.name : null,
+  container_id: env,
+  app_environment_id: releaseId,
+  mount_path: '',
+  config_key: '',
+  mount_type: 'ENVFile',
+  mount_permissions: '0000',
+});
+
 // The BFF upserts a file (content + mountPath + sensitivity) in one PUT, but the
-// Configs hook creates the config/secret (which carries the content) and then
-// mounts it (which carries the mountPath) as two calls. Stage the content by
-// fileName between the two so the mount call can issue the combined PUT.
+// Configs hook creates the config/secret (content) and then mounts it (mountPath)
+// as two calls. Stage the content by fileName between the two so the mount call
+// can issue the combined PUT. (Env-var groups need no staging — the group PUT
+// carries everything and happens in create/update directly.)
 interface PendingFile {
   content: string;
   sensitive: boolean;
 }
 const pendingFiles = new Map<string, PendingFile>();
-const stage = (fileName: string, data: { data?: Record<string, string> }, sensitive: boolean): void => {
+const stageFile = (fileName: string, data: { data?: Record<string, string> }, sensitive: boolean): void => {
   pendingFiles.set(fileName, { content: data.data?.data ?? '', sensitive });
 };
 
@@ -105,7 +145,7 @@ const envForRelease = (componentId: string, releaseId: string): Promise<string> 
 const putFile = (componentId: string, projectId: string, env: string, fileName: string, mountPath: string, secretIdSet: boolean): Promise<unknown> => {
   const staged = pendingFiles.get(fileName);
   pendingFiles.delete(fileName);
-  return bff.put(`/components/${seg(componentId)}/environments/${seg(env)}/files/${seg(fileName)}${q({ projectName: projectId })}`, {
+  return bff.put(`${filesBase(componentId, env)}/files/${seg(fileName)}${q({ projectName: projectId })}`, {
     fileName,
     mountPath,
     content: staged?.content ?? '',
@@ -114,8 +154,19 @@ const putFile = (componentId: string, projectId: string, env: string, fileName: 
   });
 };
 
-const assertFileMount = (mountType: unknown): void => {
-  if (mountType !== 'File') throw new Error('[cloud] devopsConfigs: environment-variable configs are not supported on OpenChoreo (file mounts only)');
+// PUT a whole env-var group. The component is not on the create/update signatures
+// (they carry only the env via data.environment_id), so resolve it per env.
+const putEnvGroup = async (projectId: string, env: string, name: string, sensitive: boolean, data: Record<string, string>): Promise<void> => {
+  const componentId = await componentForEnv(env);
+  if (!componentId) return;
+  await bff.put(`${filesBase(componentId, env)}/env-groups/${seg(name)}${q({ projectName: projectId })}`, { name, sensitive, data });
+};
+
+const listEnvGroups = async (projectId: string, env: string): Promise<BffEnvGroup[]> => {
+  const componentId = await componentForEnv(env);
+  if (!componentId) return [];
+  const r = await bff.get<{ groups?: BffEnvGroup[] }>(`${filesBase(componentId, env)}/env-groups${q({ projectName: projectId })}`).catch(() => null);
+  return r?.groups ?? [];
 };
 
 // ── release (synthetic container carrying the resolved env) ────────────────────
@@ -125,81 +176,105 @@ const assertFileMount = (mountType: unknown): void => {
 // functions — which receive containerId but not envId — read the env off it.
 export const getReleaseById = async (_orgUuid: string, _projectId: string, componentId: string, releaseId: string): Promise<ReleaseDetails> => {
   const env = await envForRelease(componentId, releaseId);
-  if (env) lastFileScope = { componentId, env }; // let getConfigMapDetails address this env's files
+  if (env) setComponentForEnv(env, componentId);
   const containers: ReleaseContainer[] = env ? [{ ID: env, name: env, type: 'MAIN' }] : [];
   return { ID: releaseId, containers };
 };
 
-// ── secrets / config maps (env-scoped lists have no OpenChoreo counterpart) ────
+// ── config maps / secrets = env-var groups (files have no env-scoped source) ───
 
-export const getSecrets = (_orgUuid: string, _projectId: string, _environmentId: string): Promise<DevopsSecret[]> => Promise.resolve([]);
+const toConfigMap = (g: BffEnvGroup, environmentId: string): DevopsConfigMap => ({ ID: g.name, name: g.name, environment_id: environmentId, app_environment_id: '', version: 1, config_type: 'VariableList', keys: g.keys ?? [] });
+const toSecret = (g: BffEnvGroup, environmentId: string): DevopsSecret => ({ ID: g.name, name: g.name, environment_id: environmentId, app_environment_id: '', keys: g.keys ?? [], version: 1, config_type: 'VariableList', secret_type: 'Opaque' });
 
+export const getConfigMaps = async (_orgUuid: string, projectId: string, environmentId: string): Promise<DevopsConfigMap[]> =>
+  (await listEnvGroups(projectId, environmentId)).filter((g) => !g.sensitive).map((g) => toConfigMap(g, environmentId));
+
+export const getSecrets = async (_orgUuid: string, projectId: string, environmentId: string): Promise<DevopsSecret[]> =>
+  (await listEnvGroups(projectId, environmentId)).filter((g) => g.sensitive).map((g) => toSecret(g, environmentId));
+
+// Secret values are write-only; the page never reads secret details (the editor
+// re-enters them from the row's keys), so a benign redacted default suffices.
 export const getSecretDetails = (_orgUuid: string, _projectId: string, environmentId: string, secretId: string): Promise<DevopsSecretDetails> =>
-  Promise.resolve({ ID: secretId, name: secretId, environment_id: environmentId, app_environment_id: '', keys: [], version: 1, config_type: 'File', secret_type: 'Opaque', data: null });
+  Promise.resolve({ ID: secretId, name: secretId, environment_id: environmentId, app_environment_id: '', keys: [], version: 1, config_type: 'VariableList', secret_type: 'Opaque', data: null });
 
-export const getConfigMaps = (_orgUuid: string, _projectId: string, _environmentId: string): Promise<DevopsConfigMap[]> => Promise.resolve([]);
-
-// Fetch a single non-secret file's content on edit so the editor prefills it.
-// The component is not on this signature, so reuse the (component, env) scope the
-// list read recorded — the same one that surfaced this file. Secret content is
-// unretrievable → empty (re-entered); a 404 also degrades to empty.
+// On edit, prefill values. The id can be an env-var group (→ its KEY=value map)
+// or a file mount (→ its content under `data`); try the group first, fall back to
+// the file. Secret values are unreadable → empty (re-entered); a 404 → empty.
 export const getConfigMapDetails = async (_orgUuid: string, projectId: string, environmentId: string, configMapId: string): Promise<DevopsConfigMapDetails> => {
   const base: DevopsConfigMapDetails = { ID: configMapId, name: configMapId, environment_id: environmentId, app_environment_id: '', version: 1, config_type: 'File', keys: [], data: { data: '' } };
-  if (!lastFileScope) return base;
-  const { componentId, env } = lastFileScope;
-  const file = await bff
-    .get<BffFileMount>(`/components/${seg(componentId)}/environments/${seg(env)}/files/${seg(configMapId)}${q({ projectName: projectId })}`)
-    .catch(() => null);
+  const componentId = await componentForEnv(environmentId);
+  if (!componentId) return base;
+  const group = await bff.get<BffEnvGroup>(`${filesBase(componentId, environmentId)}/env-groups/${seg(configMapId)}${q({ projectName: projectId })}`).catch(() => null);
+  if (group) return { ...base, config_type: 'VariableList', keys: group.keys ?? [], data: group.data ?? {} };
+  const file = await bff.get<BffFileMount>(`${filesBase(componentId, environmentId)}/files/${seg(configMapId)}${q({ projectName: projectId })}`).catch(() => null);
   return { ...base, data: { data: file?.content ?? '' } };
 };
 
-// Create/update stage the content; the paired mount call issues the PUT. The
-// returned record only needs a valid `ID` (== fileName) for the hook to proceed.
-export const createSecret = (_orgUuid: string, _projectId: string, data: SecretWriteData): Promise<DevopsSecret> => {
-  stage(data.name, data, true);
-  return Promise.resolve({ ID: data.name, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', keys: Object.keys(data.data ?? {}), version: 1, config_type: data.config_type, secret_type: data.secret_type });
+// ── create / update ────────────────────────────────────────────────────────────
+// Env-var groups (config_type 'VariableList') PUT the whole group here — the hook
+// does not re-mount env-var edits. File mounts (config_type 'File') stage their
+// content; the paired mount call issues the combined PUT.
+
+const isEnvVars = (configType: string): boolean => configType === 'VariableList';
+
+export const createSecret = async (_orgUuid: string, _projectId: string, data: SecretWriteData): Promise<DevopsSecret> => {
+  if (isEnvVars(data.config_type)) await putEnvGroup(data.project_id, data.environment_id, data.name, true, data.data ?? {});
+  else stageFile(data.name, data, true);
+  return { ID: data.name, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', keys: Object.keys(data.data ?? {}), version: 1, config_type: data.config_type, secret_type: data.secret_type };
 };
 
-export const updateSecret = (_orgUuid: string, _projectId: string, secretId: string, data: SecretWriteData): Promise<DevopsSecret> => {
-  stage(secretId, data, true);
-  return Promise.resolve({ ID: secretId, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', keys: Object.keys(data.data ?? {}), version: 1, config_type: data.config_type, secret_type: data.secret_type });
+export const updateSecret = async (_orgUuid: string, _projectId: string, secretId: string, data: SecretWriteData): Promise<DevopsSecret> => {
+  if (isEnvVars(data.config_type)) await putEnvGroup(data.project_id, data.environment_id, secretId, true, data.data ?? {});
+  else stageFile(secretId, data, true);
+  return { ID: secretId, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', keys: Object.keys(data.data ?? {}), version: 1, config_type: data.config_type, secret_type: data.secret_type };
 };
 
-export const createConfigMap = (_orgUuid: string, _projectId: string, data: ConfigMapWriteData): Promise<DevopsConfigMap> => {
-  stage(data.name, data, false);
-  return Promise.resolve({ ID: data.name, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', version: 1, config_type: data.config_type, keys: Object.keys(data.data ?? {}) });
+export const createConfigMap = async (_orgUuid: string, _projectId: string, data: ConfigMapWriteData): Promise<DevopsConfigMap> => {
+  if (isEnvVars(data.config_type)) await putEnvGroup(data.project_id, data.environment_id, data.name, false, data.data ?? {});
+  else stageFile(data.name, data, false);
+  return { ID: data.name, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', version: 1, config_type: data.config_type, keys: Object.keys(data.data ?? {}) };
 };
 
-export const updateConfigMapData = (_orgUuid: string, _projectId: string, configMapId: string, data: ConfigMapWriteData): Promise<DevopsConfigMapDetails> => {
-  stage(configMapId, data, false);
-  return Promise.resolve({ ID: configMapId, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', version: 1, config_type: data.config_type, keys: Object.keys(data.data ?? {}), data: data.data ?? {} });
+export const updateConfigMapData = async (_orgUuid: string, _projectId: string, configMapId: string, data: ConfigMapWriteData): Promise<DevopsConfigMapDetails> => {
+  if (isEnvVars(data.config_type)) await putEnvGroup(data.project_id, data.environment_id, configMapId, false, data.data ?? {});
+  else stageFile(configMapId, data, false);
+  return { ID: configMapId, name: data.name, environment_id: data.environment_id, app_environment_id: data.app_environment_id ?? '', version: 1, config_type: data.config_type, keys: Object.keys(data.data ?? {}), data: data.data ?? {} };
 };
 
-// Env-scoped deletes lack a component, so they cannot address a file; the page
-// deletes by unmounting (removeConfigMount) instead. Kept as benign no-ops.
+// Env-scoped deletes lack a component, so they cannot address a group/file; the
+// page deletes by unmounting (removeConfigMount) instead. Kept as benign no-ops.
 export const deleteSecret = (_orgUuid: string, _projectId: string, _environmentId: string, _secretId: string): Promise<void> => Promise.resolve();
 export const deleteConfigMap = (_orgUuid: string, _projectId: string, _environmentId: string, _configMapId: string): Promise<void> => Promise.resolve();
 
-// ── container config mounts (the sole source of config rows) ───────────────────
+// ── container config mounts (files + env-var groups) ───────────────────────────
 
-export const getContainerConfigMounts = (_orgUuid: string, projectId: string, componentId: string, releaseId: string, containerId: string): Promise<DevopsConfigMount[]> => {
+export const getContainerConfigMounts = async (_orgUuid: string, projectId: string, componentId: string, releaseId: string, containerId: string): Promise<DevopsConfigMount[]> => {
   const env = containerId; // carried through from getReleaseById
-  if (!env) return Promise.resolve([]);
-  lastFileScope = { componentId, env }; // let getConfigMapDetails address these files
-  return bff.get<{ files?: BffFileMount[] }>(`/components/${seg(componentId)}/environments/${seg(env)}/files${q({ projectName: projectId })}`).then((r) => (r?.files ?? []).map((f) => toMount(f, env, releaseId)));
+  if (!env) return [];
+  setComponentForEnv(env, componentId);
+  const [filesR, groupsR] = await Promise.all([
+    bff.get<{ files?: BffFileMount[] }>(`${filesBase(componentId, env)}/files${q({ projectName: projectId })}`).catch(() => null),
+    bff.get<{ groups?: BffEnvGroup[] }>(`${filesBase(componentId, env)}/env-groups${q({ projectName: projectId })}`).catch(() => null),
+  ]);
+  return [...(filesR?.files ?? []).map((f) => toFileMount(f, env, releaseId)), ...(groupsR?.groups ?? []).map((g) => toEnvMount(g, env, releaseId))];
 };
 
+// On create, the hook mounts the config after creating it. Env-var groups are
+// already fully written by createConfigMap/createSecret, so the ENVFile mount is
+// a no-op that echoes a synthetic mount; file mounts issue the combined PUT here.
 export const mountConfig = async (_orgUuid: string, projectId: string, componentId: string, data: ConfigMountWriteData): Promise<DevopsConfigMount> => {
-  assertFileMount(data.mount_type);
-  const fileName = data.configmap_id ?? data.secret_id ?? '';
-  const env = data.container_id;
+  const id = data.configmap_id ?? data.secret_id ?? '';
+  if (data.mount_type !== 'File') {
+    return { ID: id, configmap_id: data.configmap_id, secret_id: data.secret_id, container_id: data.container_id, app_environment_id: data.app_environment_id, mount_path: '', config_key: '', mount_type: data.mount_type, mount_permissions: data.mount_permissions };
+  }
   const mountPath = data.mount_path ?? '';
-  await putFile(componentId, projectId, env, fileName, mountPath, !!data.secret_id);
-  return { ID: fileName, configmap_id: data.configmap_id, secret_id: data.secret_id, container_id: env, app_environment_id: data.app_environment_id, mount_path: mountPath, config_key: data.config_key ?? 'data', mount_type: 'File', mount_permissions: data.mount_permissions };
+  await putFile(componentId, projectId, data.container_id, id, mountPath, !!data.secret_id);
+  return { ID: id, configmap_id: data.configmap_id, secret_id: data.secret_id, container_id: data.container_id, app_environment_id: data.app_environment_id, mount_path: mountPath, config_key: data.config_key ?? 'data', mount_type: 'File', mount_permissions: data.mount_permissions };
 };
 
+// The hook only updates a mount for file-mount edits (mount path is editable);
+// env-var edits update the group via updateConfigMapData/updateSecret instead.
 export const updateConfigMount = async (_orgUuid: string, projectId: string, path: ConfigMountPath, data: Record<string, unknown>): Promise<DevopsConfigMount> => {
-  assertFileMount(data.mount_type);
   const fileName = path.mountId;
   const env = path.containerId;
   const mountPath = (data.mount_path as string) ?? '';
@@ -208,13 +283,20 @@ export const updateConfigMount = async (_orgUuid: string, projectId: string, pat
   return { ID: fileName, configmap_id: (data.configmap_id as string | null) ?? null, secret_id: secretId, container_id: env, app_environment_id: env, mount_path: mountPath, config_key: 'data', mount_type: 'File', mount_permissions: (data.mount_permissions as string | null) ?? '0644' };
 };
 
-// DELETE requires the mount path, which the caller does not carry, so resolve it
-// from the current file list first. A file that is already gone is a no-op.
+// Unmount = delete. The id is an env-var group or a file mount; delete the group
+// if it exists, else resolve the file's mount path and delete the file. A config
+// already gone is a no-op. path carries the component, so no env→component lookup.
 export const removeConfigMount = async (_orgUuid: string, projectId: string, path: ConfigMountPath): Promise<void> => {
   const env = path.containerId;
-  const fileName = path.mountId;
-  const list = await bff.get<{ files?: BffFileMount[] }>(`/components/${seg(path.componentId)}/environments/${seg(env)}/files${q({ projectName: projectId })}`);
-  const file = (list?.files ?? []).find((f) => f.fileName === fileName);
+  const name = path.mountId;
+  const base = filesBase(path.componentId, env);
+  const group = await bff.get<BffEnvGroup>(`${base}/env-groups/${seg(name)}${q({ projectName: projectId })}`).catch(() => null);
+  if (group) {
+    await bff.delete(`${base}/env-groups/${seg(name)}${q({ projectName: projectId })}`);
+    return;
+  }
+  const list = await bff.get<{ files?: BffFileMount[] }>(`${base}/files${q({ projectName: projectId })}`).catch(() => null);
+  const file = (list?.files ?? []).find((f) => f.fileName === name);
   if (!file) return;
-  await bff.delete(`/components/${seg(path.componentId)}/environments/${seg(env)}/files/${seg(fileName)}${q({ projectName: projectId, mountPath: file.mountPath })}`);
+  await bff.delete(`${base}/files/${seg(name)}${q({ projectName: projectId, mountPath: file.mountPath })}`);
 };

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -30,22 +30,31 @@ import { bff, items, q, seg, type ListResponse, type MessageResponse } from './_
 // Environment carries `id` (slug) and `name` (label) and expresses "production"
 // as `critical`, so we translate between the two shapes at the boundary.
 interface BffEnvironment {
+  // The BFF serves the RFC 1123 slug as `id` and the human label as `name`, and
+  // flags production via `critical` with the dataplane in `dpId`. The
+  // slug/displayName/isProduction/dataPlaneRef aliases are tolerated as fallbacks.
+  id?: string;
   uid?: string;
   name: string;
   displayName?: string;
   description?: string;
   dataPlaneRef?: string;
+  dpId?: string;
   isProduction?: boolean;
+  critical?: boolean;
   createdAt?: string;
 }
 
+// `id` must be the slug used in every path (`/environments/{name}`) and in the
+// immutable ReleaseBinding `spec.environment` — NOT the display label, or deploys
+// mismatch the binding (e.g. label "Development" vs slug "development").
 const toEnvironment = (e: BffEnvironment): Environment => ({
-  id: e.name,
+  id: e.id ?? e.name,
   name: e.displayName || e.name,
-  critical: e.isProduction ?? false,
+  critical: e.critical ?? e.isProduction ?? false,
   description: e.description,
   createdAt: e.createdAt,
-  dpId: e.dataPlaneRef,
+  dpId: e.dpId ?? e.dataPlaneRef,
 });
 
 export const fetchEnvironments = (_orgUuid: string, projectId: string): Promise<Environment[]> => bff.get<ListResponse<BffEnvironment>>(`/environments${q({ project: projectId })}`).then((r) => items(r).map(toEnvironment));

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -49,7 +49,7 @@ interface BffEnvironment {
 // immutable ReleaseBinding `spec.environment` — NOT the display label, or deploys
 // mismatch the binding (e.g. label "Development" vs slug "development").
 const toEnvironment = (e: BffEnvironment): Environment => ({
-  id: e.id ?? e.name,
+  id: e.id || e.name,
   name: e.displayName || e.name,
   critical: e.critical ?? e.isProduction ?? false,
   description: e.description,

--- a/ipaas/src/components/Configs/ConfigEditor.tsx
+++ b/ipaas/src/components/Configs/ConfigEditor.tsx
@@ -22,7 +22,6 @@ import { useEffect, useRef, useState, type JSX } from 'react';
 import { useConfigMapDetails, useSaveConfig } from '../../hooks/useDevopsConfigs';
 import { parseDotEnv, validateConfigKey, validateDisplayName, validateMountPath } from '../../utils/devopsConfigs';
 import type { ConfigKind, ConfigRow } from '../../types/devopsConfigs';
-import { IS_CLOUD } from '../../features';
 
 /** The component/release/env target a config is created against. */
 export interface EditorContext {
@@ -83,8 +82,7 @@ export default function ConfigEditor({ ctx, existing, onBack, onSaved, onError }
   // Prefill values for an existing ConfigMap (secret values are write-only, so re-entered).
   const { data: details } = useConfigMapDetails(ctx.projectId, existing && !existing.isSecret ? ctx.envId : undefined, existing && !existing.isSecret ? configId : undefined);
 
-  // cloud: OpenChoreo backs file mounts only; env-var configs have no BFF route.
-  const [kind, setKind] = useState<ConfigKind>(existing?.kind ?? (IS_CLOUD ? 'fileMount' : 'envVars'));
+  const [kind, setKind] = useState<ConfigKind>(existing?.kind ?? 'envVars');
   const [isSecret, setIsSecret] = useState(existing?.isSecret ?? false);
   const [name, setName] = useState(existing?.name ?? '');
   const [rows, setRows] = useState<Array<{ key: string; value: string }>>(existing ? existing.keys.map((k) => ({ key: k, value: '' })) : []);
@@ -180,7 +178,7 @@ export default function ConfigEditor({ ctx, existing, onBack, onSaved, onError }
       )}
 
       <Stack direction="row" gap={2} sx={{ mb: 2 }}>
-        <TypeCard title="Environment Variables" description="Inject a set of environment variables into the container" selected={kind === 'envVars'} disabled={isEdit || IS_CLOUD} onSelect={() => setKind('envVars')} />
+        <TypeCard title="Environment Variables" description="Inject a set of environment variables into the container" selected={kind === 'envVars'} disabled={isEdit} onSelect={() => setKind('envVars')} />
         <TypeCard title="File Mount" description="Mount a file at a specified path in the container" selected={kind === 'fileMount'} disabled={isEdit} onSelect={() => setKind('fileMount')} />
       </Stack>
 


### PR DESCRIPTION
## Purpose
Wire the Environment Variables kind of the Configs & Secrets page for cloud against the ipaas-service BFF env-group API (a named bundle of KEY=value pairs, secret or non-secret):

- devopsConfigs.ts: list files + env-groups as mounts, list groups as ConfigMaps/Secrets with keys, prefill group values / file content on edit, create/update PUT the group, delete detects group-vs-file. Resolve the component for env-scoped reads via a per-env deferred to avoid a load-order race with the release read.
- ConfigEditor.tsx: re-enable the Environment Variables card (drop the IS_CLOUD gate); the editor is product-agnostic again.
- environments.ts: map Environment.id from the BFF slug (id), not the display label (name), and read critical/dpId from the BFF response. Fixes deploys sending a capitalized environment that mismatched the immutable ReleaseBinding spec.environment.

- Coalesce the concurrent /env-groups reads a page load fires (mounts + configmaps + secrets) into one in-flight request per (component, env), dropped on settle so a refetch after a mutation still reloads fresh.
- Bound componentForEnv with an 8s race so env-scoped reads for an undeployed environment settle to [] instead of pending forever; per-call and non-poisoning, so a later call still sees the real component.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.