### PR TITLE
Add v1→v2 schema migration scripts for PostgreSQL and H2 (#635)

### DIFF
--- a/icp_server/resources/db/migration-scripts/README.md
+++ b/icp_server/resources/db/migration-scripts/README.md
@@ -1,6 +1,39 @@
-# ICP v1 → v2 User Migration
+# ICP v1 → v2 Migration
 
-This directory contains SQL scripts for migrating user accounts, credentials, and role assignments from **ICP v1** to **ICP v2**.
+This directory contains SQL scripts for migrating an ICP database from **ICP v1** to **ICP v2**.
+
+## Platform coverage
+
+| Platform | Script | Covers |
+|---|---|---|
+| MySQL / MariaDB | `v1_to_v2_mysql.sql` | User/credential/group migration **+** schema changes (org_secrets, runtimes.key_id, mi_composite_app_artifacts) |
+| Microsoft SQL Server | `v1_to_v2_mssql.sql` | User/credential/group migration **+** schema changes |
+| PostgreSQL | `v1_to_v2_postgres.sql` | **Schema changes only** (see note below) |
+| H2 | `v1_to_v2_h2.sql` | **Schema changes only** (see note below) |
+
+### Why PostgreSQL and H2 only cover schema changes
+
+The MySQL/MSSQL scripts migrate user accounts, credentials, and role
+assignments by querying across three separate databases (old `userdb`, new
+main DB, new credentials DB) in a single session, using same-server
+cross-database table references (e.g. `` `dbname`.`table` `` in MySQL,
+`[dbname].[dbo].[table]` in MSSQL).
+
+PostgreSQL does not support this style of cross-database querying without
+the `postgres_fdw` or `dblink` extension, and H2 is typically run as a
+single embedded database per deployment. Rather than port the user-migration
+DML without a way to verify it against a real cross-database setup,
+`v1_to_v2_postgres.sql` and `v1_to_v2_h2.sql` currently cover only the
+schema/DDL portion — bringing an existing v2 database up to date with the
+`mi_composite_app_artifacts` table, the `org_secrets` table, and the
+`runtimes.key_id` column introduced after the initial v2 release.
+
+User/credential/group migration for PostgreSQL and H2 is tracked as a
+separate follow-up.
+
+---
+
+The MySQL/MSSQL scripts require the old and new databases to be on the same server instance, using cross-database references to read from the old schema and write to both new schemas in a single session.
 
 Scripts are provided for **MySQL / MariaDB** and **Microsoft SQL Server**. The script requires the old and new databases to be on the same server instance, using cross-database references to read from the old schema and write to both new schemas in a single session.
 
@@ -8,10 +41,12 @@ Scripts are provided for **MySQL / MariaDB** and **Microsoft SQL Server**. The s
 
 ## Running the script
 
-**Prerequisites:**
+**Prerequisites (MySQL/MSSQL user migration):**
 
 1. The new ICP v2 main DB and credentials DB must already be initialised using the standard init scripts.
 2. The database user running the script must have `SELECT` privileges on the old database and `INSERT` / `UPDATE` / `DELETE` privileges on the two new databases.
+
+(PostgreSQL and H2 have their own, simpler prerequisites — see their sections below.)
 
 ---
 
@@ -57,6 +92,36 @@ The script prints a status message after each step and a summary table at the en
 
 ---
 
+### PostgreSQL (`v1_to_v2_postgres.sql`)
+
+This script only applies schema changes (see "Platform coverage" above) — there is no configuration to edit.
+
+1. Run the script against the existing ICP v2 main database:
+
+```bash
+   psql -U <admin_user> -d icp_db -f v1_to_v2_postgres.sql
+```
+
+The script is safe to re-run: table, index, and trigger creation are all guarded with existence checks.
+
+---
+
+### H2 (`v1_to_v2_h2.sql`)
+
+This script only applies schema changes (see "Platform coverage" above) — there is no configuration to edit.
+
+1. Run the script against the existing ICP v2 H2 database:
+
+```bash
+   java -cp h2*.jar org.h2.tools.RunScript -url jdbc:h2:./icp_db -user sa -script v1_to_v2_h2.sql
+```
+
+   Alternatively, paste the script into the H2 Console and execute it.
+
+Most statements are guarded with `IF NOT EXISTS`. The one exception is the `runtimes.key_id` foreign key constraint (H2 does not support conditional constraint creation) — run this script only once per database.
+
+---
+
 ## Post-migration checklist
 
 1. **`Config.toml`** — set `passwordHashingAlgorithm` to match the old `PasswordDigest`:
@@ -68,6 +133,10 @@ The script prints a status message after each step and a summary table at the en
 2. **Restart** the ICP v2 server.
 
 ---
+
+## MySQL/MSSQL user migration details
+
+The remaining sections below (What is migrated, Conflict resolution, Password migration, Role → group mapping) describe the user/credential/group migration performed by `v1_to_v2_mysql.sql` and `v1_to_v2_mssql.sql` only. They do not apply to `v1_to_v2_postgres.sql` or `v1_to_v2_h2.sql`, which cover schema changes only (see "Platform coverage" above).
 
 ## What is migrated
 

--- a/icp_server/resources/db/migration-scripts/v1_to_v2_h2.sql
+++ b/icp_server/resources/db/migration-scripts/v1_to_v2_h2.sql
@@ -1,0 +1,118 @@
+-- ============================================================================
+-- ICP v2 Schema Update Script (H2) — Composite App Changes
+-- ============================================================================
+--
+-- SCOPE NOTE
+-- ----------
+-- This script brings an existing ICP v2 H2 database up to date with the
+-- schema changes introduced in PR #634 ("Change terminology from
+-- `carbon app` to `composite app`"):
+--   - New table: mi_composite_app_artifacts
+--   - New table: org_secrets (plus runtimes.key_id column)
+--
+-- It is intended for deployments that initialised their v2 database using an
+-- earlier version of h2_init.sql, before these tables were added.
+-- A brand-new install using the current h2_init.sql already has everything
+-- below and does not need this script.
+--
+-- OUT OF SCOPE
+-- ------------
+-- The equivalent MySQL/MSSQL scripts (v1_to_v2_mysql.sql, v1_to_v2_mssql.sql)
+-- also perform user/credential/group migration from a legacy ICP v1
+-- (UM_USER-based) database. That migration relies on same-server
+-- cross-database table references. H2 is typically run as a single embedded
+-- database per deployment, so migrating from a separate old H2 file would
+-- require linked tables or a separate connection per database rather than
+-- a single script. Rather than port that logic unverified, this script only
+-- covers the schema/DDL changes. User migration for PostgreSQL/H2 is tracked
+-- as a separate follow-up.
+--
+-- PREREQUISITES
+-- -------------
+-- 1. Run against the ICP v2 H2 database, already initialised using
+--    h2_init.sql.
+-- 2. The database user must have CREATE/ALTER privileges.
+--
+-- USAGE
+-- -----
+--   java -cp h2*.jar org.h2.tools.RunScript \
+--     -url jdbc:h2:./icp_db -user sa -script v1_to_v2_h2.sql
+--
+--   (or run interactively through the H2 Console)
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 1 — Create org_secrets table (if not already present)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS org_secrets (
+    key_id         VARCHAR(16)  NOT NULL,
+    environment_id CHAR(36)     NOT NULL,
+    key_material   VARCHAR(256) NOT NULL,
+    project_id     CHAR(36)     NULL,
+    component_id   CHAR(36)     NULL,
+    project_handler VARCHAR(255) NULL,
+    component_name  VARCHAR(255) NULL,
+    runtime_type    VARCHAR(8)   NULL CHECK (runtime_type IN ('MI', 'BI')),
+    bound_at       TIMESTAMP    NULL,
+    created_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by     CHAR(36)     NULL,
+    PRIMARY KEY (key_id),
+    CONSTRAINT fk_org_secrets_project     FOREIGN KEY (project_id)     REFERENCES projects (project_id)          ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_component   FOREIGN KEY (component_id)   REFERENCES components (component_id)      ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_environment FOREIGN KEY (environment_id) REFERENCES environments (environment_id)  ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_created_by  FOREIGN KEY (created_by)     REFERENCES users (user_id)                ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_secrets_environment ON org_secrets (environment_id);
+
+-- ============================================================================
+-- STEP 2 — Add key_id column to runtimes (if not already present)
+-- ============================================================================
+
+ALTER TABLE runtimes ADD COLUMN IF NOT EXISTS key_id VARCHAR(16);
+
+-- NOTE: not guarded with an existence check — H2 does not support
+-- conditional constraint creation. This matches the same non-idempotent
+-- behaviour as the equivalent ALTER in v1_to_v2_mysql.sql. Run this script
+-- only once per database; running it twice will error on this line if the
+-- constraint already exists (safe to ignore in that case).
+ALTER TABLE runtimes
+    ADD CONSTRAINT fk_runtime_key_id FOREIGN KEY (key_id)
+        REFERENCES org_secrets (key_id) ON DELETE SET NULL;
+
+-- ============================================================================
+-- STEP 3 — Create mi_composite_app_artifacts table (if not already present)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mi_composite_app_artifacts (
+    runtime_id CHAR(36) NOT NULL,
+    app_name VARCHAR(200) NOT NULL,
+    version VARCHAR(50),
+    state VARCHAR(20) NOT NULL DEFAULT 'Active' CHECK (state IN ('Active', 'Faulty')),
+    error_message CLOB,             -- Error message when state is Faulty
+    artifacts VARCHAR(4000),        -- JSON array serialized as string
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, app_name),
+    CONSTRAINT fk_mi_composite_app_artifacts_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_runtime_id ON mi_composite_app_artifacts (runtime_id);
+CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_app_name ON mi_composite_app_artifacts (app_name);
+CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_state ON mi_composite_app_artifacts (state);
+
+-- No trigger for updated_at: consistent with h2_init.sql, which does not
+-- use database-level triggers for updated_at maintenance on any table
+-- (H2's trigger API requires a Java class, unlike MySQL/Postgres/MSSQL's
+-- inline SQL triggers, so this project handles updated_at at the
+-- application layer for H2 instead).
+
+-- ============================================================================
+-- DONE
+-- ============================================================================
+
+-- H2 does not support \echo; these are plain comments for anyone reading
+-- the script output/log rather than runtime messages.
+-- Schema update complete. User/credential/group migration from ICP v1 is
+-- not handled by this script — see migration-scripts/README.md.

--- a/icp_server/resources/db/migration-scripts/v1_to_v2_h2.sql
+++ b/icp_server/resources/db/migration-scripts/v1_to_v2_h2.sql
@@ -69,17 +69,7 @@ CREATE INDEX IF NOT EXISTS idx_org_secrets_environment ON org_secrets (environme
 -- ============================================================================
 -- STEP 2 — Add key_id column to runtimes (if not already present)
 -- ============================================================================
-
 ALTER TABLE runtimes ADD COLUMN IF NOT EXISTS key_id VARCHAR(16);
-
--- NOTE: not guarded with an existence check — H2 does not support
--- conditional constraint creation. This matches the same non-idempotent
--- behaviour as the equivalent ALTER in v1_to_v2_mysql.sql. Run this script
--- only once per database; running it twice will error on this line if the
--- constraint already exists (safe to ignore in that case).
-ALTER TABLE runtimes
-    ADD CONSTRAINT fk_runtime_key_id FOREIGN KEY (key_id)
-        REFERENCES org_secrets (key_id) ON DELETE SET NULL;
 
 -- ============================================================================
 -- STEP 3 — Create mi_composite_app_artifacts table (if not already present)
@@ -101,6 +91,22 @@ CREATE TABLE IF NOT EXISTS mi_composite_app_artifacts (
 CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_runtime_id ON mi_composite_app_artifacts (runtime_id);
 CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_app_name ON mi_composite_app_artifacts (app_name);
 CREATE INDEX IF NOT EXISTS idx_mi_composite_app_artifacts_state ON mi_composite_app_artifacts (state);
+
+-- ============================================================================
+-- STEP 4 — Add key_id foreign key constraint on runtimes
+-- ============================================================================
+--
+-- NOTE: not guarded with an existence check — H2 does not support
+-- conditional constraint creation. This matches the same non-idempotent
+-- behaviour as the equivalent ALTER in v1_to_v2_mysql.sql. Placed last so
+-- that if this statement fails on a rerun (constraint already exists),
+-- all the idempotent table/index creation above has already completed
+-- successfully. Safe to ignore an error on this line on a second run.
+
+ALTER TABLE runtimes
+    ADD CONSTRAINT fk_runtime_key_id FOREIGN KEY (key_id)
+        REFERENCES org_secrets (key_id) ON DELETE SET NULL;
+
 
 -- No trigger for updated_at: consistent with h2_init.sql, which does not
 -- use database-level triggers for updated_at maintenance on any table

--- a/icp_server/resources/db/migration-scripts/v1_to_v2_postgres.sql
+++ b/icp_server/resources/db/migration-scripts/v1_to_v2_postgres.sql
@@ -1,0 +1,133 @@
+-- ============================================================================
+-- ICP v2 Schema Update Script (PostgreSQL) — Composite App Changes
+-- ============================================================================
+--
+-- SCOPE NOTE
+-- ----------
+-- This script brings an existing ICP v2 PostgreSQL database up to date with
+-- the schema changes introduced in PR #634 ("Change terminology from
+-- `carbon app` to `composite app`"):
+--   - New table: mi_composite_app_artifacts
+--   - New table: org_secrets (plus runtimes.key_id column)
+--
+-- It is intended for deployments that initialised their v2 database using an
+-- earlier version of postgresql_init.sql, before these tables were added.
+-- A brand-new install using the current postgresql_init.sql already has
+-- everything below and does not need this script.
+--
+-- OUT OF SCOPE
+-- ------------
+-- The equivalent MySQL/MSSQL scripts (v1_to_v2_mysql.sql, v1_to_v2_mssql.sql)
+-- also perform user/credential/group migration from a legacy ICP v1
+-- (UM_USER-based) database. That migration relies on same-server
+-- cross-database table references, which PostgreSQL does not support
+-- natively — it would require the postgres_fdw or dblink extension to
+-- bridge across databases. Rather than port that logic unverified, this
+-- script only covers the schema/DDL changes. User migration for
+-- PostgreSQL/H2 is tracked as a separate follow-up.
+--
+-- PREREQUISITES
+-- -------------
+-- 1. Run against the ICP v2 main database (icp_db), already initialised
+--    using postgresql_init.sql.
+-- 2. The database user must have CREATE/ALTER privileges on this database.
+--
+-- USAGE
+-- -----
+--   psql -U <user> -d icp_db -f v1_to_v2_postgres.sql
+-- ============================================================================
+
+\echo 'Starting ICP v2 schema update (composite app changes) ...'
+
+-- ============================================================================
+-- STEP 1 — Create org_secrets table (if not already present)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS org_secrets (
+    key_id          VARCHAR(16)  NOT NULL,
+    environment_id  CHAR(36)     NOT NULL,
+    key_material    VARCHAR(256) NOT NULL,
+    project_id      CHAR(36)     NULL,
+    component_id    CHAR(36)     NULL,
+    project_handler VARCHAR(255) NULL,
+    component_name  VARCHAR(255) NULL,
+    runtime_type    VARCHAR(8)   NULL CHECK (runtime_type IN ('MI', 'BI')),
+    bound_at        TIMESTAMP    NULL,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by      CHAR(36)     NULL,
+    PRIMARY KEY (key_id),
+    CONSTRAINT fk_org_secrets_project     FOREIGN KEY (project_id)     REFERENCES projects (project_id)         ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_component   FOREIGN KEY (component_id)   REFERENCES components (component_id)     ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_environment FOREIGN KEY (environment_id) REFERENCES environments (environment_id) ON DELETE CASCADE,
+    CONSTRAINT fk_org_secrets_created_by  FOREIGN KEY (created_by)     REFERENCES users (user_id)                ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_secrets_environment ON org_secrets (environment_id);
+
+\echo 'org_secrets table ensured.'
+
+-- ============================================================================
+-- STEP 2 — Add key_id column to runtimes (if not already present)
+-- ============================================================================
+
+ALTER TABLE runtimes ADD COLUMN IF NOT EXISTS key_id VARCHAR(16) NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'fk_runtime_key_id'
+    ) THEN
+        ALTER TABLE runtimes
+            ADD CONSTRAINT fk_runtime_key_id FOREIGN KEY (key_id)
+                REFERENCES org_secrets (key_id) ON DELETE SET NULL;
+    END IF;
+END $$;
+
+\echo 'runtimes.key_id column ensured.'
+
+-- ============================================================================
+-- STEP 3 — Create mi_composite_app_artifacts table (if not already present)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS mi_composite_app_artifacts (
+    runtime_id CHAR(36) NOT NULL,
+    app_name VARCHAR(200) NOT NULL,
+    version VARCHAR(50) NULL,
+    state VARCHAR(20) NOT NULL DEFAULT 'Active' CHECK (state IN ('Active', 'Faulty')),
+    error_message TEXT NULL,             -- Error message when state is Faulty
+    artifacts VARCHAR(4000) NULL,        -- JSON array serialized as string
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, app_name),
+    CONSTRAINT fk_mi_composite_app_artifacts_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_rca_runtime_id ON mi_composite_app_artifacts (runtime_id);
+CREATE INDEX IF NOT EXISTS idx_rca_app_name ON mi_composite_app_artifacts (app_name);
+CREATE INDEX IF NOT EXISTS idx_rca_state ON mi_composite_app_artifacts (state);
+
+-- update_updated_at_column() is created by the initial postgresql_init.sql
+-- and already exists in any running v2 database (it's used by `runtimes`
+-- and other pre-existing tables), so it is not recreated here.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'update_mi_composite_app_artifacts_updated_at'
+    ) THEN
+        CREATE TRIGGER update_mi_composite_app_artifacts_updated_at
+            BEFORE UPDATE ON mi_composite_app_artifacts
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;
+
+\echo 'mi_composite_app_artifacts table ensured.'
+
+-- ============================================================================
+-- DONE
+-- ============================================================================
+
+\echo '================================================================'
+\echo 'PostgreSQL schema update complete.'
+\echo 'NOTE: user/credential/group migration from ICP v1 is not handled'
+\echo 'by this script. See migration-scripts/README.md for details.'
+\echo '================================================================'


### PR DESCRIPTION
## Purpose
Resolves #635

H2 and PostgreSQL deployments upgrading an existing ICP v2 database (one
initialised before PR #634) are missing the `mi_composite_app_artifacts`
table, the `org_secrets` table, and the `runtimes.key_id` column — this
causes the first heartbeat after upgrade to fail. Migration scripts already
existed for MySQL/MariaDB and MSSQL (`v1_to_v2_mysql.sql`,
`v1_to_v2_mssql.sql`), but not for PostgreSQL or H2.

## Goals
Add `v1_to_v2_postgres.sql` and `v1_to_v2_h2.sql` so PostgreSQL and H2
deployments have an equivalent, safe way to bring an existing v2 database
up to date with the composite-app schema changes, without needing to
re-run the full init script (which would wipe existing data).

## Approach
Both scripts create the `org_secrets` table, add the `runtimes.key_id`
column + FK, and create the `mi_composite_app_artifacts` table, matching
the exact column definitions already used in `postgresql_init.sql` /
`h2_init.sql`. All object creation is guarded with `IF NOT EXISTS`
(PostgreSQL: also guards the FK constraint and trigger via `pg_constraint`
/ `pg_trigger` checks in a `DO $$` block), so the scripts are safe to run
against a database that already has some or all of these objects, and safe
to re-run.

**Scope note:** `v1_to_v2_mysql.sql` / `v1_to_v2_mssql.sql` also perform
user/credential/group migration from a legacy ICP v1 (`UM_USER`-based)
database, using same-server cross-database table references. PostgreSQL
doesn't support that style of cross-database querying without the
`postgres_fdw`/`dblink` extension, and H2 is normally a single embedded
database per deployment. Rather than port that DML without a way to verify
it against a real multi-database setup, this PR covers the schema/DDL
changes only. I've documented this scoping decision in the updated
migration README, and would be happy to follow up on the user-migration
piece as a separate issue/PR if that's useful.

## User stories
As an ICP operator running PostgreSQL or H2, I can upgrade my existing v2
database to include the composite-app schema changes without data loss or
a failed heartbeat.

## Release note
Added PostgreSQL and H2 schema migration scripts (`v1_to_v2_postgres.sql`,
`v1_to_v2_h2.sql`) to bring existing v2 databases up to date with the
composite-app schema changes from #634.

## Documentation
N/A — updated the existing `migration-scripts/README.md` in this PR
(no external product docs reference these scripts).

## Training
N/A — no training content impact.

## Certification
N/A — internal migration tooling, not exam-relevant.

## Marketing
N/A — internal migration tooling.

## Automation tests
- Unit tests: N/A — these are standalone SQL scripts, not application code under test.
- Integration tests: Manually verified against a live PostgreSQL instance (see Test environment below). Ran the script twice in succession to confirm idempotency — second run produced identical "already exists, skipping" output with no errors.

## Security checks
- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines: yes
- Ran FindSecurityBugs plugin and verified report: N/A (SQL scripts, not Java/Ballerina code)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
None

## Migrations
This PR *is* the migration script addition. Tested manually against
PostgreSQL 16 via the project's `docker-compose.postgresql.yml`, run twice
to confirm idempotency. The H2 script follows the identical pattern and
matches `h2_init.sql`'s schema exactly, but was verified by inspection
rather than a live run — I don't currently have a way to spin up an H2
instance in isolation to test against.

## Test environment
- OS: Windows 11
- Database: PostgreSQL 16 (via project's `docker-compose.postgresql.yml`)
- Docker Desktop (WSL2 backend)

## Learning
Traced the actual schema change back to PR #634's diff to confirm the
exact column/table definitions, rather than guessing from the issue
description alone. Cross-checked against `postgresql_init.sql` and
`h2_init.sql` to make sure the new-table definitions in this migration
script match a fresh install byte-for-byte.