### PR TITLE
Fix Environments listing not loading on cloud

### DIFF
--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -110,7 +110,14 @@ export const updateEnvironment = (input: EnvironmentInput & { environmentId: str
 
 export const deleteEnvironment = (environmentId: string): Promise<string> => bff.delete<MessageResponse>(`/environments/${seg(environmentId)}`).then((r) => r?.message ?? '');
 
-export const fetchEnvironmentTemplates = (_orgId: string): Promise<EnvironmentTemplate[]> => ni('fetchEnvironmentTemplates');
+export const fetchEnvironmentTemplates = (_orgId: string): Promise<EnvironmentTemplate[]> =>
+  bff.get<ListResponse<BffEnvironment>>('/environments').then((r) =>
+    items(r).map((e) => {
+      const { id, name, critical, createdAt } = toEnvironment(e);
+      return { id, name, critical, createdAt };
+    }),
+  );
+
 export const createOrgEnvironment = (_orgUuid: string, _input: CreateEnvironmentData & { vhost: string }): Promise<void> => ni('createOrgEnvironment');
 export const getEnvDeleteEligibility = (_orgUuid: string, _templateId: string): Promise<EnvDeletionEligibility> => ni('getEnvDeleteEligibility');
 export const deleteEnvironmentTemplate = (_orgUuid: string, _templateId: string): Promise<void> => ni('deleteEnvironmentTemplate');

--- a/ipaas/src/hooks/useEnvironments.ts
+++ b/ipaas/src/hooks/useEnvironments.ts
@@ -19,6 +19,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getOrgUuidFromToken } from '../auth/tokenManager';
 import { createOrgEnvironment, deleteEnvironmentTemplate, fetchAllEnvironments, fetchCloudDataPlanes, fetchEnvironments, fetchEnvironmentTemplates, fetchLoggers, getEnvDeleteEligibility, updateEnvironment, updateLogLevel } from '#api/environments';
+import { IS_CLOUD } from '../features';
 import type { CreateEnvironmentData, EnvironmentInput } from '../types/environment';
 
 export function useEnvironments(orgUuid: string, projectId: string) {
@@ -79,7 +80,7 @@ export function useEnvironmentTemplates(orgId: string) {
   return useQuery({
     queryKey: ['environment-templates', orgId],
     queryFn: () => fetchEnvironmentTemplates(orgId),
-    enabled: !!orgId,
+    enabled: IS_CLOUD || !!orgId, // orgid is false in the cloud path, thus adding the IS_CLOUD
     retry: false,
   });
 }


### PR DESCRIPTION
## Purpose
On ipaas when using wso2cloud, the Environments listing page never showed any environments, even when they existed in the cluster. 

## Approch
- Implements `fetchEnvironmentTemplates` for cloud by adapting the existing `GET /environments` BFF response into the `EnvironmentTemplate` shape the listing page expects.
- Fixes the query gate to `enabled: IS_CLOUD || !!orgId`, so cloud runs unconditionally (it doesn't need `orgId`) while wip's original org-id-gated behavior is unchanged.

Resolves https://github.com/wso2-enterprise/integration-engineering/issues/1959