### PR TITLE
Add configurable SSL support and bump version to 2.0.0

### DIFF
--- a/docs/disable-ssl.md
+++ b/docs/disable-ssl.md
@@ -1,0 +1,40 @@
+# Disabling SSL in ICP
+
+By default all three listeners (9446, 9445, 9449) start with TLS enabled.
+Set `sslEnabled = false` to switch them to plain HTTP.
+
+## Option 1 — Environment variable (Kubernetes / Docker)
+
+```
+BAL_CONFIG_VAR_SSLENABLED=false
+```
+
+Kubernetes:
+```yaml
+env:
+  - name: BAL_CONFIG_VAR_SSLENABLED
+    value: "false"
+```
+
+Docker:
+```
+docker run -e BAL_CONFIG_VAR_SSLENABLED=false anuruddhal/wso2-integration-control-plane:2.0.0
+```
+
+## Option 2 — deployment.toml
+
+Add to the top-level section (before any `[section]` header):
+
+```toml
+sslEnabled = false
+```
+
+## What changes
+
+- All three ports serve plain HTTP instead of HTTPS
+- Frontend `config.json` URLs switch from `https://` to `http://`
+- Startup log prints `http://localhost:9446`
+
+## Re-enabling
+
+Remove the env var or delete the `sslEnabled` line. SSL is on by default.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ org.gradle.daemon.idletimeout=60000
 
 # Project configuration
 project.name=integration-control-plane
-project.version=2.0.0-SNAPSHOT
+project.version=2.0.0
 project.group=wso2
 
 # Ballerina configuration

--- a/icp_server/Ballerina.toml
+++ b/icp_server/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "wso2"
 name = "icp_server"
-version = "2.0.0-SNAPSHOT"
+version = "2.0.0"
 license = ["Apache-2.0"]
 description = "ICP Server"
 

