### PR TITLE
[devant-migration] Improve UX: lazy loading, centered loaders, sidebar persistence, card components

### DIFF
--- a/ipaas/src/components/ArtifactDetail.tsx
+++ b/ipaas/src/components/ArtifactDetail.tsx
@@ -337,7 +337,12 @@ export function ArtifactTypeSelector({ envId, componentId, onSelectArtifact }: {
   const selectedArtifactType = selectedType ?? types[0]?.artifactType ?? '';
   const { data: artifacts = [], isLoading: loadingArtifacts } = useArtifacts(selectedArtifactType, envId, componentId);
 
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (types.length === 0)
     return (
       <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>
@@ -370,7 +375,9 @@ export function ArtifactTypeSelector({ envId, componentId, onSelectArtifact }: {
         </Typography>
         <SearchField value={query} onChange={setQuery} placeholder={`Search ${typePlural(selectedArtifactType)} by name`} fullWidth sx={{ mb: 2 }} />
         {loadingArtifacts ? (
-          <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={24} />
+          </Box>
         ) : (
           <SelectedTypeArtifacts artifacts={artifacts} artifactType={selectedArtifactType} envId={envId} componentId={componentId} query={query} onSelect={(a) => onSelectArtifact(a, selectedArtifactType, envId)} />
         )}

--- a/ipaas/src/components/ArtifactTabs.tsx
+++ b/ipaas/src/components/ArtifactTabs.tsx
@@ -30,7 +30,12 @@ import type { TabProps } from './artifact-config';
 export function ArtifactSource({ envId, componentId, artifactType, artifact }: TabProps) {
   const sourceType = ARTIFACT_TYPE_TO_SOURCE_TYPE[artifactType] ?? artifactType.toLowerCase();
   const { data: source, isLoading, error } = useArtifactSource(envId, componentId, sourceType, artifact.name?.toString() ?? '');
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (error || !source) return <Typography sx={emptySx}>No source content available.</Typography>;
 
   return <CodeViewer code={source} language="xml" />;
@@ -100,14 +105,24 @@ export function ServiceResources({ artifact }: TabProps) {
 export function ArtifactWsdl({ envId, componentId, artifactType, artifact }: TabProps) {
   const backendType = ARTIFACT_TYPE_TO_SOURCE_TYPE[artifactType] ?? artifactType.toLowerCase();
   const { data: wsdl, isLoading, error } = useArtifactWsdl(componentId, backendType, artifact.name, envId);
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (error || !wsdl) return <Typography sx={emptySx}>No WSDL content available.</Typography>;
   return <CodeViewer code={wsdl} language="xml" />;
 }
 
 export function ArtifactValue({ artifact, envId, componentId }: TabProps) {
   const { data: value, isLoading } = useLocalEntryValue(componentId, artifact.name?.toString() ?? '', envId);
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (!value) return <Typography sx={emptySx}>No value available.</Typography>;
   return <CodeViewer code={value} language="xml" />;
 }
@@ -139,7 +154,12 @@ export function InboundEndpointParameters({ artifact, envId, componentId, artifa
   const artifactName = artifact.name?.toString() ?? '';
   const backendType = ARTIFACT_TYPE_TO_SOURCE_TYPE[artifactType] ?? artifactType.toLowerCase();
   const { data: params, isLoading, error } = useArtifactParams(componentId, backendType, artifactName, envId);
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (error) return <Typography sx={emptySx}>Failed to load parameters.</Typography>;
   if (!params || params.length === 0) return <Typography sx={emptySx}>No parameters found.</Typography>;
 
@@ -315,7 +335,12 @@ export function ProxyApiReference({ envId, componentId, artifactType, artifact }
 
   const info = useMemo(() => (wsdl ? parseWsdl(wsdl) : null), [wsdl]);
 
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (error || !wsdl) return <Typography sx={emptySx}>No WSDL content available.</Typography>;
   if (!info) return <Typography sx={emptySx}>Could not parse WSDL.</Typography>;
 

--- a/ipaas/src/components/Connections/ConnectionsLanding.tsx
+++ b/ipaas/src/components/Connections/ConnectionsLanding.tsx
@@ -77,7 +77,9 @@ export default function ConnectionsLanding({ projectId, componentId, base }: Con
   if ((isLoading || isFetching) && projectId) {
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/components/Connections/ConnectionsListView.tsx
+++ b/ipaas/src/components/Connections/ConnectionsListView.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, IconButton, ListingTable, MenuItem, PageTitle, Select, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, IconButton, ListingTable, MenuItem, PageTitle, Select, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -98,7 +98,9 @@ export default function ConnectionsListView({ projectId, componentId, base }: Co
       )}
 
       {isLoading || (isFetching && !connections?.length) ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/components/Containers/ContainerInfoCard.tsx
+++ b/ipaas/src/components/Containers/ContainerInfoCard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Box, Button, Chip, Grid, IconButton, Slider, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, Grid, IconButton, Paper, Slider, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Check, Clock, Copy, Pencil } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import ResourceRangeSlider from '../common/ResourceRangeSlider';
@@ -36,7 +36,7 @@ interface ContainerInfoCardProps {
   onError: (message: string) => void;
 }
 
-const cardSx = { border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 3, mb: 2 } as const;
+const cardSx = { p: 3, mb: 2 } as const;
 const cpuFmt = (v: number): string => String(Math.round(v * 100) / 100);
 const memFmt = (v: number): string => String(Math.round(v));
 
@@ -66,7 +66,7 @@ export default function ContainerInfoCard({ container: c, projectId, componentId
   const policyLabel = c.image_pull_policy === 'Always' ? 'Always' : 'If Not Present';
 
   return (
-    <Box sx={cardSx}>
+    <Paper variant="outlined" sx={cardSx}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
         <Stack direction="row" alignItems="center" gap={1.5}>
           <Typography variant="h6" fontWeight={700}>
@@ -109,7 +109,7 @@ export default function ContainerInfoCard({ container: c, projectId, componentId
       </Grid>
 
       <CommandAndArgs command={c.command} args={c.args} />
-    </Box>
+    </Paper>
   );
 }
 

--- a/ipaas/src/components/DataPlanes/PdpProgressDrawer.tsx
+++ b/ipaas/src/components/DataPlanes/PdpProgressDrawer.tsx
@@ -47,7 +47,9 @@ export default function PdpProgressDrawer({ open, pdpName, onClose }: PdpProgres
       return (
         <Drawer anchor="right" open onClose={onClose}>
           <Box sx={drawerBody}>
-            <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+              <CircularProgress />
+            </Box>
           </Box>
         </Drawer>
       );

--- a/ipaas/src/components/Databases/detail/BackupsTab.tsx
+++ b/ipaas/src/components/Databases/detail/BackupsTab.tsx
@@ -26,7 +26,12 @@ export default function BackupsTab({ serverId }: { serverId: string }): JSX.Elem
   const { data, isLoading, isError, refetch } = useServerBackups(serverId);
   const backups = data?.backups ?? [];
 
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (isError) {
     return (
       <Alert

--- a/ipaas/src/components/Databases/detail/DatabasesTab.tsx
+++ b/ipaas/src/components/Databases/detail/DatabasesTab.tsx
@@ -61,7 +61,12 @@ export default function DatabasesTab({ service, orgHandle }: { service: Database
     });
   }, [databases, credentialsByDb, filters, search]);
 
-  if (databasesQuery.isLoading || credentialsQuery.isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />;
+  if (databasesQuery.isLoading || credentialsQuery.isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (databasesQuery.isError || credentialsQuery.isError) {
     const retry = () => {
       if (databasesQuery.isError) databasesQuery.refetch();

--- a/ipaas/src/components/Databases/detail/MetricsTab.tsx
+++ b/ipaas/src/components/Databases/detail/MetricsTab.tsx
@@ -43,7 +43,9 @@ export default function MetricsTab({ serverId }: { serverId: string }): JSX.Elem
       </Stack>
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/components/Databases/detail/databases/CredentialDialog.tsx
+++ b/ipaas/src/components/Databases/detail/databases/CredentialDialog.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Autocomplete, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, InputAdornment, Stack, TextField } from '@wso2/oxygen-ui';
+import { Alert, Autocomplete, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, InputAdornment, Stack, TextField } from '@wso2/oxygen-ui';
 import { Eye, EyeOff } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useMemo, useState, type JSX } from 'react';
 import { useCreateDbCredential, useDbCredential, useUpdateDbCredential } from '../../../../hooks/usePlatformServices';
@@ -101,7 +101,9 @@ export default function CredentialDialog({ serverId, orgHandle, dbName, defaultU
         </Alert>
 
         {isEdit && loadingExisting ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 4 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
         ) : (
           <Stack gap={2.5} sx={{ mt: 1 }}>
             {!isEdit && (

--- a/ipaas/src/components/Documents/DocFormPage.tsx
+++ b/ipaas/src/components/Documents/DocFormPage.tsx
@@ -76,7 +76,11 @@ export default function DocFormPage({ view, initialName, initialType, initialOth
         <Button variant="outlined" onClick={onBack} disabled={saving}>
           Back
         </Button>
-        <Button variant="contained" onClick={() => onSave(name.trim(), type, otherType.trim(), content === PLACEHOLDER ? '' : content, initialSourceType)} disabled={!isValid || saving} startIcon={saving ? <CircularProgress size={14} color="inherit" /> : undefined}>
+        <Button
+          variant="contained"
+          onClick={() => onSave(name.trim(), type, otherType.trim(), content === PLACEHOLDER ? '' : content, initialSourceType)}
+          disabled={!isValid || saving}
+          startIcon={saving ? <CircularProgress size={14} color="inherit" /> : undefined}>
           {saving ? 'Saving...' : isCreate ? 'Create' : 'Save'}
         </Button>
       </Stack>

--- a/ipaas/src/components/EntryPoints.tsx
+++ b/ipaas/src/components/EntryPoints.tsx
@@ -443,7 +443,12 @@ function EntryPointsList({ envId, componentId, projectId, componentType, onOpenD
     [allEntryPoints, activeKey],
   );
 
-  if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
   if (allEntryPoints.length === 0)
     return (
       <Typography color="text.secondary" sx={{ py: 4, textAlign: 'center' }}>

--- a/ipaas/src/components/ExternalCI/CiTokensTable.tsx
+++ b/ipaas/src/components/ExternalCI/CiTokensTable.tsx
@@ -78,7 +78,9 @@ export default function CiTokensTable({ projectId, componentId, canManage }: { p
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/components/HealthChecks/HealthCheckCard.tsx
+++ b/ipaas/src/components/HealthChecks/HealthCheckCard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, Button, Divider, IconButton, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, Divider, IconButton, Paper, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Pencil, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import ProbeDisplay from './ProbeDisplay';
@@ -36,7 +36,7 @@ interface HealthCheckCardProps {
   onNotify: (type: 'success' | 'error', message: string) => void;
 }
 
-const cardSx = { border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 3, mb: 2 } as const;
+const cardSx = { p: 3, mb: 2 } as const;
 
 export default function HealthCheckCard({ healthCheck: hc, container, projectId, componentId, releaseId, canManage, onNotify }: HealthCheckCardProps): JSX.Element {
   const [formKind, setFormKind] = useState<ProbeKind | null>(null);
@@ -96,7 +96,7 @@ export default function HealthCheckCard({ healthCheck: hc, container, projectId,
   const missingKind: ProbeKind = hasLiveness ? PROBE_KIND.READINESS : PROBE_KIND.LIVENESS;
 
   return (
-    <Box sx={cardSx}>
+    <Paper variant="outlined" sx={cardSx}>
       <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
         <Typography variant="body2" color="text.secondary">
           Container: {container.name}
@@ -123,7 +123,7 @@ export default function HealthCheckCard({ healthCheck: hc, container, projectId,
           <ProbeDisplay probe={hc.probes.readiness_probe} showSuccess />
         </Box>
       )}
-    </Box>
+    </Paper>
   );
 }
 

--- a/ipaas/src/components/Logs/LogsPanel.tsx
+++ b/ipaas/src/components/Logs/LogsPanel.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Button, CircularProgress, Stack, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, CircularProgress, Stack, Typography } from '@wso2/oxygen-ui';
 import { AlertTriangle, RefreshCw, ScrollText } from '@wso2/oxygen-ui-icons-react';
 import { Fragment, useCallback, useEffect, useRef, useState, type JSX, type ReactNode } from 'react';
 
@@ -93,7 +93,11 @@ export default function LogsPanel<T>({
   }, [handleScroll, paginated]);
 
   if (isLoading) {
-    return <CircularProgress size={28} sx={{ display: 'block', mx: 'auto', my: 6 }} />;
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', my: 6 }}>
+        <CircularProgress size={28} />
+      </Box>
+    );
   }
 
   if (error) {
@@ -156,7 +160,11 @@ export default function LogsPanel<T>({
       {paginated && (
         <>
           <div ref={sentinelRef} />
-          {isFetchingNextPage && <CircularProgress size={20} sx={{ display: 'block', mx: 'auto', my: 1 }} />}
+          {isFetchingNextPage && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', my: 1 }}>
+              <CircularProgress size={20} />
+            </Box>
+          )}
           {!hasNextPage && (
             <Typography variant="body2" color="text.secondary" textAlign="center" sx={{ py: 1 }}>
               End of logs

--- a/ipaas/src/components/Overview/tailscale-vpn/TailscaleCustomOverview.tsx
+++ b/ipaas/src/components/Overview/tailscale-vpn/TailscaleCustomOverview.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, type JSX } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, type JSX } from '@wso2/oxygen-ui';
 import TailscaleOverview from './TailscaleOverview';
 import { Permissions } from '../../../constants/permissions';
 import { useAccessControl } from '../../../contexts/AccessControlContext';
@@ -40,7 +40,12 @@ export default function TailscaleCustomOverview({ component }: OverviewHeaderSlo
   const { hasAnyPermission } = useAccessControl();
   const canManage = hasAnyPermission([Permissions.INTEGRATION_MANAGE], projectId || undefined, component.id);
 
-  if (!detail) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (!detail)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
 
   return <TailscaleOverview orgHandler={scope.org} projectId={projectId} component={detail} environments={environments} canManage={canManage} />;
 }

--- a/ipaas/src/components/Overview/tailscale-vpn/TailscaleOverview.tsx
+++ b/ipaas/src/components/Overview/tailscale-vpn/TailscaleOverview.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, CircularProgress, Stack, type JSX } from '@wso2/oxygen-ui';
+import { Alert, Box, CircularProgress, Stack, type JSX } from '@wso2/oxygen-ui';
 import { useMemo } from 'react';
 import TailscaleComponentInfo from './TailscaleComponentInfo';
 import TailscaleEnvCard from './TailscaleEnvCard';
@@ -48,7 +48,9 @@ export default function TailscaleOverview({ orgHandler, projectId, component, en
       {!versionId ? (
         <Alert severity="info">This proxy has no deployment track yet.</Alert>
       ) : environments.length === 0 ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
       ) : (
         <Stack>
           {environments.map((env) => (

--- a/ipaas/src/components/Runtime/PodInsightsTable.tsx
+++ b/ipaas/src/components/Runtime/PodInsightsTable.tsx
@@ -90,7 +90,9 @@ export default function PodInsightsTable({ pods, metrics, replicas, isLoading, i
       </Stack>
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/components/Scaling/HpaConfig.tsx
+++ b/ipaas/src/components/Scaling/HpaConfig.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, Button, CircularProgress, FormControlLabel, Slider, Stack, Switch, Typography } from '@wso2/oxygen-ui';
+import { Box, Button, CircularProgress, FormControlLabel, Paper, Slider, Stack, Switch, Typography } from '@wso2/oxygen-ui';
 import { useEffect, useState, type JSX } from 'react';
 import { useCreateHpa, useHpaMetricMutations, useUpdateHpa } from '../../hooks/useScaling';
 import { CPU_THRESHOLD, MEMORY_THRESHOLD } from '../../constants/scaling';
@@ -63,7 +63,7 @@ function ThresholdSlider({
   disabled: boolean;
 }): JSX.Element {
   return (
-    <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, p: 2, flex: 1, minWidth: 260 }}>
+    <Paper variant="outlined" sx={{ p: 2, flex: 1, minWidth: 260 }}>
       <FormControlLabel control={<Switch checked={enabled} onChange={(e) => onToggle(e.target.checked)} disabled={disabled} />} label={label} />
       <Box sx={{ px: 1, mt: 1, opacity: enabled ? 1 : 0.5 }}>
         <Slider value={value} min={min} max={max} onChange={(_e, v) => onChange(v as number)} disabled={disabled || !enabled} valueLabelDisplay="auto" />
@@ -71,7 +71,7 @@ function ThresholdSlider({
           {value}% utilization
         </Typography>
       </Box>
-    </Box>
+    </Paper>
   );
 }
 

--- a/ipaas/src/components/Scaling/ReplicasTable.tsx
+++ b/ipaas/src/components/Scaling/ReplicasTable.tsx
@@ -71,7 +71,9 @@ export default function ReplicasTable({ projectId, clusterId, releaseId, dataPla
       </Stack>
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
       ) : rows.length === 0 ? (
         <Typography variant="body2" color="text.secondary" sx={{ py: 3 }}>
           No running replicas.

--- a/ipaas/src/components/Scaling/ScaleMethodCard.tsx
+++ b/ipaas/src/components/Scaling/ScaleMethodCard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Box, Stack, Typography } from '@wso2/oxygen-ui';
+import { Card, CardActionArea, CardContent, Typography } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 
 interface ScaleMethodCardProps {
@@ -29,41 +29,29 @@ interface ScaleMethodCardProps {
 
 export default function ScaleMethodCard({ title, description, selected, disabled, onSelect }: ScaleMethodCardProps): JSX.Element {
   return (
-    <Box
-      role="button"
-      tabIndex={disabled ? -1 : 0}
-      aria-pressed={selected}
-      aria-disabled={disabled}
-      onClick={disabled ? undefined : onSelect}
-      onKeyDown={(e) => {
-        if (disabled) return;
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect();
-        }
-      }}
+    <Card
+      variant="outlined"
       sx={{
         flex: 1,
         minWidth: 280,
         maxWidth: 420,
-        border: '1px solid',
+        border: '2px solid',
         borderColor: selected ? 'primary.main' : 'divider',
-        bgcolor: selected ? 'action.hover' : 'transparent',
-        borderRadius: 1,
-        p: 2,
-        cursor: disabled ? 'not-allowed' : 'pointer',
+        bgcolor: selected ? 'primary.50' : 'background.paper',
         opacity: disabled ? 0.55 : 1,
-        transition: 'border-color 0.15s',
+        transition: 'border-color 0.15s, background-color 0.15s',
         '&:hover': disabled ? undefined : { borderColor: 'primary.main' },
       }}>
-      <Stack gap={1}>
-        <Typography variant="body1" sx={{ fontWeight: 600 }}>
-          {title}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          {description}
-        </Typography>
-      </Stack>
-    </Box>
+      <CardActionArea disabled={disabled} aria-pressed={selected} onClick={onSelect} sx={{ height: '100%' }}>
+        <CardContent>
+          <Typography variant="body1" sx={{ fontWeight: 600, mb: 0.5, color: selected ? 'primary.main' : 'text.primary' }}>
+            {title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {description}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
   );
 }

--- a/ipaas/src/components/ServiceCatalog/detail/EndpointsTab.tsx
+++ b/ipaas/src/components/ServiceCatalog/detail/EndpointsTab.tsx
@@ -100,7 +100,12 @@ export default function EndpointsTab({ service, orgHandle, canEdit }: { service:
     });
 
   if (!schemaId) return <Alert severity="info">This service has no connection schema.</Alert>;
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (isError) {
     return (
       <Alert

--- a/ipaas/src/components/Settings/AccessControl/shared.tsx
+++ b/ipaas/src/components/Settings/AccessControl/shared.tsx
@@ -16,11 +16,15 @@
  * under the License.
  */
 
-import { Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Stack } from '@wso2/oxygen-ui';
+import { Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Stack } from '@wso2/oxygen-ui';
 import { type JSX, type ReactNode } from 'react';
 
 export function Loading(): JSX.Element {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 export function FormDialog({

--- a/ipaas/src/components/Settings/AppSecurity/IdentityProvidersTab.tsx
+++ b/ipaas/src/components/Settings/AppSecurity/IdentityProvidersTab.tsx
@@ -71,7 +71,12 @@ export default function IdentityProvidersTab({ orgHandler }: { orgHandler: strin
     });
   };
 
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (isError)
     return (
       <Alert

--- a/ipaas/src/components/Settings/AppSecurity/IdpDetailModal.tsx
+++ b/ipaas/src/components/Settings/AppSecurity/IdpDetailModal.tsx
@@ -50,7 +50,9 @@ export default function IdpDetailModal({ idp, displayName, onClose }: { idp: Ide
           <IdpLogo type={idp.type} height={44} />
         </Box>
         {isLoading ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 4 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
         ) : (
           <Stack>
             <Field label="Name" value={displayName} />

--- a/ipaas/src/components/Settings/AppSecurity/RoleManagementTab.tsx
+++ b/ipaas/src/components/Settings/AppSecurity/RoleManagementTab.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, ListingTable, Stack } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, ListingTable, Stack } from '@wso2/oxygen-ui';
 import { Users } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import Authorized from '../../Authorized';
@@ -31,7 +31,12 @@ export default function RoleManagementTab(): JSX.Element {
   const [mapping, setMapping] = useState<RoleGroupMapping | null>(null);
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (isError)
     return (
       <Alert

--- a/ipaas/src/components/Settings/AppSecurity/StsTab.tsx
+++ b/ipaas/src/components/Settings/AppSecurity/StsTab.tsx
@@ -62,7 +62,12 @@ export default function StsTab({ orgHandler }: { orgHandler: string }): JSX.Elem
 
   const stsDomain = useMemo(() => (dataplanes ?? []).map((d) => d.stsDefaultDomain).find((d): d is string => !!d), [dataplanes]);
 
-  if (loadingEnvs || loadingDps) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (loadingEnvs || loadingDps)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
 
   if (!envTemplates?.length) return <EmptyListing icon={<KeyRound size={48} />} title="No environments" description="There are no environments to show security token service endpoints for." />;
 

--- a/ipaas/src/components/Settings/Egress/EgressPolicyEditor.tsx
+++ b/ipaas/src/components/Settings/Egress/EgressPolicyEditor.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, Stack, TextField, Tooltip } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, Stack, TextField, Tooltip } from '@wso2/oxygen-ui';
 import { Plus, ShieldOff, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import Authorized from '../../Authorized';
@@ -115,7 +115,9 @@ export default function EgressPolicyEditor({ projectId }: EgressPolicyEditorProp
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/config/routes.tsx
+++ b/ipaas/src/config/routes.tsx
@@ -24,14 +24,15 @@ import { IS_WIP, IS_CLOUD } from '../features';
 import { createElement } from 'react';
 const PrebuiltIntegrationConfigProvider = lazy(() => import('../contexts/PrebuiltIntegrationConfigContext').then((m) => ({ default: m.PrebuiltIntegrationConfigProvider })));
 
-// Eager — needed on first paint for unauthenticated pages
+// Eager — needed on first paint for unauthenticated pages, and the authenticated
+// shell (AppLayout) which must remain stable across route transitions.
 import PublicLayout from '../layouts/PublicLayout';
 import Login from '../pages/Login';
 import Signup from '../pages/Signup';
 import RouteErrorBoundary from '../components/RouteErrorBoundary';
+import AppLayout from '../layouts/AppLayout';
 
-// Lazy — authenticated app shell and all pages
-const AppLayout = lazy(() => import('../layouts/AppLayout'));
+// Lazy — all pages inside the authenticated shell
 const PolicyLayout = lazy(() => import('../layouts/PolicyLayout'));
 const ProtectedRoute = lazy(() => import('../auth/ProtectedRoute'));
 const OrgHomeRedirect = lazy(() => import('../components/OrgHomeRedirect'));

--- a/ipaas/src/layouts/AppLayout.tsx
+++ b/ipaas/src/layouts/AppLayout.tsx
@@ -37,6 +37,7 @@ import {
   MenuItem,
   NotificationPanel,
   Box,
+  CircularProgress,
   Popover,
   Sidebar,
   TextField,
@@ -46,7 +47,7 @@ import {
   useAppShell,
   useNotifications,
 } from '@wso2/oxygen-ui';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import type { JSX } from 'react';
 import { useNavigate, Outlet, NavLink, useLocation } from 'react-router';
@@ -219,7 +220,12 @@ function AppLayoutInner(): JSX.Element {
   const billingTrial = billingOrg?.subscription?.status === 'trial' ? billingOrg.subscription.trial : null;
   const trialEndLabel = billingTrial?.trial_end ? `Trial ends ${new Date(billingTrial.trial_end).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })}` : '';
 
-  const { state: shell, actions } = useAppShell({ initialCollapsed: true });
+  const { state: shell, actions } = useAppShell({ initialCollapsed: localStorage.getItem('sidebar:collapsed') !== 'false' });
+
+  const handleToggleSidebar = () => {
+    localStorage.setItem('sidebar:collapsed', String(!shell.sidebarCollapsed));
+    actions.toggleSidebar();
+  };
 
   // Compute the active nav item ID — uses URL matching for component/org scopes; Matrix resource for project scope
   const activeNavId = useMemo((): string => {
@@ -566,7 +572,7 @@ function AppLayoutInner(): JSX.Element {
     <AppShell>
       <AppShell.Navbar>
         <Header>
-          <Header.Toggle collapsed={shell.sidebarCollapsed} onToggle={actions.toggleSidebar} />
+          <Header.Toggle collapsed={shell.sidebarCollapsed} onToggle={handleToggleSidebar} />
           <Header.Brand>
             <Header.BrandLogo>
               <NavLink to={orgHomeUrl(scope.org)} style={{ display: 'flex', alignItems: 'center', textDecoration: 'none' }}>
@@ -1064,7 +1070,7 @@ function AppLayoutInner(): JSX.Element {
           expandedMenus={shell.expandedMenus}
           onSelect={(id) => {
             if (id === 'expand') {
-              actions.toggleSidebar();
+              handleToggleSidebar();
             } else if (hasComponent(scope)) {
               handleComponentNavSelect(id);
             } else if (!hasProject(scope)) {
@@ -1673,10 +1679,18 @@ function AppLayoutInner(): JSX.Element {
             sx={{
               flex: 1,
               minWidth: 0,
+              height: '100%',
               overflowY: 'auto',
               overflowX: 'auto',
             }}>
-            <Outlet />
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                  <CircularProgress color="primary" />
+                </Box>
+              }>
+              <Outlet />
+            </Suspense>
           </Box>
           {IS_WIP && <CopilotDrawer />}
         </Box>

--- a/ipaas/src/pages/AutomationTest.tsx
+++ b/ipaas/src/pages/AutomationTest.tsx
@@ -379,10 +379,20 @@ export default function AutomationTest({ org, project, component }: ComponentSco
   );
 
   const renderBody = (): JSX.Element => {
-    if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+    if (isLoading)
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      );
     if (!comp) return <Typography>Integration not found</Typography>;
     if (!releaseId) return <Alert severity="info">Deploy this integration to the selected environment to test it.</Alert>;
-    if (argsLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+    if (argsLoading)
+      return (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      );
     if (hardArgsError) return <Alert severity="error">Failed to load the runtime arguments for this automation.</Alert>;
     return hasArgs ? renderFormView() : renderExecutionsView();
   };

--- a/ipaas/src/pages/CdPipelineEditor.tsx
+++ b/ipaas/src/pages/CdPipelineEditor.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, PageContent } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, PageContent } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 import { useParams } from 'react-router';
 import { useEnvTemplates, useOrgDeploymentPipelines } from '../hooks/useDeploymentPipelines';
@@ -40,7 +40,9 @@ export default function CdPipelineEditor(): JSX.Element {
   if (loadingEnvs || (isEdit && loadingPipelines)) {
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/ComponentConfigs.tsx
+++ b/ipaas/src/pages/ComponentConfigs.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, MenuItem, PageContent, PageTitle, Select, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, MenuItem, PageContent, PageTitle, Select, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { KeyRound, Pencil, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useMemo, useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -117,7 +117,9 @@ export default function ComponentConfigs({ org, project, component }: ComponentS
       {tracks.length > 0 && <DeploymentTrackBar tracks={tracks} selectedId={trackId} onChange={setTrackId} orgHandler={org} projectHandler={project} componentHandler={component} extra={envSelect} />}
       <PageContent>
         {isLoading ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Typography>Integration not found</Typography>
         ) : !releaseId || !containerId ? (
@@ -146,7 +148,9 @@ export default function ComponentConfigs({ org, project, component }: ComponentS
             )}
 
             {loadingMounts ? (
-              <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                <CircularProgress />
+              </Box>
             ) : rows.length === 0 ? (
               <EmptyListing icon={<KeyRound size={48} />} title="No configs or secrets" description="Inject environment variables or mount files into this integration's container." />
             ) : (

--- a/ipaas/src/pages/ComponentConnections.tsx
+++ b/ipaas/src/pages/ComponentConnections.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 import { isConnectionsEnabled } from '../hooks/useConnections';
 import { useProjectId } from '../hooks/useProjects';
@@ -40,9 +40,9 @@ export default function ComponentConnections({ org, project, component }: Compon
 
   if (isLoading) {
     return (
-      <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
-      </PageContent>
+      <Box sx={{ display: 'flex', minHeight: '100%', justifyContent: 'center', alignItems: 'center' }}>
+        <CircularProgress />
+      </Box>
     );
   }
   if (!projectId || !comp) {

--- a/ipaas/src/pages/ComponentContainers.tsx
+++ b/ipaas/src/pages/ComponentContainers.tsx
@@ -88,7 +88,9 @@ export default function ComponentContainers({ org, project, component }: Compone
         )}
 
         {isLoading || (loadingRelease && !!releaseId) ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Alert severity="error">Integration not found</Alert>
         ) : containers.length === 0 ? (

--- a/ipaas/src/pages/ComponentDeploymentTracks.tsx
+++ b/ipaas/src/pages/ComponentDeploymentTracks.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, ListingTable, PageContent, Stack, TextField, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, ListingTable, PageContent, Stack, TextField, Typography } from '@wso2/oxygen-ui';
 import { GitBranch, Plus } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -170,7 +170,15 @@ export default function ComponentDeploymentTracks({ org, project, component }: C
   return (
     <PageContent>
       <ComponentSettingsTabs active="deployment-tracks" />
-      {isLoading ? <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} /> : !comp ? <Typography>Integration not found</Typography> : <TracksBody orgHandler={org} projectId={projectId} componentId={comp.id} tracks={comp.deploymentTracks ?? []} />}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : !comp ? (
+        <Typography>Integration not found</Typography>
+      ) : (
+        <TracksBody orgHandler={org} projectId={projectId} componentId={comp.id} tracks={comp.deploymentTracks ?? []} />
+      )}
     </PageContent>
   );
 }

--- a/ipaas/src/pages/ComponentDocuments.tsx
+++ b/ipaas/src/pages/ComponentDocuments.tsx
@@ -31,7 +31,7 @@ import { useApimApi, useApimDocumentContent, useApimDocuments, useChangeLifecycl
 import { PUBLISH_ACTIONS, SUCCESS_TEXT } from '../constants/lifecycle';
 import { broaden, resourceUrl, type ComponentScope } from '../nav';
 import type { ApiDocument } from '../types/marketplace';
-import type { DeploymentTrack } from '../types/component';
+import { typeLabel, aggregateByMajorVersion, stripLeadingTitle } from '../utils/documents';
 
 type View = 'list' | 'create' | 'edit';
 
@@ -41,47 +41,7 @@ interface EditingState {
   apimId: string;
 }
 
-const DOC_TYPE_LABEL: Record<string, string> = {
-  HOWTO: 'How To',
-  SAMPLES: 'Sample and SDK',
-  PUBLIC_FORUM: 'Public Forum',
-  SUPPORT_FORUM: 'Support Forum',
-};
-
-function typeLabel(doc: ApiDocument): string {
-  return doc.type === 'OTHER' ? (doc.otherTypeName ?? 'Other') : (DOC_TYPE_LABEL[doc.type] ?? doc.type);
-}
-
-function getMajorVersion(apiVersion: string): string {
-  return apiVersion.replace(/^v/i, '').split('.')[0];
-}
-
-function aggregateByMajorVersion(tracks: DeploymentTrack[]): DeploymentTrack[] {
-  const groups = new Map<string, DeploymentTrack>();
-  for (const track of tracks) {
-    if (!track.apiVersion) {
-      groups.set(track.id, track);
-      continue;
-    }
-    const key = `${getMajorVersion(track.apiVersion)}.x`;
-    const existing = groups.get(key);
-    if (!existing || track.latest) {
-      groups.set(key, { ...track, apiVersion: key });
-    }
-  }
-  return Array.from(groups.values());
-}
-
 // ── Document content pane (right side of list view) ──────────────────────────
-
-function stripLeadingTitle(content: string, docName: string): string {
-  const firstLine = content.match(/^#+ .+/m)?.[0] ?? '';
-  const heading = firstLine.replace(/^#+ /, '').trim();
-  if (heading.toLowerCase() === docName.toLowerCase()) {
-    return content.replace(firstLine, '').trimStart();
-  }
-  return content;
-}
 
 function DocContentPane({ apimId, doc }: { apimId: string; doc: ApiDocument }) {
   const isInline = doc.sourceType === 'MARKDOWN' || doc.sourceType === 'INLINE';
@@ -475,7 +435,21 @@ export default function ComponentDocuments(scope: ComponentScope): JSX.Element {
                     const collapsed = collapsedGroups.has(label);
                     return (
                       <Box key={label}>
-                        <Stack direction="row" alignItems="center" justifyContent="space-between" role="button" tabIndex={0} aria-expanded={!collapsed} onClick={() => toggleGroup(label)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleGroup(label); } }} sx={{ px: 2, py: 1, mt: 1, cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}>
+                        <Stack
+                          direction="row"
+                          alignItems="center"
+                          justifyContent="space-between"
+                          role="button"
+                          tabIndex={0}
+                          aria-expanded={!collapsed}
+                          onClick={() => toggleGroup(label)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              toggleGroup(label);
+                            }
+                          }}
+                          sx={{ px: 2, py: 1, mt: 1, cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}>
                           <Typography variant="body2" sx={{ fontWeight: 600 }}>
                             {label}
                           </Typography>
@@ -492,7 +466,12 @@ export default function ComponentDocuments(scope: ComponentScope): JSX.Element {
                                   tabIndex={0}
                                   aria-selected={isSelected}
                                   onClick={() => setSelectedDocId(doc.documentId)}
-                                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedDocId(doc.documentId); } }}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault();
+                                      setSelectedDocId(doc.documentId);
+                                    }
+                                  }}
                                   sx={{
                                     display: 'flex',
                                     alignItems: 'center',

--- a/ipaas/src/pages/ComponentExternalCI.tsx
+++ b/ipaas/src/pages/ComponentExternalCI.tsx
@@ -55,7 +55,9 @@ export default function ComponentExternalCI({ org, project, component }: Compone
       {tracks.length > 0 && <DeploymentTrackBar tracks={tracks} selectedId={trackId} onChange={setTrackId} orgHandler={org} projectHandler={project} componentHandler={component} versionView />}
       <PageContent>
         {isLoading ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Alert severity="error">Integration not found</Alert>
         ) : !isByoi ? (

--- a/ipaas/src/pages/ComponentGroupDetail.tsx
+++ b/ipaas/src/pages/ComponentGroupDetail.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import { type JSX } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useGroups } from '../hooks/useAuth';
@@ -26,7 +26,11 @@ import { componentAccessControlUrl } from '../paths';
 import { GroupDetailView } from './EditGroup';
 
 function Loading() {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 export default function ComponentGroupDetail(): JSX.Element {

--- a/ipaas/src/pages/ComponentHealthChecks.tsx
+++ b/ipaas/src/pages/ComponentHealthChecks.tsx
@@ -94,7 +94,9 @@ export default function ComponentHealthChecks({ org, project, component }: Compo
         )}
 
         {isLoading || (loadingHc && !!releaseId) ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Alert severity="error">Integration not found</Alert>
         ) : !mainC ? (

--- a/ipaas/src/pages/ComponentProxyVersions.tsx
+++ b/ipaas/src/pages/ComponentProxyVersions.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Chip, CircularProgress, ListingTable, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Chip, CircularProgress, ListingTable, PageContent, Stack, Typography } from '@wso2/oxygen-ui';
 import { GitMerge } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -97,7 +97,15 @@ export default function ComponentProxyVersions({ org, project, component }: Comp
   return (
     <PageContent>
       <ComponentSettingsTabs active="proxy-versions" />
-      {isLoading ? <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} /> : !comp ? <Typography>Integration not found</Typography> : <VersionsBody orgHandler={org} projectId={projectId} componentId={comp.id} versions={comp.apiVersions ?? []} />}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : !comp ? (
+        <Typography>Integration not found</Typography>
+      ) : (
+        <VersionsBody orgHandler={org} projectId={projectId} componentId={comp.id} versions={comp.apiVersions ?? []} />
+      )}
     </PageContent>
   );
 }

--- a/ipaas/src/pages/ComponentRoleDetail.tsx
+++ b/ipaas/src/pages/ComponentRoleDetail.tsx
@@ -54,7 +54,11 @@ import { useComponentByHandler } from '../hooks/useComponents';
 import { componentAccessControlUrl } from '../paths';
 
 function Loading() {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 function AssignRoleToGroupsDialog({

--- a/ipaas/src/pages/ComponentRuntime.tsx
+++ b/ipaas/src/pages/ComponentRuntime.tsx
@@ -75,9 +75,9 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
 
   if (isLoading) {
     return (
-      <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
-      </PageContent>
+      <Box sx={{ display: 'flex', minHeight: '100%', justifyContent: 'center', alignItems: 'center' }}>
+        <CircularProgress />
+      </Box>
     );
   }
 
@@ -116,6 +116,9 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>
       {tracks.length > 0 && <DeploymentTrackBar tracks={tracks} selectedId={trackId} onChange={setTrackId} orgHandler={org} projectHandler={project} componentHandler={component} extra={envSelect} />}
       <PageContent>
+        <Typography variant="h1" sx={{ mb: 3 }}>
+          Runtime
+        </Typography>
         <RuntimeOverview
           componentName={comp.displayName || comp.name || component}
           status={status}

--- a/ipaas/src/pages/ComponentScaling.tsx
+++ b/ipaas/src/pages/ComponentScaling.tsx
@@ -130,7 +130,9 @@ export default function ComponentScaling({ org, project, component }: ComponentS
       {tracks.length > 0 && <DeploymentTrackBar tracks={tracks} selectedId={trackId} onChange={setTrackId} orgHandler={org} projectHandler={project} componentHandler={component} versionView extra={envSelect} />}
       <PageContent>
         {isLoading || (loadingState && releaseId) ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Alert severity="error">Integration not found</Alert>
         ) : !GENERIC_SERVICE_TYPES.has(comp.displayType) ? (

--- a/ipaas/src/pages/ComponentStorage.tsx
+++ b/ipaas/src/pages/ComponentStorage.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, MenuItem, PageContent, PageTitle, Select } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, MenuItem, PageContent, PageTitle, Select } from '@wso2/oxygen-ui';
 import { HardDrive, Plus } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useMemo, useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -112,7 +112,9 @@ export default function ComponentStorage({ org, project, component }: ComponentS
       {tracks.length > 0 && <DeploymentTrackBar tracks={tracks} selectedId={trackId} onChange={setTrackId} orgHandler={org} projectHandler={project} componentHandler={component} extra={envSelect} />}
       <PageContent>
         {isLoading ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : !comp ? (
           <Alert severity="error">Integration not found</Alert>
         ) : !releaseId || !containerId ? (
@@ -148,7 +150,9 @@ export default function ComponentStorage({ org, project, component }: ComponentS
             )}
 
             {loadingVolumes || loadingMounts ? (
-              <CircularProgress sx={{ display: 'block', mx: 'auto', py: 6 }} />
+              <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+                <CircularProgress />
+              </Box>
             ) : rows.length === 0 ? (
               <EmptyListing icon={<HardDrive size={48} />} title="No volume mounts" description="Attach in-memory, disk or persistent volumes to this integration's container." />
             ) : (

--- a/ipaas/src/pages/ComponentTest.tsx
+++ b/ipaas/src/pages/ComponentTest.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 import AutomationTest from './AutomationTest';
 import ComingSoon from './ComingSoon';
@@ -39,7 +39,9 @@ export default function ComponentTest(scope: ComponentScope): JSX.Element {
   if (isLoading) {
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/ComponentUrlSettings.tsx
+++ b/ipaas/src/pages/ComponentUrlSettings.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, InputAdornment, ListingTable, MenuItem, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, InputAdornment, ListingTable, MenuItem, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Globe, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -124,7 +124,12 @@ function UrlSettingsBody({ componentId }: { componentId: string }): JSX.Element 
     });
   };
 
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
 
   return (
     <>
@@ -220,7 +225,9 @@ export default function ComponentUrlSettings({ project, component }: ComponentSc
       {!urlSettingsEnabled() ? (
         <Alert severity="info">Custom URL mappings are not enabled for this environment.</Alert>
       ) : isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : !comp ? (
         <Typography>Integration not found</Typography>
       ) : (

--- a/ipaas/src/pages/ConnectionDetail.tsx
+++ b/ipaas/src/pages/ConnectionDetail.tsx
@@ -148,7 +148,9 @@ export default function ConnectionDetail(scope: ProjectScope | ComponentScope): 
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError || !connection ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/CreateDatabaseServer.tsx
+++ b/ipaas/src/pages/CreateDatabaseServer.tsx
@@ -145,7 +145,9 @@ export function CreateDatabaseServerView({ scope, kind }: { scope: OrgScope; kin
           )}
 
           {plansQuery.isLoading ? (
-            <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+              <CircularProgress />
+            </Box>
           ) : activeStep === 0 ? (
             <>
               {!kind.isVector && (

--- a/ipaas/src/pages/Credentials.tsx
+++ b/ipaas/src/pages/Credentials.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, IconButton, ListingTable, PageContent, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, IconButton, ListingTable, PageContent, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { KeyRound, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import EmptyListing from '../components/EmptyListing';
@@ -61,7 +61,9 @@ export default function Credentials(_scope: OrgScope): JSX.Element {
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/DatabaseServerDetail.tsx
+++ b/ipaas/src/pages/DatabaseServerDetail.tsx
@@ -78,7 +78,9 @@ export function DatabaseServerDetailView({ scope, kind }: { scope: OrgScope; kin
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError || !service ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/EditConfigGroup.tsx
+++ b/ipaas/src/pages/EditConfigGroup.tsx
@@ -73,7 +73,9 @@ export default function EditConfigGroup(scope: OrgScope): JSX.Element {
 
       {tab === 'config' ? (
         isLoading ? (
-          <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+            <CircularProgress />
+          </Box>
         ) : isError || !group || !initial ? (
           <Alert
             severity="error"

--- a/ipaas/src/pages/EditEnvironment.tsx
+++ b/ipaas/src/pages/EditEnvironment.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Checkbox, CircularProgress, FormControlLabel, PageContent, Stack, TextField, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Checkbox, CircularProgress, FormControlLabel, PageContent, Stack, TextField, Typography } from '@wso2/oxygen-ui';
 import { ArrowLeft } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -87,7 +87,9 @@ export default function EditEnvironment(): JSX.Element {
   if (isLoading)
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   if (isError)

--- a/ipaas/src/pages/EditGroup.tsx
+++ b/ipaas/src/pages/EditGroup.tsx
@@ -516,7 +516,9 @@ export default function EditGroup(): JSX.Element {
   if (isLoading)
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   if (isError)

--- a/ipaas/src/pages/EditUser.tsx
+++ b/ipaas/src/pages/EditUser.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Autocomplete, Avatar, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, ListingTable, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Autocomplete, Avatar, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, ListingTable, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { ArrowLeft, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useState, useCallback, type JSX } from 'react';
 import { useNavigate, useParams } from 'react-router';
@@ -208,7 +208,9 @@ export default function EditUser(): JSX.Element {
   if (isLoading)
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
 

--- a/ipaas/src/pages/Environments.tsx
+++ b/ipaas/src/pages/Environments.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Avatar, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, ListingTable, TablePagination, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Avatar, Box, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, ListingTable, TablePagination, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Clock, Layers, Plus, Trash2, AlertTriangle } from '@wso2/oxygen-ui-icons-react';
 import { useState, useMemo, useEffect, type JSX } from 'react';
 import { useNavigate, useLocation } from 'react-router';
@@ -149,7 +149,9 @@ export default function Environments(scope: OrgScope | ProjectScope): JSX.Elemen
       </PageTitle>
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/GenAIServiceDetail.tsx
+++ b/ipaas/src/pages/GenAIServiceDetail.tsx
@@ -75,7 +75,9 @@ export default function GenAIServiceDetail(scope: OrgScope | ProjectScope): JSX.
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError || !service ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/Login.tsx
+++ b/ipaas/src/pages/Login.tsx
@@ -123,8 +123,7 @@ export default function Login(): JSX.Element {
             <ColorSchemeImage
               src={{ light: `${base}assets/images/logo/WSO2-Integration-Platform-Black.svg`, dark: `${base}assets/images/logo/WSO2-Integration-Platform-White.svg` }}
               alt={{ light: 'WSO2 Integration Platform Logo', dark: 'WSO2 Integration Platform Logo' }}
-              height={48}
-              width="auto"
+              sx={{ width: '100%', maxWidth: 260, height: 'auto' }}
             />
           </Box>
 

--- a/ipaas/src/pages/OnPremKeys.tsx
+++ b/ipaas/src/pages/OnPremKeys.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, IconButton, ListingTable, PageContent, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, IconButton, ListingTable, PageContent, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { KeyRound, Pencil, Plus, RefreshCw, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -145,7 +145,9 @@ export default function OnPremKeys({ org }: OrgScope): JSX.Element {
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         forbidden ? (
           <Alert severity="info">On-premises keys aren&apos;t available for this organization. Your access token isn&apos;t scoped for the on-premises key service — contact WSO2 if you need this enabled.</Alert>

--- a/ipaas/src/pages/OrgApprovals.tsx
+++ b/ipaas/src/pages/OrgApprovals.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, PageContent, PageTitle, Tab, Tabs } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, PageContent, PageTitle, Tab, Tabs } from '@wso2/oxygen-ui';
 import { ClipboardCheck } from '@wso2/oxygen-ui-icons-react';
 import { useState, type JSX } from 'react';
 import EmptyListing from '../components/EmptyListing';
@@ -59,7 +59,9 @@ export default function OrgApprovals(_scope: OrgScope): JSX.Element {
       </Tabs>
 
       {active.isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : active.isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/OrgCdPipelines.tsx
+++ b/ipaas/src/pages/OrgCdPipelines.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
 import { GitBranch, Pencil, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -56,7 +56,9 @@ export default function OrgCdPipelines(scope: OrgScope): JSX.Element {
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/OrgConfigGroups.tsx
+++ b/ipaas/src/pages/OrgConfigGroups.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -72,7 +72,9 @@ export default function OrgConfigGroups(scope: OrgScope): JSX.Element {
       )}
 
       {isLoading || (isFetching && !groups?.length) ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/OrgDataPlanes.tsx
+++ b/ipaas/src/pages/OrgDataPlanes.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Network, RefreshCw } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import EmptyListing from '../components/EmptyListing';
@@ -80,7 +80,9 @@ export default function OrgDataPlanes(_scope: OrgScope): JSX.Element {
       </Stack>
 
       {isLoading || (isFetching && !clusters?.length && !pdps?.length) ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/OrgDatabases.tsx
+++ b/ipaas/src/pages/OrgDatabases.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
 import { Plus, RefreshCw } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -91,7 +91,9 @@ export function DatabaseServersListView({ scope, kind }: { scope: OrgScope; kind
       )}
 
       {servers.isLoading || availability.isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : notAllowlisted ? (
         <Alert severity="info">This feature is only available for selected organizations in this environment.</Alert>
       ) : servers.isError || availability.isError ? (

--- a/ipaas/src/pages/OrgGenAIServices.tsx
+++ b/ipaas/src/pages/OrgGenAIServices.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, TablePagination, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, TablePagination, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -106,7 +106,9 @@ export default function OrgGenAIServices(scope: OrgScope | ProjectScope): JSX.El
       )}
 
       {resolvingProject || isLoading || (isFetching && !data) ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/Project.tsx
+++ b/ipaas/src/pages/Project.tsx
@@ -736,7 +736,9 @@ function IntegrationsTable({
       </Stack>
 
       {isLoading ? (
-        <CircularProgress size={24} color="primary" sx={{ display: 'block', mx: 'auto', py: 4 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress size={24} color="primary" />
+        </Box>
       ) : filtered.length === 0 ? (
         <EmptyListing icon={<PlugZap size={48} />} title="No integrations found" description={query || selectedLabels.length > 0 ? 'Try adjusting your search or filters' : 'Create your first integration to get started'} />
       ) : (
@@ -962,7 +964,7 @@ export default function Project(scope: ProjectScope): JSX.Element {
 
   if (loadingProject) {
     return (
-      <Box sx={{ display: 'flex', flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', minHeight: '100%', justifyContent: 'center', alignItems: 'center' }}>
         <CircularProgress color="primary" />
       </Box>
     );

--- a/ipaas/src/pages/ProjectApplicationSecurity.tsx
+++ b/ipaas/src/pages/ProjectApplicationSecurity.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Autocomplete, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Autocomplete, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, PageContent, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { KeyRound, Pencil, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -117,7 +117,12 @@ function ApplicationSecurityBody({ projectId }: { projectId: string }): JSX.Elem
     });
   };
 
-  if (isLoading) return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  if (isLoading)
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+        <CircularProgress />
+      </Box>
+    );
   if (isError)
     return (
       <Alert
@@ -241,7 +246,15 @@ export default function ProjectApplicationSecurity({ project }: ProjectScope): J
   return (
     <PageContent>
       <ProjectSettingsTabs active="application-security" />
-      {isLoading ? <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} /> : !data ? <Typography>Project not found</Typography> : <ApplicationSecurityBody key={data.id} projectId={data.id} />}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : !data ? (
+        <Typography>Project not found</Typography>
+      ) : (
+        <ApplicationSecurityBody key={data.id} projectId={data.id} />
+      )}
     </PageContent>
   );
 }

--- a/ipaas/src/pages/ProjectCdPipelines.tsx
+++ b/ipaas/src/pages/ProjectCdPipelines.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, CircularProgress, IconButton, PageContent, PageTitle, Stack, Tooltip } from '@wso2/oxygen-ui';
 import { GitBranch, Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import { useEnvTemplates, useProjectDeploymentPipelines } from '../hooks/useDeploymentPipelines';
@@ -63,7 +63,9 @@ export default function ProjectCdPipelines(scope: ProjectScope): JSX.Element {
       )}
 
       {resolvingProject || isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/ProjectConnections.tsx
+++ b/ipaas/src/pages/ProjectConnections.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 import { isConnectionsEnabled } from '../hooks/useConnections';
 import { useProjectId } from '../hooks/useProjects';
@@ -35,7 +35,9 @@ export default function ProjectConnections({ org, project }: ProjectScope): JSX.
   if (isLoading) {
     return (
       <PageContent>
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/ProjectEgressControl.tsx
+++ b/ipaas/src/pages/ProjectEgressControl.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import type { JSX } from 'react';
 import ProjectSettingsTabs from '../components/Settings/ProjectSettingsTabs';
 import EgressPolicyEditor from '../components/Settings/Egress/EgressPolicyEditor';
@@ -29,7 +29,15 @@ export default function ProjectEgressControl({ project }: ProjectScope): JSX.Ele
   return (
     <PageContent>
       <ProjectSettingsTabs active="egress-control" />
-      {isLoading ? <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} /> : !data ? <Typography>Project not found</Typography> : <EgressPolicyEditor key={data.id} projectId={data.id} />}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : !data ? (
+        <Typography>Project not found</Typography>
+      ) : (
+        <EgressPolicyEditor key={data.id} projectId={data.id} />
+      )}
     </PageContent>
   );
 }

--- a/ipaas/src/pages/ProjectGroupDetail.tsx
+++ b/ipaas/src/pages/ProjectGroupDetail.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent, Typography } from '@wso2/oxygen-ui';
 import { type JSX } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useGroups } from '../hooks/useAuth';
@@ -25,7 +25,11 @@ import { projectAccessControlUrl } from '../paths';
 import { GroupDetailView } from './EditGroup';
 
 function Loading() {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 export default function ProjectGroupDetail(): JSX.Element {

--- a/ipaas/src/pages/ProjectOverview.tsx
+++ b/ipaas/src/pages/ProjectOverview.tsx
@@ -151,7 +151,15 @@ export default function ProjectOverview({ org, project }: ProjectScope): JSX.Ele
   return (
     <PageContent>
       <ProjectSettingsTabs active="project-overview" />
-      {isLoading ? <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} /> : !data ? <Typography>Project not found</Typography> : <ProjectOverviewForm key={data.id} org={org} project={data} />}
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      ) : !data ? (
+        <Typography>Project not found</Typography>
+      ) : (
+        <ProjectOverviewForm key={data.id} org={org} project={data} />
+      )}
     </PageContent>
   );
 }

--- a/ipaas/src/pages/ProjectRoleDetail.tsx
+++ b/ipaas/src/pages/ProjectRoleDetail.tsx
@@ -53,7 +53,11 @@ import { useProjectByHandler } from '../hooks/useProjects';
 import { projectAccessControlUrl } from '../paths';
 
 function Loading() {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 function AssignRoleToGroupsDialog({

--- a/ipaas/src/pages/ProjectVpnConfiguration.tsx
+++ b/ipaas/src/pages/ProjectVpnConfiguration.tsx
@@ -124,7 +124,9 @@ function ConfigView({ orgHandler, projectId, handler, canManage, onBack }: { org
         Back to list
       </Button>
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : !detail ? (
         <Typography>Proxy not found</Typography>
       ) : (
@@ -177,7 +179,9 @@ export default function ProjectVpnConfiguration({ org, project }: ProjectScope):
       ) : view.kind === 'config' ? (
         <ConfigView orgHandler={org} projectId={projectId} handler={view.handler} canManage={canManage} onBack={() => setView({ kind: 'list' })} />
       ) : isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : proxies.length === 0 ? (
         <EmptyListing
           icon={<Network size={48} />}

--- a/ipaas/src/pages/RagRetrieval.tsx
+++ b/ipaas/src/pages/RagRetrieval.tsx
@@ -62,7 +62,9 @@ export default function RagRetrieval(_scope: OrgScope): JSX.Element {
     return (
       <PageContent>
         {title}
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/RoleDetail.tsx
+++ b/ipaas/src/pages/RoleDetail.tsx
@@ -56,7 +56,11 @@ import { ALL_ROLE_MODIFY_PERMISSIONS } from '../constants/permissions';
 import { useAccessControl } from '../contexts/AccessControlContext';
 
 function Loading() {
-  return <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />;
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+      <CircularProgress />
+    </Box>
+  );
 }
 
 function PermissionsEditor({ allPermissions, selectedIds, onChange }: { allPermissions: Record<string, Permission[]>; selectedIds: Set<string>; onChange: (ids: Set<string>) => void }) {

--- a/ipaas/src/pages/RuntimeLogsIntegration.tsx
+++ b/ipaas/src/pages/RuntimeLogsIntegration.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { CircularProgress, PageContent } from '@wso2/oxygen-ui';
+import { Box, CircularProgress, PageContent } from '@wso2/oxygen-ui';
 import { ScrollText } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, type JSX } from 'react';
 import { useOrgs } from '../hooks/useOrg';
@@ -90,9 +90,9 @@ export default function RuntimeLogsIntegration(scope: ComponentScope): JSX.Eleme
 
   if (loadingOrgs || loadingProjects || loadingComponent || loadingEnvironments) {
     return (
-      <PageContent sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box sx={{ display: 'flex', minHeight: '100%', justifyContent: 'center', alignItems: 'center' }}>
         <CircularProgress />
-      </PageContent>
+      </Box>
     );
   }
 

--- a/ipaas/src/pages/SetupRagIngestion.tsx
+++ b/ipaas/src/pages/SetupRagIngestion.tsx
@@ -74,7 +74,9 @@ export default function SetupRagIngestion(scope: OrgScope): JSX.Element {
     return (
       <PageContent>
         {title}
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/SetupRagService.tsx
+++ b/ipaas/src/pages/SetupRagService.tsx
@@ -62,7 +62,9 @@ export default function SetupRagService(scope: OrgScope): JSX.Element {
     return (
       <PageContent>
         {title}
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       </PageContent>
     );
   }

--- a/ipaas/src/pages/Signup.tsx
+++ b/ipaas/src/pages/Signup.tsx
@@ -131,8 +131,7 @@ export default function Signup(): JSX.Element {
             <ColorSchemeImage
               src={{ light: `${base}assets/images/logo/WSO2-Integration-Platform-Black.svg`, dark: `${base}assets/images/logo/WSO2-Integration-Platform-White.svg` }}
               alt={{ light: 'WSO2 Integration Platform Logo', dark: 'WSO2 Integration Platform Logo' }}
-              height={48}
-              width="auto"
+              sx={{ width: '100%', maxWidth: 260, height: 'auto' }}
             />
           </Box>
 

--- a/ipaas/src/pages/ThirdPartyServiceDetail.tsx
+++ b/ipaas/src/pages/ThirdPartyServiceDetail.tsx
@@ -74,7 +74,9 @@ export default function ThirdPartyServiceDetail(scope: OrgScope | ProjectScope):
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError || !service ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/ThirdPartyServices.tsx
+++ b/ipaas/src/pages/ThirdPartyServices.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, TablePagination, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, IconButton, ListingTable, PageContent, PageTitle, Stack, TablePagination, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Plus, Trash2 } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
@@ -110,7 +110,9 @@ export default function ThirdPartyServices(scope: OrgScope | ProjectScope): JSX.
       )}
 
       {resolvingProject || isLoading || (isFetching && !data) ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/pages/Workflows.tsx
+++ b/ipaas/src/pages/Workflows.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Alert, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, PageContent, Switch, Tooltip } from '@wso2/oxygen-ui';
+import { Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, IconButton, ListingTable, PageContent, Switch, Tooltip } from '@wso2/oxygen-ui';
 import { GitBranch, Pencil } from '@wso2/oxygen-ui-icons-react';
 import { useMemo, useState, type JSX } from 'react';
 import Authorized from '../components/Authorized';
@@ -98,7 +98,9 @@ export default function Workflows({ org }: OrgScope): JSX.Element {
       )}
 
       {isLoading ? (
-        <CircularProgress sx={{ display: 'block', mx: 'auto', py: 8 }} />
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
       ) : isError ? (
         <Alert
           severity="error"

--- a/ipaas/src/utils/documents.test.ts
+++ b/ipaas/src/utils/documents.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { typeLabel, getMajorVersion, aggregateByMajorVersion, stripLeadingTitle } from './documents';
+import type { ApiDocument } from '../types/marketplace';
+import type { DeploymentTrack } from '../types/component';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function doc(overrides: Partial<ApiDocument> & Pick<ApiDocument, 'type'>): ApiDocument {
+  return { documentId: 'id', name: 'name', ...overrides };
+}
+
+function track(overrides: Partial<DeploymentTrack> & Pick<DeploymentTrack, 'id'>): DeploymentTrack {
+  return { ...overrides };
+}
+
+// ── typeLabel ─────────────────────────────────────────────────────────────────
+
+describe('typeLabel', () => {
+  it.each([
+    ['HOWTO', 'How To'],
+    ['SAMPLES', 'Sample and SDK'],
+    ['PUBLIC_FORUM', 'Public Forum'],
+    ['SUPPORT_FORUM', 'Support Forum'],
+  ])('maps known type %s to %s', (type, expected) => {
+    expect(typeLabel(doc({ type }))).toBe(expected);
+  });
+
+  it('returns otherTypeName for OTHER type', () => {
+    expect(typeLabel(doc({ type: 'OTHER', otherTypeName: 'Release Notes' }))).toBe('Release Notes');
+  });
+
+  it('falls back to "Other" for OTHER type without otherTypeName', () => {
+    expect(typeLabel(doc({ type: 'OTHER' }))).toBe('Other');
+  });
+
+  it('returns the raw type string for unknown types', () => {
+    expect(typeLabel(doc({ type: 'UNKNOWN_TYPE' }))).toBe('UNKNOWN_TYPE');
+  });
+});
+
+// ── getMajorVersion ───────────────────────────────────────────────────────────
+
+describe('getMajorVersion', () => {
+  it('strips lowercase v prefix', () => {
+    expect(getMajorVersion('v1.2.3')).toBe('1');
+  });
+
+  it('strips uppercase V prefix', () => {
+    expect(getMajorVersion('V2.0.0')).toBe('2');
+  });
+
+  it('handles version strings without a prefix', () => {
+    expect(getMajorVersion('3.5.1')).toBe('3');
+  });
+
+  it('handles a bare major number', () => {
+    expect(getMajorVersion('4')).toBe('4');
+  });
+});
+
+// ── aggregateByMajorVersion ───────────────────────────────────────────────────
+
+describe('aggregateByMajorVersion', () => {
+  it('returns an empty array for no tracks', () => {
+    expect(aggregateByMajorVersion([])).toEqual([]);
+  });
+
+  it('keeps tracks without an apiVersion under their own id', () => {
+    const t = track({ id: 'no-version' });
+    const result = aggregateByMajorVersion([t]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('no-version');
+  });
+
+  it('groups tracks sharing a major version under a single x-suffixed key', () => {
+    const t1 = track({ id: 'a', apiVersion: 'v1.0.0' });
+    const t2 = track({ id: 'b', apiVersion: 'v1.2.0' });
+    const result = aggregateByMajorVersion([t1, t2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].apiVersion).toBe('1.x');
+  });
+
+  it('the latest-flagged track wins when major versions collide', () => {
+    const old = track({ id: 'old', apiVersion: 'v2.0.0' });
+    const latest = track({ id: 'latest', apiVersion: 'v2.5.0', latest: true });
+    const result = aggregateByMajorVersion([old, latest]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('latest');
+    expect(result[0].apiVersion).toBe('2.x');
+  });
+
+  it('keeps distinct major versions as separate entries', () => {
+    const v1 = track({ id: 'v1', apiVersion: 'v1.0.0' });
+    const v2 = track({ id: 'v2', apiVersion: 'v2.0.0' });
+    const result = aggregateByMajorVersion([v1, v2]);
+    expect(result).toHaveLength(2);
+    const versions = result.map((t) => t.apiVersion).sort();
+    expect(versions).toEqual(['1.x', '2.x']);
+  });
+
+  it('mixes versioned and unversioned tracks correctly', () => {
+    const unversioned = track({ id: 'bare' });
+    const versioned = track({ id: 'v1', apiVersion: 'v1.0.0' });
+    const result = aggregateByMajorVersion([unversioned, versioned]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ── stripLeadingTitle ─────────────────────────────────────────────────────────
+
+describe('stripLeadingTitle', () => {
+  it('strips a h1 heading that matches the document name', () => {
+    const content = '# My Doc\n\nSome body text.';
+    expect(stripLeadingTitle(content, 'My Doc')).toBe('Some body text.');
+  });
+
+  it('strips a h2 heading that matches the document name', () => {
+    const content = '## My Doc\n\nBody.';
+    expect(stripLeadingTitle(content, 'My Doc')).toBe('Body.');
+  });
+
+  it('is case-insensitive when matching', () => {
+    const content = '# MY DOC\n\nBody.';
+    expect(stripLeadingTitle(content, 'my doc')).toBe('Body.');
+  });
+
+  it('leaves content unchanged when heading does not match the document name', () => {
+    const content = '# Different Title\n\nBody.';
+    expect(stripLeadingTitle(content, 'My Doc')).toBe(content);
+  });
+
+  it('leaves content unchanged when there is no heading', () => {
+    const content = 'Just plain text.';
+    expect(stripLeadingTitle(content, 'My Doc')).toBe(content);
+  });
+
+  it('returns empty string when heading is the only content', () => {
+    expect(stripLeadingTitle('# My Doc', 'My Doc')).toBe('');
+  });
+});

--- a/ipaas/src/utils/documents.ts
+++ b/ipaas/src/utils/documents.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { DeploymentTrack } from '../types/component';
+import type { ApiDocument } from '../types/marketplace';
+
+const DOC_TYPE_LABEL: Record<string, string> = {
+  HOWTO: 'How To',
+  SAMPLES: 'Sample and SDK',
+  PUBLIC_FORUM: 'Public Forum',
+  SUPPORT_FORUM: 'Support Forum',
+};
+
+export function typeLabel(doc: ApiDocument): string {
+  return doc.type === 'OTHER' ? (doc.otherTypeName ?? 'Other') : (DOC_TYPE_LABEL[doc.type] ?? doc.type);
+}
+
+export function getMajorVersion(apiVersion: string): string {
+  return apiVersion.replace(/^v/i, '').split('.')[0];
+}
+
+export function aggregateByMajorVersion(tracks: DeploymentTrack[]): DeploymentTrack[] {
+  const groups = new Map<string, DeploymentTrack>();
+  for (const track of tracks) {
+    if (!track.apiVersion) {
+      groups.set(track.id, track);
+      continue;
+    }
+    const key = `${getMajorVersion(track.apiVersion)}.x`;
+    const existing = groups.get(key);
+    if (!existing || track.latest) {
+      groups.set(key, { ...track, apiVersion: key });
+    }
+  }
+  return Array.from(groups.values());
+}
+
+export function stripLeadingTitle(content: string, docName: string): string {
+  const firstLine = content.match(/^#+ .+/m)?.[0] ?? '';
+  const heading = firstLine.replace(/^#+ /, '').trim();
+  if (heading.toLowerCase() === docName.toLowerCase()) {
+    return content.replace(firstLine, '').trimStart();
+  }
+  return content;
+}


### PR DESCRIPTION
## Purpose
> $subject

### Lazy loading & navigation performance
  - Made `AppLayout` an eager import so the authenticated shell stays mounted across route transitions — prevents layout remounts and sidebar collapsing on navigation
  - Moved `<Suspense>` boundary inside `AppLayout` wrapping `<Outlet>`, with a centered `CircularProgress` fallback for lazy-loaded pages
  - Fixed Suspense fallback spinner being anchored to the top bar by adding `height: '100%'` to the scroll container
  
  ### Loader centering (80+ files)
  - Replaced the widespread `<CircularProgress sx={{ display: 'block', mx: 'auto', py: N }} />` anti-pattern across all pages and components — `py` on the spinner element directly inflates its CSS bounding box and shifts the rotation origin
  off-center
  - Fixed pattern: `py` moved to a flex wrapper `<Box>`, spinner rendered clean inside it
  - Page-level loading states replaced `PageContent` + `flex: 1` (dead in a block parent) with `Box sx={{ minHeight: '100%' }}` so the spinner fills and centers within the scroll container

  ### UI polish
  - **Sidebar persistence**: expanded/collapsed state saved to `localStorage` and restored on page load
  - **Mobile logo**: fixed SVG logo on Login and Signup not scaling on small screens
  - **Container/HealthCheck cards**: switched from manually-bordered `Box` to `Paper variant="outlined"` for correct paper background semantics and dark mode support
  - **Scaling page**:
    - Scale method selectors replaced with `Card` + `CardActionArea` + `CardContent`; selected state uses `primary.50` background tint + 2px primary border, matching the existing `PrebuiltIntegrationCard` pattern
    - CPU/Memory threshold boxes switched to `Paper variant="outlined"`
    - Added "Runtime" page title
  
  ### Developer documents (`ComponentDocuments`)
  - Extracted pure helper functions (`typeLabel`, `getMajorVersion`, `aggregateByMajorVersion`, `stripLeadingTitle`) to `src/utils/documents.ts` with 16 unit tests
  - Disabled edit button for URL-type documents (cannot open in Monaco editor)
  - Fixed `handleSave` to use the APIM ID captured at edit-open time, not the current picker value, preventing ID drift during edits

Resolves https://github.com/wso2-enterprise/integration-engineering/issues/1842 



## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.