### PR TITLE
[Devant migration] Fix GitHub App install flow and gate cloud-only behavior with IS_CLOUD

### DIFF
--- a/ipaas/src/components/ProjectCreate/GitProviderCards.tsx
+++ b/ipaas/src/components/ProjectCreate/GitProviderCards.tsx
@@ -20,6 +20,7 @@ import { Box, Card, CardActionArea, Stack, Tooltip, Typography } from '@wso2/oxy
 import { GitHub, Bitbucket, GitLab } from '@wso2/oxygen-ui-icons-react';
 import { type JSX } from 'react';
 import GitIcon from '../../assets/icons/GitIcon';
+import { IS_CLOUD } from '../../features';
 
 interface GitProviderCardsProps {
   onGitHubSelect: () => void;
@@ -27,9 +28,10 @@ interface GitProviderCardsProps {
 }
 
 export default function GitProviderCards({ onGitHubSelect, onPublicSelect }: GitProviderCardsProps): JSX.Element {
-  // Private GitHub needs the platform GitHub App; environments without a
-  // configured client id can only import public repos.
-  const gitHubEnabled = !!window.API_CONFIG.githubAppClientId;
+  // Cloud only: private GitHub needs the platform GitHub App, so environments
+  // without a configured client id can only import public repos. Other
+  // variants always render the card enabled, as before.
+  const gitHubEnabled = !IS_CLOUD || !!window.API_CONFIG.githubAppClientId;
   const gitHubCard = (
     <Card variant="outlined" sx={{ flex: 1, ...(gitHubEnabled ? {} : { height: '100%', opacity: 0.5 }) }}>
       <CardActionArea onClick={onGitHubSelect} disabled={!gitHubEnabled} sx={{ p: 2, ...(gitHubEnabled ? {} : { height: '100%' }) }}>

--- a/ipaas/src/hooks/useGitHubAuth.ts
+++ b/ipaas/src/hooks/useGitHubAuth.ts
@@ -21,6 +21,7 @@ import { useObtainGithubToken } from './useRepository';
 import { GITHUB_AUTH } from '../constants/github';
 import { buildGitHubAppInstallUrl, buildGitHubOAuthUrl } from '../paths';
 import { generateAndSaveGitHubState, validateAndClearGitHubState } from '../auth/tokenManager';
+import { IS_CLOUD } from '../features';
 import type { AuthStatus } from '../types/import';
 
 export interface UseGitHubAuthReturn {
@@ -29,6 +30,13 @@ export interface UseGitHubAuthReturn {
   startGitHubAuth: (onSuccess?: () => void) => void;
   /** Exchanges a raw OAuth auth code for a token (used when code arrives via location state). */
   exchangeAuthCode: (code: string) => Promise<void>;
+  /**
+   * Opens the GitHub App installation page in a popup. Must be called from a
+   * button click (a fresh user gesture) — popups opened after an async
+   * exchange are blocked by the browser. `onClosed` fires when the popup
+   * closes; the user then authorizes again to bind the new installation.
+   */
+  startGitHubAppInstall: (onClosed?: () => void) => void;
 }
 
 export function useGitHubAuth(initialStatus: AuthStatus = 'idle'): UseGitHubAuthReturn {
@@ -36,36 +44,59 @@ export function useGitHubAuth(initialStatus: AuthStatus = 'idle'): UseGitHubAuth
   const obtainToken = useObtainGithubToken();
 
   // Cloud GitHub-App flow: the user authorized the App but has not installed
-  // it on any account (exchange returns needsInstallation). Open GitHub's
-  // installation page and, when the popup closes, just report done so the
-  // caller re-fetches repos — never chain a second authorize popup (a
-  // non-gesture window.open is blocked and would hang the flow). If the user
-  // closed the popup without installing, the repo list stays empty and the
-  // Authorize button simply re-renders.
+  // it on any account (exchange returns needsInstallation, a bind 409 —
+  // git-app-service persists nothing in that case). We only flag the state
+  // here; the install popup must be opened by startGitHubAppInstall from a
+  // fresh button click — a window.open at this point runs after the async
+  // exchange, outside the user-activation window, and gets popup-blocked.
   const handleExchangeResult = (result: { success: boolean; needsInstallation?: boolean }, onSuccess?: () => void): void => {
     if (result.success) {
       setAuthStatus('done');
       onSuccess?.();
       return;
     }
-    const slug = window.API_CONFIG.githubAppSlug;
-    if (result.needsInstallation && slug) {
-      setAuthStatus('installing');
-      const installPopup = window.open(buildGitHubAppInstallUrl(slug), 'github-app-install', GITHUB_AUTH.POPUP_DIMENSIONS);
-      if (!installPopup) {
-        setAuthStatus('failed');
-        return;
-      }
-      const poll = setInterval(() => {
-        if (installPopup.closed) {
-          clearInterval(poll);
-          setAuthStatus('done');
-          onSuccess?.();
-        }
-      }, GITHUB_AUTH.POPUP_POLL_INTERVAL_MS);
+    if (IS_CLOUD && result.needsInstallation && window.API_CONFIG.githubAppSlug) {
+      setAuthStatus('needs-install');
       return;
     }
     setAuthStatus('failed');
+  };
+
+  const startGitHubAppInstall = (onClosed?: () => void): void => {
+    const slug = window.API_CONFIG.githubAppSlug;
+    if (!IS_CLOUD || !slug) return;
+    const popup = window.open(buildGitHubAppInstallUrl(slug), 'github-app-install', GITHUB_AUTH.POPUP_DIMENSIONS);
+    if (!popup) {
+      // Popup blocked: keep the Install CTA on screen so the user can allow
+      // pop-ups and retry, rather than bouncing back to a failed state.
+      setAuthStatus('needs-install');
+      return;
+    }
+    setAuthStatus('installing');
+    // Finish on either signal — the popup closing (reliable everywhere), or
+    // /ghapp posting the install redirect params (only when the App's Setup
+    // URL points at this console). On finish, drop back to idle so the
+    // Authorize button re-renders: the earlier bind persisted nothing, so the
+    // user re-authorizes (instant redirect — already authorized) and the
+    // fresh code binds the new installation. Never chain the authorize popup
+    // from here.
+    const channel = new BroadcastChannel(GITHUB_AUTH.BROADCAST_CHANNEL);
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      channel.close();
+      clearInterval(poll);
+      setAuthStatus('idle');
+      onClosed?.();
+    };
+    channel.onmessage = (event) => {
+      const { installationId, setupAction } = (event.data ?? {}) as { installationId?: string | null; setupAction?: string | null };
+      if (installationId || setupAction) finish();
+    };
+    const poll = setInterval(() => {
+      if (popup.closed) finish();
+    }, GITHUB_AUTH.POPUP_POLL_INTERVAL_MS);
   };
 
   const exchangeAuthCode = async (code: string): Promise<void> => {
@@ -113,5 +144,5 @@ export function useGitHubAuth(initialStatus: AuthStatus = 'idle'): UseGitHubAuth
     };
   };
 
-  return { authStatus, startGitHubAuth, exchangeAuthCode };
+  return { authStatus, startGitHubAuth, exchangeAuthCode, startGitHubAppInstall };
 }

--- a/ipaas/src/pages/CreateIntegrationOptions.tsx
+++ b/ipaas/src/pages/CreateIntegrationOptions.tsx
@@ -23,6 +23,7 @@ import { useNavigate } from 'react-router';
 import { useCreateComponent } from '../hooks/useComponents';
 import { useChoreoSampleImages } from '../hooks/useRepository';
 import { generateAndSaveGitHubState, validateAndClearGitHubState } from '../auth/tokenManager';
+import { IS_CLOUD } from '../features';
 import { useOrgUuid } from '../hooks/useOrgUuid';
 import { useAuth } from '../auth/AuthContext';
 import IDEMockup from '../components/IDEMockup/IDEMockup';
@@ -88,10 +89,11 @@ export default function CreateIntegrationOptions(scope: ProjectScope): JSX.Eleme
   const handleImportClick = () => {
     const { githubAppClientId, githubAppAuthRedirectUrl } = window.API_CONFIG;
     if (!githubAppClientId) {
-      // No GitHub App configured — private-repo authorization is impossible,
-      // so land the import page in public-URL mode instead of its default
-      // (private) mode with a dead Authorize button.
-      navigate(importUrl, { state: { mode: 'public' } });
+      // Cloud only: no GitHub App configured means private-repo authorization
+      // is impossible, so land the import page in public-URL mode instead of
+      // its default (private) mode with a dead Authorize button. Other
+      // variants keep the original navigation.
+      navigate(importUrl, IS_CLOUD ? { state: { mode: 'public' } } : undefined);
       return;
     }
     setIsImportAuthenticating(true);

--- a/ipaas/src/pages/CreateProject.tsx
+++ b/ipaas/src/pages/CreateProject.tsx
@@ -33,6 +33,7 @@ import { FREE_COMPONENT_LIMIT, URL_DEBOUNCE_MS } from '../constants/project';
 import { useProjectHandler } from '../hooks/useProjectHandler';
 import { resourceUrl, narrow, type OrgScope } from '../nav';
 import { useGitHubAuth } from '../hooks/useGitHubAuth';
+import { IS_CLOUD } from '../features';
 import { toHandler } from '../utils/string';
 import { parseGitHubUrl } from '../utils/github';
 import { isBallerinaWorkspace } from '../utils/technologyDetection';
@@ -76,7 +77,7 @@ export default function CreateProject(scope: OrgScope): JSX.Element {
   const colSize = !isPublicRepo && showBranchAndSubPath ? 3 : 4;
 
   const { handler: effectiveHandler, handlerEdited, isCheckingAvailability, availability, startEditing, stopEditing, onHandlerChange } = useProjectHandler(displayName);
-  const { authStatus, startGitHubAuth } = useGitHubAuth();
+  const { authStatus, startGitHubAuth, startGitHubAppInstall } = useGitHubAuth();
   const createProject = useCreateProject();
   const createMonoRepoProject = useCreateMonoRepoProject();
   const createComponent = useCreateComponent();
@@ -303,7 +304,7 @@ export default function CreateProject(scope: OrgScope): JSX.Element {
       );
     }
     if (isAuthenticated) return null;
-    if (authStatus === 'authenticating' || authStatus === 'installing') {
+    if (authStatus === 'authenticating' || (IS_CLOUD && authStatus === 'installing')) {
       return (
         <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 3, minHeight: 40 }}>
           <CircularProgress size={16} />
@@ -323,6 +324,30 @@ export default function CreateProject(scope: OrgScope): JSX.Element {
             Try again
           </Button>
         </Stack>
+      );
+    }
+    // Cloud only: authorized, but the GitHub App is not installed on any
+    // account yet. The install popup must open from this button's click —
+    // opening it straight from the token exchange gets popup-blocked (no
+    // user gesture).
+    if (IS_CLOUD && authStatus === 'needs-install') {
+      return (
+        <Box sx={{ mb: 3 }}>
+          <Alert severity="info" sx={{ mb: 1.5 }}>
+            The GitHub App is not installed on any of your accounts yet. Install it on the account or organization that owns your repository, then authorize again.
+          </Alert>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={
+              <Box sx={{ color: 'common.black', display: 'flex' }}>
+                <GitHub size={16} />
+              </Box>
+            }
+            onClick={() => startGitHubAppInstall(refetchRepos)}>
+            Install GitHub App
+          </Button>
+        </Box>
       );
     }
     return (

--- a/ipaas/src/pages/GitHubOAuthCallback.tsx
+++ b/ipaas/src/pages/GitHubOAuthCallback.tsx
@@ -19,6 +19,7 @@
 import { Box, CircularProgress, Typography } from '@wso2/oxygen-ui';
 import { useEffect, type JSX } from 'react';
 import { GITHUB_AUTH } from '../constants/github';
+import { IS_CLOUD } from '../features';
 
 export default function GitHubOAuthCallback(): JSX.Element {
   useEffect(() => {
@@ -26,14 +27,13 @@ export default function GitHubOAuthCallback(): JSX.Element {
     const code = params.get('code');
     const state = params.get('state');
     const channel = new BroadcastChannel(GITHUB_AUTH.BROADCAST_CHANNEL);
-    // installationId/setupAction are present only when GitHub redirects here
-    // after a GitHub App installation (App "Setup URL" pointed at /ghapp);
-    // listeners that only destructure authCode/state are unaffected.
+    // Cloud only: installationId/setupAction are present when GitHub redirects
+    // here after a GitHub App installation (App "Setup URL" pointed at /ghapp).
+    // Other variants post the original { authCode, state } shape untouched.
     channel.postMessage({
       authCode: code ?? null,
       state: state ?? null,
-      installationId: params.get('installation_id'),
-      setupAction: params.get('setup_action'),
+      ...(IS_CLOUD ? { installationId: params.get('installation_id'), setupAction: params.get('setup_action') } : {}),
     });
     channel.close();
     window.close();

--- a/ipaas/src/pages/ImportIntegration.tsx
+++ b/ipaas/src/pages/ImportIntegration.tsx
@@ -34,6 +34,7 @@ import { SAMPLE_REPO_URL } from '../constants/github';
 import { URL_DEBOUNCE_MS } from '../constants/project';
 import { resourceUrl, narrow, newComponentUrl, type ProjectScope } from '../nav';
 import { useGitHubAuth } from '../hooks/useGitHubAuth';
+import { IS_CLOUD } from '../features';
 import { toHandler, formatRepoNameToDisplayName } from '../utils/string';
 import { parseGitHubUrl } from '../utils/github';
 import { detectTechnology } from '../utils/technologyDetection';
@@ -52,7 +53,7 @@ export default function ImportIntegration(scope: ProjectScope): JSX.Element {
   const [sourceMode] = useState<SourceMode>(locationState?.mode ?? 'github');
   const isPublicRepo = sourceMode === 'public';
 
-  const { authStatus, startGitHubAuth, exchangeAuthCode } = useGitHubAuth(preAuthenticated ? 'done' : pendingAuthCode ? 'authenticating' : 'idle');
+  const { authStatus, startGitHubAuth, exchangeAuthCode, startGitHubAppInstall } = useGitHubAuth(preAuthenticated ? 'done' : pendingAuthCode ? 'authenticating' : 'idle');
   const [selectedOrg, setSelectedOrg] = useState('');
   const [selectedRepo, setSelectedRepo] = useState('');
 
@@ -276,10 +277,10 @@ export default function ImportIntegration(scope: ProjectScope): JSX.Element {
         repositoryBranch: selectedBranch,
         repositorySubPath: subPath || '/',
         isPublicRepo,
-        // Private repos build through the GitHub App installation that grants
-        // access (cloud sets installationId on UserRepo; other variants don't
-        // and ignore the field).
-        ...(isPublicRepo ? { enableAutoDeploy: true } : { gitHubAppInstallationId: userRepos?.find((o) => o.orgName === activeOrg)?.installationId }),
+        // Private repos in the cloud variant build through the GitHub App
+        // installation that grants access; other variants keep their original
+        // payload untouched.
+        ...(isPublicRepo ? { enableAutoDeploy: true } : IS_CLOUD ? { gitHubAppInstallationId: userRepos?.find((o) => o.orgName === activeOrg)?.installationId } : {}),
       },
       {
         onSuccess: (component) => navigate(resourceUrl(narrow(scope, component.handler), 'overview')),
@@ -327,35 +328,53 @@ export default function ImportIntegration(scope: ProjectScope): JSX.Element {
         </Box>
       );
     }
+    // Cloud only: authorized, but the GitHub App is not installed on any
+    // account yet. The install popup must open from this button's click —
+    // opening it straight from the token exchange gets popup-blocked (no
+    // user gesture).
+    if (IS_CLOUD && authStatus === 'needs-install') {
+      return (
+        <Box sx={{ mb: 4 }}>
+          <Alert severity="info" sx={{ mb: 1.5 }}>
+            The GitHub App is not installed on any of your accounts yet. Install it on the account or organization that owns your repository, then authorize again.
+          </Alert>
+          <Button
+            variant="outlined"
+            startIcon={
+              <Box sx={{ color: 'common.black', display: 'flex' }}>
+                <GitHub size={16} />
+              </Box>
+            }
+            onClick={() => startGitHubAppInstall(refetchRepos)}
+            size="small">
+            Install GitHub App
+          </Button>
+        </Box>
+      );
+    }
+
+    // The authenticating/installing states never reach here — the page-level
+    // early return above renders the full-page progress view for them.
     return (
       <Box sx={{ mb: 4 }}>
-        {authStatus === 'authenticating' || authStatus === 'installing' ? (
-          <Stack direction="row" spacing={1.5} alignItems="center" sx={{ minHeight: 50 }}>
-            <CircularProgress size={16} />
-            <Typography color="text.secondary" variant="body2">
-              {authStatus === 'installing' ? 'Install the GitHub App in the popup, then return here…' : 'Completing GitHub authorization…'}
-            </Typography>
-          </Stack>
-        ) : (
-          <Box>
-            {authStatus === 'failed' && (
-              <Alert severity="error" sx={{ mb: 1.5 }}>
-                GitHub authorization failed. Please try again.
-              </Alert>
-            )}
-            <Button
-              variant="outlined"
-              startIcon={
-                <Box sx={{ color: 'common.black', display: 'flex' }}>
-                  <GitHub size={16} />
-                </Box>
-              }
-              onClick={() => startGitHubAuth(refetchRepos)}
-              size="small">
-              Authorize with GitHub
-            </Button>
-          </Box>
-        )}
+        <Box>
+          {authStatus === 'failed' && (
+            <Alert severity="error" sx={{ mb: 1.5 }}>
+              GitHub authorization failed. Please try again.
+            </Alert>
+          )}
+          <Button
+            variant="outlined"
+            startIcon={
+              <Box sx={{ color: 'common.black', display: 'flex' }}>
+                <GitHub size={16} />
+              </Box>
+            }
+            onClick={() => startGitHubAuth(refetchRepos)}
+            size="small">
+            Authorize with GitHub
+          </Button>
+        </Box>
       </Box>
     );
   };
@@ -529,7 +548,7 @@ export default function ImportIntegration(scope: ProjectScope): JSX.Element {
 
   // Early returns
 
-  if (!isPublicRepo && (authStatus === 'authenticating' || authStatus === 'installing')) {
+  if (!isPublicRepo && (authStatus === 'authenticating' || (IS_CLOUD && authStatus === 'installing'))) {
     return (
       <PageContent sx={{ pt: 5 }}>
         <Button startIcon={<ArrowLeft size={16} />} onClick={() => navigate(backUrl)} sx={{ mb: 3 }}>

--- a/ipaas/src/pages/ImportProject.tsx
+++ b/ipaas/src/pages/ImportProject.tsx
@@ -34,6 +34,7 @@ import { FREE_COMPONENT_LIMIT, URL_DEBOUNCE_MS } from '../constants/project';
 import { useProjectHandler } from '../hooks/useProjectHandler';
 import { resourceUrl, narrow, type OrgScope } from '../nav';
 import { useGitHubAuth } from '../hooks/useGitHubAuth';
+import { IS_CLOUD } from '../features';
 import { toHandler } from '../utils/string';
 import { parseGitHubUrl } from '../utils/github';
 import { isBallerinaWorkspace } from '../utils/technologyDetection';
@@ -84,7 +85,7 @@ export default function ImportProject(scope: OrgScope): JSX.Element {
   const quotaRemaining = isUpgraded ? undefined : Math.max(0, FREE_COMPONENT_LIMIT - orgBillableCount);
 
   const { handler: effectiveHandler, handlerEdited, isCheckingAvailability, availability, startEditing, stopEditing, onHandlerChange } = useProjectHandler(displayName);
-  const { authStatus, startGitHubAuth } = useGitHubAuth();
+  const { authStatus, startGitHubAuth, startGitHubAppInstall } = useGitHubAuth();
   const createMonoRepoProject = useCreateMonoRepoProject();
   const createComponent = useCreateComponent();
 
@@ -258,7 +259,7 @@ export default function ImportProject(scope: OrgScope): JSX.Element {
       );
     }
     if (isAuthenticated) return null;
-    if (authStatus === 'authenticating' || authStatus === 'installing') {
+    if (authStatus === 'authenticating' || (IS_CLOUD && authStatus === 'installing')) {
       return (
         <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 3, minHeight: 40 }}>
           <CircularProgress size={16} />
@@ -278,6 +279,30 @@ export default function ImportProject(scope: OrgScope): JSX.Element {
             Try again
           </Button>
         </Stack>
+      );
+    }
+    // Cloud only: authorized, but the GitHub App is not installed on any
+    // account yet. The install popup must open from this button's click —
+    // opening it straight from the token exchange gets popup-blocked (no
+    // user gesture).
+    if (IS_CLOUD && authStatus === 'needs-install') {
+      return (
+        <Box sx={{ mb: 3 }}>
+          <Alert severity="info" sx={{ mb: 1.5 }}>
+            The GitHub App is not installed on any of your accounts yet. Install it on the account or organization that owns your repository, then authorize again.
+          </Alert>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={
+              <Box sx={{ color: 'common.black', display: 'flex' }}>
+                <GitHub size={16} />
+              </Box>
+            }
+            onClick={() => startGitHubAppInstall(refetchRepos)}>
+            Install GitHub App
+          </Button>
+        </Box>
       );
     }
     return (

--- a/ipaas/src/pages/Project.tsx
+++ b/ipaas/src/pages/Project.tsx
@@ -78,6 +78,7 @@ import NotFound from '../components/NotFound';
 import { formatDistanceToNow } from '../utils/time';
 import { resourceUrl, broaden, narrow, newComponentUrl, type ProjectScope } from '../nav';
 import { generateAndSaveGitHubState, validateAndClearGitHubState } from '../auth/tokenManager';
+import { IS_CLOUD } from '../features';
 import { useOrgUuid } from '../hooks/useOrgUuid';
 import { useAuth } from '../auth/AuthContext';
 import { componentOverviewUrl, importComponentUrl, browseSamplesUrl, prebuiltIntegrationsUrl, importComingSoonUrl, buildGitHubOAuthUrl } from '../paths';
@@ -163,10 +164,11 @@ function EmptyProjectView({ scope, projectId }: { scope: ProjectScope; projectId
     if (!checkCreationGuard()) return;
     const { githubAppClientId, githubAppAuthRedirectUrl } = window.API_CONFIG;
     if (!githubAppClientId) {
-      // No GitHub App configured — private-repo authorization is impossible,
-      // so land the import page in public-URL mode instead of its default
-      // (private) mode with a dead Authorize button.
-      navigate(importUrl, { state: { mode: 'public' } });
+      // Cloud only: no GitHub App configured means private-repo authorization
+      // is impossible, so land the import page in public-URL mode instead of
+      // its default (private) mode with a dead Authorize button. Other
+      // variants keep the original navigation.
+      navigate(importUrl, IS_CLOUD ? { state: { mode: 'public' } } : undefined);
       return;
     }
     setIsImportAuthenticating(true);

--- a/ipaas/src/types/import.ts
+++ b/ipaas/src/types/import.ts
@@ -22,7 +22,7 @@ import type { GitProvider, WorkspaceIntegrationType } from './project';
 export type { GitProvider as SourceMode } from './project';
 export type { WorkspaceIntegrationType as IntegrationType } from './project';
 
-export type AuthStatus = 'idle' | 'authenticating' | 'installing' | 'done' | 'failed';
+export type AuthStatus = 'idle' | 'authenticating' | 'needs-install' | 'installing' | 'done' | 'failed';
 
 export interface LocationState {
   authCode?: string;


### PR DESCRIPTION
## Purpose
Install flow (bind 409 = authorized but App not installed):
- Render an 'Install GitHub App' CTA instead of auto-opening the install popup from the async token exchange, where window.open runs outside the user-activation window and gets popup-blocked (matches sample-console's handleInstall: popup only from a button click, never chained)
- On a blocked popup keep the CTA on screen for a retry instead of failing the flow
- Finish install on either popup close (reliable everywhere) or the /ghapp install-redirect message, then return to the Authorize button — the 409 bind persists nothing, so a fresh authorize binds the new installation

Gating: all cloud-only GitHub-App behavior in shared code is now behind the build-time IS_CLOUD flag (dead-code-eliminated from wip/icp bundles): needs-install/installing states, install popup, create-payload installationId, /ghapp extra params, provider-card disabling, and the no-clientId public-mode fallback. wip/icp behavior is byte-identical to before the feature.


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.