### PR TITLE
Fix misleading empty-state message in Manage Secrets dialog

### DIFF
--- a/frontend/src/pages/Runtime.tsx
+++ b/frontend/src/pages/Runtime.tsx
@@ -217,7 +217,7 @@ function BoundSecretDrawer({ componentId, environmentId, environmentName, onClos
           <CircularProgress sx={{ mx: 'auto', my: 4 }} />
         ) : secrets.length === 0 ? (
           <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
-            No bound secrets for this integration in this environment.
+            No secrets for this integration in this environment.
           </Typography>
         ) : (
           <Box sx={{ width: '100%', overflowX: 'auto' }}>


### PR DESCRIPTION
## Purpose
The Manage Secrets dialog (Integration view → Runtime → Manage Secrets) lists both bound and unbound secrets for an integration. However, when all secrets are deleted, the empty-state message displayed is "No bound secrets for this integration in this environment." This is misleading, as it implies the dialog only shows bound secrets.
Resolves https://github.com/wso2/product-integrator/issues/1834