### PR TITLE
Fix blob URL revoked too early in downloadLogs

### DIFF
--- a/frontend/src/pages/RuntimeLogs.tsx
+++ b/frontend/src/pages/RuntimeLogs.tsx
@@ -86,8 +86,12 @@ function downloadLogs(logs: LogRow[]) {
   const a = document.createElement('a');
   a.href = url;
   a.download = `logs-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+  document.body.appendChild(a);
   a.click();
-  URL.revokeObjectURL(url);
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 100);
 }
 
 /** Convert a Date to a datetime-local input value (YYYY-MM-DDTHH:MM) */


### PR DESCRIPTION
## Purpose
The `downloadLogs` function in `RuntimeLogs.tsx` calls `URL.revokeObjectURL()` synchronously right after `a.click()`, before the browser has a chance to start reading the blob URL. This creates a race condition that can cause the log file download to silently fail, particularly on slower machines or under heavy load.

## Goals
Ensure log file downloads complete reliably by deferring blob URL cleanup, matching the established pattern already used in other download functions within the same codebase.

## Approach
- Defer `URL.revokeObjectURL()` and anchor element cleanup into a `setTimeout(..., 100)` callback, giving the browser time to initiate the download stream.
- Append the anchor element to `document.body` before clicking (required by some browsers like Firefox for programmatic downloads).
- This matches the exact pattern already used in `LogFilesDrawer.tsx` and `RegistryFileViewer.tsx`.

## User stories
As a user viewing Runtime Logs, when I click the download button, the log file should always download successfully regardless of system load or browser implementation.

## Release note
Fixed a race condition in the Runtime Logs download function where the blob URL could be revoked before the browser initiated the download.

## Documentation
N/A — Internal bug fix with no user-facing documentation impact.

## Training
N/A

## Certification
N/A — Internal bug fix, no impact on certification content.

## Marketing
N/A

## Automation tests
 - Unit tests
   > N/A — The fix is a minimal timing change in a browser-specific download helper function.
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A (frontend-only change)
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
 - Node.js 22, Windows 11, Chrome latest

## Learning
- MDN Web Docs on [`URL.revokeObjectURL()`](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static) - documents that revocation should be deferred until after the object URL is no longer needed.
- Pattern comparison with existing download functions in the same codebase (`LogFilesDrawer.tsx`, `RegistryFileViewer.tsx`).