--- a/icp_server/Dependencies.toml
+++ b/icp_server/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.2"
+distribution-version = "2201.13.3"
 
 [[package]]
 org = "ballerina"
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.16.2"
+version = "2.16.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -144,7 +144,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -305,7 +305,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -385,7 +385,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -412,7 +412,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -423,7 +423,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -448,7 +448,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "websocket"
-version = "2.15.2"
+version = "2.15.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "constraint"},
@@ -498,7 +498,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -606,7 +606,7 @@ modules = [
 [[package]]
 org = "wso2"
 name = "icp_server"
-version = "2.0.0-SNAPSHOT"
+version = "2.0.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},

--- a/icp_server/config.bal
+++ b/icp_server/config.bal
@@ -19,7 +19,7 @@ import icp_server.types;
 import ballerina/file;
 
 // ICP version
-configurable string icpVersion = "2.0.0-SNAPSHOT";
+configurable string icpVersion = "2.0.0";
 
 // Server configuration
 configurable int serverPort = 9446;
@@ -29,6 +29,7 @@ configurable int runtimeListenerPort = 9445;
 configurable string serverHost = "0.0.0.0";
 configurable string organization = "WSO2 Inc.";
 
+configurable boolean sslEnabled = true;
 configurable string keystorePath = check file:joinPath("..", "conf", "security", "wso2carbon.jks");
 configurable string keystorePassword = "wso2carbon";
 configurable string truststorePath = check file:joinPath("..", "conf", "security", "client-truststore.jks");

--- a/icp_server/opensearch_adapter_service.bal
+++ b/icp_server/opensearch_adapter_service.bal
@@ -103,12 +103,12 @@ final http:Client? opensearchClient;
 listener http:Listener openSerachObservabilityListener = new (defaultOpensearchAdaptorPort,
     config = {
         host: serverHost,
-        secureSocket: {
+        secureSocket: sslEnabled ? {
             key: {
                 path: keystorePath,
                 password: resolvedKeystorePassword
             }
-        }
+        } : ()
     }
 );
 

--- a/icp_server/runtime_service.bal
+++ b/icp_server/runtime_service.bal
@@ -26,12 +26,12 @@ import ballerina/log;
 listener http:Listener httpListener = new (serverPort,
     config = {
         host: serverHost,
-        secureSocket: {
+        secureSocket: sslEnabled ? {
             key: {
                 path: keystorePath,
                 password: resolvedKeystorePassword
             }
-        }
+        } : ()
     }
 );
 
@@ -39,12 +39,12 @@ listener http:Listener httpListener = new (serverPort,
 listener http:Listener runtimeListener = new (runtimeListenerPort,
     config = {
         host: serverHost,
-        secureSocket: {
+        secureSocket: sslEnabled ? {
             key: {
                 path: keystorePath,
                 password: resolvedKeystorePassword
             }
-        }
+        } : ()
     }
 );
 

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -30,7 +30,8 @@ service / on httpListener {
 
         log:printInfo("Starting console on " + serverHost + ":" + serverPort.toString());
         log:printInfo("--------------------------------");
-        log:printInfo("WSO2 Integrator: ICP Console started at https://localhost:" + serverPort.toString());
+        string scheme = sslEnabled ? "https" : "http";
+        log:printInfo("WSO2 Integrator: ICP Console started at " + scheme + "://localhost:" + serverPort.toString());
         log:printInfo("--------------------------------");
     }
 
@@ -141,12 +142,13 @@ function getContentType(string filePath) returns string {
 // Update frontend config.json with runtime backend URLs
 function updateFrontendConfig() returns error? {
     string configPath = "../www/config.json";
+    string scheme = sslEnabled ? "https" : "http";
 
     // Create config JSON with runtime values
     json configJson = {
-        "VITE_GRAPHQL_URL": backendGraphqlEndpoint,
-        "VITE_AUTH_BASE_URL": backendAuthBaseUrl,
-        "VITE_OBSERVABILITY_URL": backendObservabilityEndpoint,
+        "VITE_GRAPHQL_URL": applyScheme(backendGraphqlEndpoint, scheme),
+        "VITE_AUTH_BASE_URL": applyScheme(backendAuthBaseUrl, scheme),
+        "VITE_OBSERVABILITY_URL": applyScheme(backendObservabilityEndpoint, scheme),
         "VITE_SSO_ENABLED": ssoEnabled,
         "VITE_ICP_VERSION": icpVersion
     };
@@ -154,4 +156,14 @@ function updateFrontendConfig() returns error? {
     // Write to config.json
     check io:fileWriteJson(configPath, configJson);
     log:printInfo("Updated frontend config.json with backend URLs");
+}
+
+isolated function applyScheme(string url, string scheme) returns string {
+    if url.startsWith("https://") {
+        return scheme + "://" + url.substring(8);
+    }
+    if url.startsWith("http://") {
+        return scheme + "://" + url.substring(7);
+    }
+    return url;
 }


### PR DESCRIPTION
## Summary

- Add `sslEnabled` configurable (default `true`) — when set to `false`, all three listeners (9446, 9445, 9449) switch from HTTPS to plain HTTP
- Derive startup log URL scheme and frontend `config.json` URLs from `sslEnabled` so they stay in sync with the actual protocol
- Bump version from `2.0.0-SNAPSHOT` to `2.0.0` across `gradle.properties`, `Ballerina.toml`, `Dependencies.toml`, and `config.bal`
- Add `docs/disable-ssl.md` documenting both disable methods

## How to disable SSL

**Kubernetes / Docker — env var (recommended):**
```yaml
env:
  - name: BAL_CONFIG_VAR_SSLENABLED
    value: "false"
```

**Config file — `deployment.toml`:**
```toml
sslEnabled = false
```

## Test plan

- [x] Built and pushed multi-arch image (`linux/amd64`, `linux/arm64`) to `anuruddhal/wso2-integration-control-plane:2.0.0`
- [x] Deployed to local k8s (Rancher Desktop / k3s) with `BAL_CONFIG_VAR_SSLENABLED=false` — HTTP 200 on all ports, HTTPS rejected
- [x] Verified `config.json` shows `http://` URLs when SSL disabled, `https://` when enabled
- [x] Verified startup log prints correct scheme in both modes
- [x] Redeployed with SSL enabled (default) — HTTPS 200, HTTP rejected