### PR TITLE
Fix ThunderID 0.48.0 e2e bootstrap: missing certs, secret file, and operation DB

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -51,7 +51,7 @@ and not-found resources.
 ## SSO (ThunderID)
 
 `e2eSso` runs a full OIDC login through a ThunderID IdP. It starts ThunderID
-(`ghcr.io/thunder-id/thunderid:latest`) via Testcontainers, enables ICP SSO
+(`ghcr.io/thunder-id/thunderid:0.48.0`) via Testcontainers, enables ICP SSO
 against it, seeds a matching OIDC super-admin user, then drives the **Sign in
 with SSO** flow in the browser. It needs Docker and fails if the fixture cannot
 start.

--- a/e2e-tests/src/test/java/org/wso2/icp/e2e/E2EEnvironment.java
+++ b/e2e-tests/src/test/java/org/wso2/icp/e2e/E2EEnvironment.java
@@ -51,7 +51,7 @@ public final class E2EEnvironment implements AutoCloseable {
     // password logins do not collide. ICP uses the OIDC `sub` as the user id, so ThunderID's
     // declarative user id and this seeded id must match.
     private static final String SSO_USER_ID = "5501b0b0-e29b-41d4-a716-446655440111";
-    private static final String THUNDERID_IMAGE = "ghcr.io/thunder-id/thunderid:latest";
+    private static final String THUNDERID_IMAGE = "ghcr.io/thunder-id/thunderid:0.48.0";
     private static final int THUNDERID_PORT = 8090;
     private static final String MYSQL_IMAGE = "mysql:8.0";
     private static final int MYSQL_PORT = 3306;
@@ -258,9 +258,10 @@ public final class E2EEnvironment implements AutoCloseable {
         writeThunderIdConfig(home);
 
         new GenericContainer<>(THUNDERID_IMAGE)
-                .withCommand("sh", "-c", "cp -r /opt/thunderid/database/* /data/ && (cp -r /opt/thunderid/consent/repository/database/* /consent-data/ 2>/dev/null || true)")
+                .withCommand("sh", "-c", "cp -r /opt/thunderid/database/* /data/ && (cp -r /opt/thunderid/consent/repository/database/* /consent-data/ 2>/dev/null || true) && cp -r /opt/thunderid/config/certs/* /certs/")
                 .withFileSystemBind(db.toString(), "/data", BindMode.READ_WRITE)
                 .withFileSystemBind(consentDb.toString(), "/consent-data", BindMode.READ_WRITE)
+                .withFileSystemBind(certs.toString(), "/certs", BindMode.READ_WRITE)
                 .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofMinutes(2)))
                 .start();
 
@@ -295,6 +296,9 @@ public final class E2EEnvironment implements AutoCloseable {
         Path resources = home.resolve("resources");
         Files.createDirectories(resources.resolve("applications"));
         Files.createDirectories(resources.resolve("users"));
+        // deployment-base.yaml.template references this file via a `file://` URI; ThunderID resolves
+        // it at config-load time, and unlike the `crypto` cert material it ships no default for it.
+        Files.writeString(home.resolve("config/secrets/direct_auth_secret"), UUID.randomUUID().toString());
 
         Map<String, String> vars = thunderIdVars();
         String baseDeployment = render("thunderid/deployment-base.yaml.template", vars);

--- a/e2e-tests/src/test/resources/thunderid/deployment-base.yaml.template
+++ b/e2e-tests/src/test/resources/thunderid/deployment-base.yaml.template
@@ -15,6 +15,18 @@ jwt:
   issuer: "{{THUNDERID_URL}}"
   preferred_key_id: "default-key"
 
+# The bundled config defaults (config/default.json) omit the "operation" database — used by the
+# SSO session service — unlike config/runtime/user, so it must be configured explicitly here.
+database:
+  operation:
+    type: "sqlite"
+    sqlite:
+      path: "database/operationdb.db"
+      options: "_journal_mode=WAL&_busy_timeout=5000&_pragma=foreign_keys(1)"
+      max_open_conns: 500
+      max_idle_conns: 100
+      conn_max_lifetime: 3600
+
 passkey:
   allowed_origins:
     - "{{THUNDERID_URL}}"


### PR DESCRIPTION
## Summary
- Pinning `THUNDERID_IMAGE` to `0.48.0` (added in #702 after `:latest` stopped resolving) exposed three gaps in the e2e SSO fixture that never surfaced against the older image:
  - The empty host dir bind-mounted over `/opt/thunderid/config/certs` shadowed the image's baked-in default cert/key files (`crypto.key`, `signing.*`, etc.), so bootstrap failed reading `crypto.key`.
  - `deployment-base.yaml.template` points `security.direct_auth_secret` at `file://config/secrets/direct_auth_secret`, but nothing created that file.
  - The bundled config defaults (`config/default.json`) configure `config`/`runtime`/`user` sqlite databases but omit `operation`, which the SSO session service needs, and our override didn't fill the gap.
- `e2e-tests/README.md` still referenced the now-nonexistent `:latest` tag; updated to `:0.48.0` (confirmed via the GHCR tag list that `0.48.0` is in fact the newest published tag).

## Test plan
- [x] `./gradlew :e2e-tests:e2eSso` passes
- [x] `./gradlew clean build` passes

https://claude.ai/code/session_01PNSm3GpH4EG5W7kGG8bpuC