### PR TITLE
Fix missing static getDerivedStateFromError in ErrorBoundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -29,8 +29,11 @@ interface State {
 export default class ErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false };
 
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    this.setState({ hasError: true });
     console.error('Unhandled error caught by ErrorBoundary:', error, info);
   }
 


### PR DESCRIPTION
## Purpose
The `ErrorBoundary` component is missing the required `static getDerivedStateFromError()` lifecycle method. Without it, React does not reliably identify the component as an error boundary during the render phase, which can cause rendering errors to go uncaught.

## Goals
Ensure the `ErrorBoundary` component follows React's official error boundary API by adding the required `static getDerivedStateFromError()` method and removing the incorrect `setState()` call from `componentDidCatch()`.

## Approach
- Added `static getDerivedStateFromError()` which returns `{ hasError: true }` during the render phase — this is the React-prescribed way to update state in response to an error.
- Removed `this.setState({ hasError: true })` from `componentDidCatch()`, keeping it solely for error logging (its intended purpose per React docs).

**References:**
- https://react.dev/reference/react/Component#static-getderivedstatefromerror
- https://react.dev/reference/react/Component#componentdidcatch

## User stories
As a user, when an unhandled rendering error occurs, the error boundary should reliably catch it and redirect to the error page instead of crashing the entire application.

## Release note
Fixed `ErrorBoundary` component to include the required `static getDerivedStateFromError()` method, ensuring errors are reliably caught during the React render phase.

## Documentation
N/A — Internal bug fix with no user-facing documentation impact.

## Training
N/A

## Certification
N/A — Internal bug fix, no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — Minimal change following React's documented API.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
 - Node.js 22, Windows 11, Chrome latest

## Learning
React documentation on error boundaries:
- https://react.dev/reference/react/Component#static-getderivedstatefromerror
- https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
