### PR TITLE
Align Integration UI with Devant

### DIFF
--- a/frontend/src/api/mutations.ts
+++ b/frontend/src/api/mutations.ts
@@ -307,7 +307,13 @@ export function useUpdateListenerState() {
           port: input.port,
           action: input.action,
         },
-      }).then((d) => d.updateListenerState),
+      }).then((d) => {
+        // The backend signals failure via `success: false` on an otherwise-200 response
+        // (unlike a thrown GraphQL error), so that has to be checked explicitly here —
+        // otherwise a rejected action looks identical to a successful one to react-query.
+        if (!d.updateListenerState.success) throw new Error(d.updateListenerState.message || 'Failed to update listener state');
+        return d.updateListenerState;
+      }),
     onSuccess: () => {
       // Invalidate all listener queries to refetch the updated state
       qc.invalidateQueries({ queryKey: ['artifacts', 'Listener'] });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -535,7 +535,7 @@ const ARTIFACT_QUERY_MAP: Record<string, { queryName: string; field: string; fie
     queryName: 'servicesByEnvironmentAndComponent',
     field: 'servicesByEnvironmentAndComponent',
     fields: 'name, package, basePath, type',
-    gqlFields: 'name, package, basePath, type, state, stateInSync, runtimes { runtimeId, runtimeName, status }, resources { path, method, url, methods }',
+    gqlFields: 'name, package, basePath, type, state, stateInSync, runtimes { runtimeId, runtimeName, status }, resources { path, method, url, methods }, listeners { name, package, protocol, host, port, state }',
   },
   Automation: {
     queryName: 'automationsByEnvironmentAndComponent',

--- a/frontend/src/components/ArtifactTabs.tsx
+++ b/frontend/src/components/ArtifactTabs.tsx
@@ -16,41 +16,71 @@
  * under the License.
  */
 
-import { Accordion, AccordionSummary, AccordionDetails, Box, Card, CardContent, Chip, CircularProgress, Divider, Stack, Typography } from '@wso2/oxygen-ui';
+import { Accordion, AccordionSummary, AccordionDetails, Box, Button, Card, CardContent, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Drawer, IconButton, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
 import SearchField from './SearchField';
-import { ChevronDown } from '@wso2/oxygen-ui-icons-react';
-import { useMemo, useState } from 'react';
+import { ChevronDown, Play, Square, X } from '@wso2/oxygen-ui-icons-react';
+import { useEffect, useMemo, useState } from 'react';
 import { useArtifactSource, useArtifactParams, useArtifactWsdl, useLocalEntryValue, useDataSourceOverview, useDataServiceOverview, useMessageProcessorOverview, ARTIFACT_TYPE_TO_SOURCE_TYPE } from '../api/queries';
 import { WSDL_NS, SOAP_NS, SOAP12_NS } from '../paths';
 import CodeViewer from './CodeViewer';
 import { ListingTable, TablePagination } from '@wso2/oxygen-ui';
 const emptySx = { py: 4, textAlign: 'center', color: 'text.secondary' };
+import { useUpdateListenerState } from '../api/mutations';
+import { useQueryClient } from '@tanstack/react-query';
 import type { TabProps } from './artifact-config';
 
 // Shared style for resource/method display boxes
-const RESOURCE_BOX_SX = {
-  bgcolor: 'action.hover',
-  p: 1.5,
-  borderRadius: 1,
-  display: 'flex',
-  alignItems: 'center',
-  gap: 1.5,
-  border: '1px solid',
-  borderColor: 'divider',
-} as const;
-
-const HTTP_METHOD_CHIP_SX: Record<string, { bgcolor: string; color: string }> = {
-  GET: { bgcolor: '#2e7d32', color: '#fff' },
-  POST: { bgcolor: '#1565c0', color: '#fff' },
-  PUT: { bgcolor: '#b54708', color: '#fff' },
-  DELETE: { bgcolor: '#d32f2f', color: '#fff' },
-  PATCH: { bgcolor: '#6a1b9a', color: '#fff' },
+const HTTP_METHOD_BADGE_COLORS: Record<string, string> = {
+  GET: '#0095FF',
+  POST: '#36B475',
+  PUT: '#FF9D52',
+  DELETE: '#FE523C',
+  PATCH: '#01CEB5',
 };
 
-const getMethodChipSx = (method: string) => ({
-  ...(HTTP_METHOD_CHIP_SX[method.toUpperCase()] ?? { bgcolor: '#546e7a', color: '#fff' }),
-  fontWeight: 700,
-});
+const DEFAULT_METHOD_BADGE_COLOR = '#9e9e9e';
+
+const getMethodBadgeColor = (method: string) => HTTP_METHOD_BADGE_COLORS[method.toUpperCase()] ?? DEFAULT_METHOD_BADGE_COLOR;
+
+const getResourceRowSx = (method: string) => {
+  return {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 1.5,
+    px: 1,
+    py: 0.75,
+    border: '0.5px solid',
+    borderColor: getMethodBadgeColor(method),
+    borderRadius: 0.5,
+  } as const;
+};
+
+const getMethodBadgeSx = (method: string) =>
+  ({
+    bgcolor: getMethodBadgeColor(method),
+    color: '#fff',
+    fontWeight: 700,
+    fontSize: '11px',
+    minWidth: 72,
+    px: 1,
+    py: 0.5,
+    borderRadius: 0.5,
+    textAlign: 'center',
+    flexShrink: 0,
+  }) as const;
+
+const RESOURCE_LABEL_SX = { flex: 1, fontSize: '13px', fontWeight: 500, wordBreak: 'break-word', color: 'text.primary' } as const;
+
+function ResourceRow({ method, path }: { method: string; path: string }) {
+  const upperMethod = method.toUpperCase();
+
+  return (
+    <Box sx={{ ...getResourceRowSx(upperMethod), flexWrap: 'wrap' }}>
+      <Box sx={getMethodBadgeSx(upperMethod)}>{upperMethod}</Box>
+      <Typography sx={RESOURCE_LABEL_SX}>{path}</Typography>
+    </Box>
+  );
+}
 
 export function ArtifactSource({ envId, componentId, artifactType, artifact }: TabProps) {
   const sourceType = ARTIFACT_TYPE_TO_SOURCE_TYPE[artifactType] ?? artifactType.toLowerCase();
@@ -78,14 +108,9 @@ export function ArtifactApiDefinition({ artifact }: TabProps) {
   });
 
   return (
-    <Stack gap={1}>
+    <Stack gap={0.75}>
       {expandedItems.map((item, i) => (
-        <Box key={i} sx={RESOURCE_BOX_SX}>
-          <Chip label={item.method} size="small" sx={getMethodChipSx(item.method)} />
-          <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
-            {item.path}
-          </Typography>
-        </Box>
+        <ResourceRow key={i} method={item.method} path={item.path} />
       ))}
     </Stack>
   );
@@ -125,29 +150,227 @@ export function ArtifactEndpoints({ artifact }: TabProps) {
 
 export function ServiceResources({ artifact }: TabProps) {
   const resources = (artifact.resources as Array<{ url?: string; methods?: string[] }> | undefined) ?? [];
-  const basePath = (artifact.basePath ?? '/').toString();
+
+  const expandedItems: Array<{ method: string; path: string }> = [];
+  resources.forEach((r) => {
+    const raw = r.methods ?? [];
+    const methods = Array.isArray(raw) ? raw : [String(raw)];
+    methods.forEach((method) => {
+      expandedItems.push({ method: method.toUpperCase(), path: r.url ?? '' });
+    });
+  });
 
   return (
-    <Stack gap={1}>
-      {resources.length === 0 ? (
+    <Stack gap={0.75}>
+      {expandedItems.length === 0 ? (
         <Typography sx={emptySx}>No resources available.</Typography>
       ) : (
-        resources.map((r, i) => {
-          const raw = r.methods ?? [];
-          const methods = Array.isArray(raw) ? raw : [String(raw)];
-          return (
-            <Box key={i} sx={{ ...RESOURCE_BOX_SX, flexWrap: 'wrap' }}>
-              {methods.map((method, idx) => (
-                <Chip key={idx} label={method.toUpperCase()} size="small" sx={getMethodChipSx(method)} />
-              ))}
-              <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 500 }}>
-                {basePath}
-                {r.url ?? ''}
-              </Typography>
-            </Box>
-          );
-        })
+        expandedItems.map((item, i) => <ResourceRow key={i} method={item.method} path={item.path} />)
       )}
+    </Stack>
+  );
+}
+
+// Listener(s) a service is attached to. Backed by Service.listeners, which the
+// heartbeat now carries. Each row has an Enable/Disable toggle — a bound listener
+// runs on the same runtime(s) as the service, so we target the service's runtimes
+// for START/STOP. Disabling a listener stops the service(s) attached to it.
+export function ServiceListeners({ artifact, artifactType, envId, componentId }: TabProps) {
+  const listeners =
+    (artifact.listeners as Array<{ name?: string; package?: string; protocol?: string; host?: string; port?: number; state?: string }> | undefined) ?? [];
+  // A bound listener runs on the same runtime(s) as the service, so we reuse the
+  // service's runtimes both for START/STOP and for the details view's Runtimes list.
+  const serviceRuntimes = (artifact.runtimes as Array<{ runtimeId: string; runtimeName?: string; status?: string }> | undefined) ?? [];
+  const runtimeIds = serviceRuntimes.map((r) => r.runtimeId);
+  const hasRuntimes = runtimeIds.length > 0;
+
+  const queryClient = useQueryClient();
+  const updateListenerState = useUpdateListenerState();
+  const [pending, setPending] = useState<{ name: string; pkg?: string; port?: number; enable: boolean } | null>(null);
+  // Per-listener in-flight action. Enable/disable is eventually-consistent — the
+  // backend records the intent and the state flips after the next reconcile/heartbeat —
+  // so we keep the "Enabling…/Disabling…" busy state until the state actually reflects it.
+  const [actions, setActions] = useState<Record<string, 'START' | 'STOP'>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [detail, setDetail] = useState<{ name?: string; package?: string; protocol?: string; host?: string; port?: number; state?: string } | null>(null);
+
+  const isEnabled = (s?: string) => String(s ?? '').toLowerCase() === 'enabled';
+
+  // Clear a listener's busy state once its reported state matches the requested action.
+  useEffect(() => {
+    setActions((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const l of listeners) {
+        const name = l.name ?? '';
+        const act = next[name];
+        if (act && isEnabled(l.state) === (act === 'START')) {
+          delete next[name];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [listeners]);
+
+  const confirmToggle = () => {
+    if (!pending) return;
+    const action: 'START' | 'STOP' = pending.enable ? 'START' : 'STOP';
+    const name = pending.name;
+    setActions((prev) => ({ ...prev, [name]: action }));
+    setError(null);
+    updateListenerState.mutate(
+      { runtimeIds, listenerName: name, listenerPackage: pending.pkg, port: typeof pending.port === 'number' ? pending.port : undefined, action },
+      {
+        onError: (err) => {
+          setActions((prev) => {
+            const n = { ...prev };
+            delete n[name];
+            return n;
+          });
+          setError(err instanceof Error ? err.message : 'Failed to update listener state');
+        },
+        onSettled: () => {
+          queryClient.invalidateQueries({ queryKey: ['artifacts', artifactType, envId, componentId] });
+          queryClient.invalidateQueries({ queryKey: ['artifacts', 'Listener', envId, componentId] });
+        },
+      },
+    );
+    setPending(null);
+  };
+
+  if (listeners.length === 0) {
+    return <Typography sx={emptySx}>This service is not attached to any listener.</Typography>;
+  }
+
+  return (
+    <Stack gap={0.75}>
+      {error ? (
+        <Typography variant="caption" color="error">
+          {error}
+        </Typography>
+      ) : null}
+      {listeners.map((l, i) => {
+        const name = l.name ?? '';
+        const enabled = isEnabled(l.state);
+        const hostPort = [l.host, l.port].filter((v) => v !== undefined && v !== null && v !== '').join(':');
+        const act = actions[name];
+        return (
+          <Box
+            key={i}
+            sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 1, py: 0.75, border: '0.5px solid', borderColor: 'divider', borderRadius: 0.5 }}
+          >
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
+              {name || '—'}
+            </Typography>
+            {l.protocol ? <Chip size="small" label={String(l.protocol)} sx={{ height: 20 }} /> : null}
+            {hostPort ? (
+              <Typography variant="body2" sx={{ fontFamily: 'monospace', color: 'text.secondary' }}>
+                {hostPort}
+              </Typography>
+            ) : null}
+            <Box sx={{ flexGrow: 1 }} />
+            <Stack direction="row" alignItems="center" gap={0.75}>
+              <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: enabled ? 'success.main' : 'text.disabled' }} />
+              <Typography variant="body2">{enabled ? 'Enabled' : 'Disabled'}</Typography>
+            </Stack>
+            <Button variant="text" size="small" onClick={() => setDetail(l)} sx={{ fontSize: '12px', flexShrink: 0, textTransform: 'none' }}>
+              View Details
+            </Button>
+            <Tooltip title={!hasRuntimes ? 'No runtimes available' : enabled ? 'Disable listener (stops the service)' : 'Enable listener'}>
+              <span>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  color={enabled ? 'error' : 'success'}
+                  startIcon={act ? <CircularProgress size={12} color="inherit" /> : enabled ? <Square size={14} /> : <Play size={14} />}
+                  disabled={act != null || !hasRuntimes}
+                  onClick={() => setPending({ name, pkg: l.package, port: l.port, enable: !enabled })}
+                >
+                  {act === 'STOP' ? 'Disabling…' : act === 'START' ? 'Enabling…' : enabled ? 'Disable' : 'Enable'}
+                </Button>
+              </span>
+            </Tooltip>
+          </Box>
+        );
+      })}
+
+      <Dialog open={pending !== null} onClose={() => setPending(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>{pending?.enable ? 'Enable Listener' : 'Disable Listener'}</DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            Are you sure you want to {pending?.enable ? 'enable' : 'disable'} the listener <strong>{pending?.name}</strong>?
+            {!pending?.enable ? ' Any service attached to it will stop.' : ''}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPending(null)}>Cancel</Button>
+          <Button variant="contained" color={pending?.enable ? 'success' : 'error'} onClick={confirmToggle}>
+            {pending?.enable ? 'Enable' : 'Disable'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Drawer
+        anchor="right"
+        open={detail !== null}
+        onClose={() => setDetail(null)}
+        sx={{ '& .MuiDrawer-paper': { width: '60%', maxWidth: 700, minWidth: 400, position: 'fixed', top: 64, height: 'calc(100% - 64px)', borderLeft: '1px solid', borderColor: 'divider' } }}
+      >
+        <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, fontFamily: 'monospace' }}>
+            {detail?.name}
+          </Typography>
+          <IconButton size="small" aria-label="close" onClick={() => setDetail(null)}>
+            <X size={16} />
+          </IconButton>
+        </Stack>
+        <Box sx={{ p: 2, overflowY: 'auto' }}>
+          <Typography variant="overline" color="text.secondary" sx={{ fontSize: 10, fontWeight: 600, display: 'block', mb: 1 }}>
+            Overview
+          </Typography>
+          <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', columnGap: 3, rowGap: 2, mb: 3 }}>
+            {(
+              [
+                ['Package', detail?.package],
+                ['Protocol', detail?.protocol],
+                ['Host', detail?.host],
+                ['Port', detail?.port],
+                ['State', detail?.state],
+              ] as Array<[string, unknown]>
+            ).map(([label, v]) => (
+              <Box key={label}>
+                <Typography variant="overline" color="text.secondary" sx={{ fontSize: 10, fontWeight: 600, display: 'block' }}>
+                  {label}
+                </Typography>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace', mt: 0.25 }}>
+                  {v !== undefined && v !== null && v !== '' ? String(v) : '—'}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+          <Typography variant="overline" color="text.secondary" sx={{ fontSize: 10, fontWeight: 600, display: 'block', mb: 1 }}>
+            Runtimes
+          </Typography>
+          {serviceRuntimes.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No runtimes.
+            </Typography>
+          ) : (
+            <Stack gap={0.5}>
+              {serviceRuntimes.map((r) => (
+                <Box key={r.runtimeId} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: String(r.status).toUpperCase() === 'RUNNING' ? 'success.main' : 'text.disabled' }} />
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                    {r.runtimeName || r.runtimeId}
+                  </Typography>
+                  {r.status ? <Chip size="small" label={String(r.status)} sx={{ height: 20 }} /> : null}
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </Box>
+      </Drawer>
     </Stack>
   );
 }

--- a/frontend/src/components/ArtifactTabs.tsx
+++ b/frontend/src/components/ArtifactTabs.tsx
@@ -160,15 +160,7 @@ export function ServiceResources({ artifact }: TabProps) {
     });
   });
 
-  return (
-    <Stack gap={0.75}>
-      {expandedItems.length === 0 ? (
-        <Typography sx={emptySx}>No resources available.</Typography>
-      ) : (
-        expandedItems.map((item, i) => <ResourceRow key={i} method={item.method} path={item.path} />)
-      )}
-    </Stack>
-  );
+  return <Stack gap={0.75}>{expandedItems.length === 0 ? <Typography sx={emptySx}>No resources available.</Typography> : expandedItems.map((item, i) => <ResourceRow key={i} method={item.method} path={item.path} />)}</Stack>;
 }
 
 // Listener(s) a service is attached to. Backed by Service.listeners, which the
@@ -176,8 +168,7 @@ export function ServiceResources({ artifact }: TabProps) {
 // runs on the same runtime(s) as the service, so we target the service's runtimes
 // for START/STOP. Disabling a listener stops the service(s) attached to it.
 export function ServiceListeners({ artifact, artifactType, envId, componentId }: TabProps) {
-  const listeners =
-    (artifact.listeners as Array<{ name?: string; package?: string; protocol?: string; host?: string; port?: number; state?: string }> | undefined) ?? [];
+  const listeners = (artifact.listeners as Array<{ name?: string; package?: string; protocol?: string; host?: string; port?: number; state?: string }> | undefined) ?? [];
   // A bound listener runs on the same runtime(s) as the service, so we reuse the
   // service's runtimes both for START/STOP and for the details view's Runtimes list.
   const serviceRuntimes = (artifact.runtimes as Array<{ runtimeId: string; runtimeName?: string; status?: string }> | undefined) ?? [];
@@ -256,10 +247,7 @@ export function ServiceListeners({ artifact, artifactType, envId, componentId }:
         const hostPort = [l.host, l.port].filter((v) => v !== undefined && v !== null && v !== '').join(':');
         const act = actions[name];
         return (
-          <Box
-            key={i}
-            sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 1, py: 0.75, border: '0.5px solid', borderColor: 'divider', borderRadius: 0.5 }}
-          >
+          <Box key={i} sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 1, py: 0.75, border: '0.5px solid', borderColor: 'divider', borderRadius: 0.5 }}>
             <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>
               {name || '—'}
             </Typography>
@@ -285,8 +273,7 @@ export function ServiceListeners({ artifact, artifactType, envId, componentId }:
                   color={enabled ? 'error' : 'success'}
                   startIcon={act ? <CircularProgress size={12} color="inherit" /> : enabled ? <Square size={14} /> : <Play size={14} />}
                   disabled={act != null || !hasRuntimes}
-                  onClick={() => setPending({ name, pkg: l.package, port: l.port, enable: !enabled })}
-                >
+                  onClick={() => setPending({ name, pkg: l.package, port: l.port, enable: !enabled })}>
                   {act === 'STOP' ? 'Disabling…' : act === 'START' ? 'Enabling…' : enabled ? 'Disable' : 'Enable'}
                 </Button>
               </span>
@@ -299,8 +286,7 @@ export function ServiceListeners({ artifact, artifactType, envId, componentId }:
         <DialogTitle>{pending?.enable ? 'Enable Listener' : 'Disable Listener'}</DialogTitle>
         <DialogContent>
           <Typography variant="body2">
-            Are you sure you want to {pending?.enable ? 'enable' : 'disable'} the listener <strong>{pending?.name}</strong>?
-            {!pending?.enable ? ' Any service attached to it will stop.' : ''}
+            Are you sure you want to {pending?.enable ? 'enable' : 'disable'} the listener <strong>{pending?.name}</strong>?{!pending?.enable ? ' Any service attached to it will stop.' : ''}
           </Typography>
         </DialogContent>
         <DialogActions>
@@ -315,8 +301,7 @@ export function ServiceListeners({ artifact, artifactType, envId, componentId }:
         anchor="right"
         open={detail !== null}
         onClose={() => setDetail(null)}
-        sx={{ '& .MuiDrawer-paper': { width: '60%', maxWidth: 700, minWidth: 400, position: 'fixed', top: 64, height: 'calc(100% - 64px)', borderLeft: '1px solid', borderColor: 'divider' } }}
-      >
+        sx={{ '& .MuiDrawer-paper': { width: '60%', maxWidth: 700, minWidth: 400, position: 'fixed', top: 64, height: 'calc(100% - 64px)', borderLeft: '1px solid', borderColor: 'divider' } }}>
         <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
           <Typography variant="subtitle1" sx={{ fontWeight: 600, fontFamily: 'monospace' }}>
             {detail?.name}

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -33,11 +33,12 @@ import {
   Drawer,
   FormControlLabel,
   IconButton,
-  InputAdornment,
   Link,
   List,
   ListItem,
   ListItemText,
+  MenuItem,
+  Select,
   Snackbar,
   Alert,
   Stack,
@@ -46,15 +47,15 @@ import {
   Tooltip,
   Typography,
 } from '@wso2/oxygen-ui';
-import { RefreshCw, ListFilter, LayoutGrid, Server, Settings, Play, Square, Plus, X, Trash2, UserPlus, Code, Sliders, Link as LinkIcon, FileText } from '@wso2/oxygen-ui-icons-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { RefreshCw, ListFilter, LayoutGrid, Server, Settings, Play, Square, Plus, X, Trash2, UserPlus, Code, Sliders, Link as LinkIcon, FileText, Package, Tag, Check, Copy, Layers } from '@wso2/oxygen-ui-icons-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { useArtifacts, useRefreshEnvironmentArtifacts, useComponentRuntimes, type GqlArtifact, type GqlEnvironment } from '../api/queries';
 import { useUpdateArtifactTracingStatus, useUpdateArtifactStatisticsStatus } from '../api/artifactToggleMutations';
 import { useUpdateArtifactStatus, useUpdateListenerState, useTriggerTask } from '../api/mutations';
 import { useListMiUsers, useCreateMiUser, useDeleteMiUser } from '../api/miUsers';
-import { ArtifactApiDefinition, ServiceResources, AutomationExecutions, ProxyApiReference } from './ArtifactTabs';
+import { ArtifactApiDefinition, ServiceResources, ServiceListeners, AutomationExecutions, ProxyApiReference } from './ArtifactTabs';
 import { SchemaDisclosure } from './workflow/shared';
 import { StartWorkflowDialog, type Toast as WorkflowToast } from './workflow/AdminPortal';
 import { ArtifactTypeSelector } from './ArtifactDetail';
@@ -64,14 +65,51 @@ import { resourceUrl, useScope } from '../nav';
 import { ENTRY_POINT_CONFIG, ENTRY_POINT_DETAIL_TABS, type SelectedArtifact, type TabProps } from './artifact-config';
 import SyncSwitch from './SyncSwitch';
 
+function toEnabled(value: unknown) {
+  if (typeof value === 'boolean') return value;
+  const normalized = (value ?? '').toString().toLowerCase();
+  return normalized === 'enabled' || normalized === 'active' || normalized === 'true';
+}
+
+// Small colored tag identifying an entry point's artifact type (API, Proxy, Inbound, Task…) — used
+// in the MI entry point picker, where several artifact types are mixed into a single list.
+function EntryTypeChip({ cfg }: { cfg?: { label: string; color: string; bgColor: string } }) {
+  if (!cfg) return null;
+  return <Chip label={cfg.label} size="small" sx={{ bgcolor: cfg.bgColor, color: cfg.color, fontWeight: 700, fontSize: 11, minWidth: 60, justifyContent: 'center' }} />;
+}
+
+// Mirrors devant's EndpointUrlsPanel CopyButton — same 2s "Copied!" revert and icon sizing.
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  useEffect(() => () => clearTimeout(resetTimer.current), []);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      clearTimeout(resetTimer.current);
+      resetTimer.current = setTimeout(() => setCopied(false), 2000);
+    });
+  }, [value]);
+  return (
+    <Tooltip title={copied ? 'Copied!' : `Copy ${label}`}>
+      <IconButton size="small" onClick={handleCopy} sx={{ p: 0.25, flexShrink: 0 }}>
+        {copied ? <Check size={13} /> : <Copy size={13} />}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
 function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArtifact; onOpenDrawerTab: (tab: string) => void }) {
   const [tracingEnabled, setTracingEnabled] = useState(false);
   const [statisticsEnabled, setStatisticsEnabled] = useState(false);
   const [statusEnabled, setStatusEnabled] = useState(false);
-  const [listenerEnabled, setListenerEnabled] = useState(false);
   const [pendingToggle, setPendingToggle] = useState<{ type: 'tracing' | 'statistics' | 'status'; checked: boolean } | null>(null);
+  const [listenerEnabled, setListenerEnabled] = useState(false);
   const [pendingListenerToggle, setPendingListenerToggle] = useState<{ checked: boolean } | null>(null);
-  const pendingActionRef = useRef<'START' | 'STOP' | null>(null);
+  // Which direction is actually in flight — drives each button's own busy label, so a
+  // Disable action in progress can't make the (now-visible) Enable button say "Enabling…".
+  const [pendingListenerAction, setPendingListenerAction] = useState<'START' | 'STOP' | null>(null);
+  const [listenerToggleError, setListenerToggleError] = useState<string | null>(null);
   const [triggerConfirmDialogOpen, setTriggerConfirmDialogOpen] = useState(false);
   const [triggerSuccessMessage, setTriggerSuccessMessage] = useState<string | null>(null);
   const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
@@ -91,9 +129,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   const artifactState = artifact.state?.toString();
   const overviewFields = (config?.overviewFields ?? '').split(', ').filter(Boolean);
   const showTracingToggle = ['RestApi', 'ProxyService', 'InboundEndpoint'].includes(artifactType);
-  const showRuntimesButton = true; // Show View Runtimes button for all entry points
   const showParametersButton = artifactType === 'InboundEndpoint';
-  const showSourceButton = ['RestApi', 'ProxyService', 'InboundEndpoint', 'Task'].includes(artifactType);
   const showInstancesButton = artifactType === 'Workflow';
   const showWsdlButton = artifactType === 'ProxyService';
   const showStatisticsToggle = ['RestApi', 'ProxyService', 'InboundEndpoint'].includes(artifactType);
@@ -106,11 +142,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
 
   // Track if any preceding controls are visible for proper divider placement
   const hasPrecedingControls = compositeApp || showStatusToggle || showStatusChip || showTracingToggle || showStatisticsToggle || showListenerToggle;
-  const toEnabled = (value: unknown) => {
-    if (typeof value === 'boolean') return value;
-    const normalized = (value ?? '').toString().toLowerCase();
-    return normalized === 'enabled' || normalized === 'active' || normalized === 'true';
-  };
+  const hasHeaderControls = !!compositeApp || showStatusChip || showStatusToggle || showTracingToggle || showStatisticsToggle || showListenerToggle || showParametersButton || showWsdlButton || showInstancesButton || showTaskToggle || showTaskTrigger;
 
   const artifactName = artifactType === 'Automation' ? (artifact.packageName?.toString() ?? '') : (artifact.name?.toString() ?? '');
   const artifactKey = `${artifactType}-${artifactName}`;
@@ -118,11 +150,23 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
     setTracingEnabled(toEnabled(artifact.tracing));
     setStatisticsEnabled(toEnabled(artifact.statistics));
     setStatusEnabled(toEnabled(artifact.state));
-    // Don't overwrite the optimistic listenerEnabled while a listener action is still in flight.
-    if (!pendingActionRef.current) {
+  }, [artifactKey, artifact.tracing, artifact.statistics, artifact.state]);
+
+  useEffect(() => {
+    if (showListenerToggle && !pendingListenerAction) {
       setListenerEnabled(toEnabled(artifact.state));
     }
-  }, [artifactKey, artifact.tracing, artifact.statistics, artifact.state]);
+  }, [showListenerToggle, artifact.state, pendingListenerAction]);
+
+  // Clear the busy state as soon as `state` itself reflects the requested change — the
+  // same field the status indicator below already uses, so both update in lockstep.
+  useEffect(() => {
+    if (!showListenerToggle || !pendingListenerAction) return;
+    const targetEnabled = pendingListenerAction === 'START';
+    if (toEnabled(artifact.state) === targetEnabled) {
+      setPendingListenerAction(null);
+    }
+  }, [showListenerToggle, artifact.state, pendingListenerAction]);
 
   const handleToggleTracing = (checked: boolean) => {
     if (!showTracingToggle) return;
@@ -137,11 +181,6 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   const handleToggleStatus = (checked: boolean) => {
     if (!showStatusToggle && !showTaskToggle) return;
     setPendingToggle({ type: 'status', checked });
-  };
-
-  const handleToggleListener = (checked: boolean) => {
-    if (!showListenerToggle) return;
-    setPendingListenerToggle({ checked });
   };
 
   const handleTriggerTask = () => {
@@ -202,23 +241,28 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
     setPendingToggle(null);
   };
 
-  const handleConfirmListenerToggle = () => {
-    if (!pendingListenerToggle) return;
+  const handleToggleListener = (checked: boolean) => {
+    if (!showListenerToggle) return;
+    setPendingListenerToggle({ checked });
+  };
 
-    const runtimes = artifact.runtimes;
-    if (!runtimes || !Array.isArray(runtimes) || runtimes.length === 0) {
-      console.error('No valid runtimes available for listener toggle');
+  const handleConfirmListenerToggle = () => {
+    const runtimes = artifact.runtimes as Array<{ runtimeId: string }> | undefined;
+    if (!pendingListenerToggle || !runtimes || runtimes.length === 0) {
       setPendingListenerToggle(null);
       return;
     }
 
-    const runtimeIds = runtimes.map((r: { runtimeId: string }) => r.runtimeId);
+    const runtimeIds = runtimes.map((r) => r.runtimeId);
     const action = pendingListenerToggle.checked ? 'START' : 'STOP';
-    const targetEnabled = pendingListenerToggle.checked;
     const artifactQueryKey = ['artifacts', artifactType, envId, componentId];
 
-    pendingActionRef.current = action;
-    setListenerEnabled(targetEnabled);
+    // Don't optimistically flip listenerEnabled here — that would swap which button is
+    // visible before the backend has confirmed anything. The clicked button stays put
+    // and shows its own busy label until the sync effect above updates listenerEnabled
+    // from the real (confirmed) artifact state once pendingListenerAction clears.
+    setPendingListenerAction(action);
+    setListenerToggleError(null);
 
     updateListenerState.mutate(
       {
@@ -229,13 +273,12 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
         action,
       },
       {
-        onError: () => {
-          setListenerEnabled(!targetEnabled);
-          pendingActionRef.current = null;
+        onError: (err) => {
+          setPendingListenerAction(null);
+          setListenerToggleError(err instanceof Error ? err.message : 'Failed to update listener state');
         },
-        onSettled: async () => {
-          await queryClient.invalidateQueries({ queryKey: artifactQueryKey });
-          pendingActionRef.current = null;
+        onSettled: () => {
+          queryClient.invalidateQueries({ queryKey: artifactQueryKey });
         },
       },
     );
@@ -243,9 +286,10 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
     setPendingListenerToggle(null);
   };
 
+  const listenerToggleAction = pendingListenerToggle?.checked ? 'enable' : 'disable';
+
   const toggleLabel = pendingToggle?.type ?? 'status';
   const toggleAction = pendingToggle?.checked ? 'enable' : 'disable';
-  const listenerAction = pendingListenerToggle?.checked ? 'enable' : 'disable';
 
   return (
     <>
@@ -266,16 +310,16 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
         </DialogActions>
       </Dialog>
       <Dialog open={pendingListenerToggle !== null} onClose={() => setPendingListenerToggle(null)} maxWidth="xs" fullWidth>
-        <DialogTitle>{listenerAction === 'enable' ? 'Enable Listener' : 'Disable Listener'}</DialogTitle>
+        <DialogTitle>{listenerToggleAction === 'enable' ? 'Enable Listener' : 'Disable Listener'}</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Are you sure you want to {listenerAction} the listener <strong>{artifactName}</strong>?
+            Are you sure you want to {listenerToggleAction} the listener <strong>{artifactName}</strong>?
           </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setPendingListenerToggle(null)}>Cancel</Button>
-          <Button variant="contained" color={listenerAction === 'disable' ? 'error' : 'success'} onClick={handleConfirmListenerToggle}>
-            {listenerAction === 'enable' ? 'Enable' : 'Disable'}
+          <Button variant="contained" color={listenerToggleAction === 'disable' ? 'error' : 'success'} onClick={handleConfirmListenerToggle}>
+            {listenerToggleAction === 'enable' ? 'Enable' : 'Disable'}
           </Button>
         </DialogActions>
       </Dialog>
@@ -294,9 +338,10 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
           </Button>
         </DialogActions>
       </Dialog>
-      <Box sx={{ mt: 2 }}>
-        {/* Header row */}
-        <Stack direction="row" alignItems="center" gap={1.5} sx={{ px: 2, py: 1.5 }}>
+      <Box sx={{ mt: hasHeaderControls ? 2 : 0 }}>
+        {/* Header row — hidden when this artifact type has no controls (e.g. a BI service) */}
+        {hasHeaderControls && (
+          <Stack direction="row" alignItems="center" gap={1.5} sx={{ px: 2, py: 1.5 }}>
           {compositeApp && <Chip label={`Composite App: ${compositeApp}`} size="small" variant="outlined" sx={{ bgcolor: '#e8eaf6', color: '#3949ab', fontSize: 11 }} />}
           {compositeApp && <Divider orientation="vertical" flexItem />}
           {showStatusChip && artifactState && (
@@ -304,7 +349,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
               <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>
                 Status
               </Typography>
-              {artifactType === 'Listener' ? (
+              {artifactType === 'Listener' || artifactType === 'RestApi' ? (
                 <Stack direction="row" alignItems="center" gap={0.75}>
                   <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: toEnabled(artifact.state) ? 'success.main' : 'text.disabled' }} />
                   <Typography variant="body2">{toEnabled(artifact.state) ? 'Enabled' : 'Disabled'}</Typography>
@@ -320,32 +365,32 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
           {showTracingToggle && <SyncSwitch label="Tracing" checked={tracingEnabled} inSync={artifact.tracingInSync as boolean | null} onChange={handleToggleTracing} disabled={updateTracingStatus.isPending} />}
           {showTracingToggle && showStatisticsToggle && <Divider orientation="vertical" flexItem />}
           {showStatisticsToggle && <SyncSwitch label="Statistics" checked={statisticsEnabled} inSync={artifact.statisticsInSync as boolean | null} onChange={handleToggleStatistics} disabled={updateStatisticsStatus.isPending} />}
-          {showListenerToggle && (updateListenerState.isPending ? pendingActionRef.current === 'START' : !listenerEnabled) && (
+          {showListenerToggle && !listenerEnabled && (
             <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Enable listener'}>
               <span style={{ marginLeft: 'auto' }}>
                 <Button
-                  variant="contained"
+                  variant="outlined"
                   size="small"
                   color="success"
-                  startIcon={updateListenerState.isPending || artifact.stateInSync === false ? <CircularProgress size={12} color="inherit" /> : <Play size={14} />}
-                  disabled={updateListenerState.isPending || !hasRuntimes}
+                  startIcon={pendingListenerAction === 'START' ? <CircularProgress size={12} color="inherit" /> : <Play size={14} />}
+                  disabled={pendingListenerAction !== null || !hasRuntimes}
                   onClick={() => handleToggleListener(true)}>
-                  {updateListenerState.isPending ? 'Enabling…' : 'Enable'}
+                  {pendingListenerAction === 'START' ? 'Enabling…' : 'Enable'}
                 </Button>
               </span>
             </Tooltip>
           )}
-          {showListenerToggle && (updateListenerState.isPending ? pendingActionRef.current === 'STOP' : listenerEnabled) && (
+          {showListenerToggle && listenerEnabled && (
             <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Disable listener'}>
               <span style={{ marginLeft: 'auto' }}>
                 <Button
-                  variant="contained"
+                  variant="outlined"
                   size="small"
                   color="error"
-                  startIcon={updateListenerState.isPending || artifact.stateInSync === false ? <CircularProgress size={12} color="inherit" /> : <Square size={14} />}
-                  disabled={updateListenerState.isPending || !hasRuntimes}
+                  startIcon={pendingListenerAction === 'STOP' ? <CircularProgress size={12} color="inherit" /> : <Square size={14} />}
+                  disabled={pendingListenerAction !== null || !hasRuntimes}
                   onClick={() => handleToggleListener(false)}>
-                  {updateListenerState.isPending ? 'Disabling…' : 'Disable'}
+                  {pendingListenerAction === 'STOP' ? 'Disabling…' : 'Disable'}
                 </Button>
               </span>
             </Tooltip>
@@ -368,23 +413,18 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
               </Tooltip>
             </>
           )}
-          {showSourceButton && (
-            <Button variant="contained" size="small" startIcon={<Code size={14} />} onClick={() => onOpenDrawerTab('Source')} sx={{ ml: 'auto' }}>
-              View Source
-            </Button>
-          )}
           {showParametersButton && (
-            <Button variant="contained" size="small" startIcon={<Sliders size={14} />} onClick={() => onOpenDrawerTab('Parameters')} sx={{ ml: showSourceButton ? 0 : 'auto' }}>
+            <Button variant="contained" size="small" startIcon={<Sliders size={14} />} onClick={() => onOpenDrawerTab('Parameters')} sx={{ ml: 'auto' }}>
               View Parameters
             </Button>
           )}
           {showWsdlButton && (
-            <Button variant="contained" size="small" startIcon={<LinkIcon size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ ml: showSourceButton || showParametersButton ? 0 : 'auto' }}>
+            <Button variant="text" size="small" startIcon={<LinkIcon size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ textTransform: 'none', ml: showParametersButton ? 0 : 'auto' }}>
               View Endpoints
             </Button>
           )}
           {showWsdlButton && (
-            <Button variant="contained" size="small" startIcon={<FileText size={14} />} onClick={() => onOpenDrawerTab('WSDL')}>
+            <Button variant="text" size="small" startIcon={<FileText size={14} />} onClick={() => onOpenDrawerTab('WSDL')} sx={{ textTransform: 'none' }}>
               View WSDL
             </Button>
           )}
@@ -394,7 +434,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
               size="small"
               startIcon={<LayoutGrid size={14} />}
               onClick={() => navigate(`${resourceUrl(scope, 'workflows')}?tab=admin&type=${encodeURIComponent(artifactName)}&env=${encodeURIComponent(envId)}`)}
-              sx={{ ml: showSourceButton || showParametersButton || showWsdlButton ? 0 : 'auto' }}>
+              sx={{ ml: showParametersButton || showWsdlButton ? 0 : 'auto' }}>
               View Instances
             </Button>
           )}
@@ -405,14 +445,10 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
               </Button>
             </Authorized>
           )}
-          {showRuntimesButton && (
-            <Button variant="contained" size="small" startIcon={<Server size={14} />} onClick={() => onOpenDrawerTab('Runtimes')} sx={{ ml: showSourceButton || showParametersButton || showWsdlButton || showListenerToggle || showInstancesButton ? 0 : 'auto' }}>
-              View Runtimes
-            </Button>
-          )}
-        </Stack>
+          </Stack>
+        )}
         {/* Overview columns */}
-        {overviewFields.length > 0 && (
+        {overviewFields.length > 0 && artifactType !== 'Service' && (
           <Box sx={{ display: 'grid', gridTemplateColumns: `repeat(${overviewFields.length}, 1fr)` }}>
             {overviewFields.map((f, i) => (
               <Box key={f} sx={{ px: 2, py: 1.5, ...(i < overviewFields.length - 1 && { borderRight: '1px solid', borderColor: 'divider' }) }}>
@@ -447,7 +483,13 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
             )}
           </Box>
         )}
-        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Resources') && <Box sx={{ px: 2, py: 1.5 }}>{artifactType === 'RestApi' ? <ArtifactApiDefinition {...tabProps} /> : <ServiceResources {...tabProps} />}</Box>}
+        {/* pt: 0 for Service — it's the first block rendered (no header/overview above it here), so
+            the grid's own mb above already provides the gap; adding padding-top on top of that
+            margin doesn't collapse the way devant's stacked margins do, and reads as too much space. */}
+        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Resources') && (
+          <Box sx={{ px: 2, pt: artifactType === 'Service' ? 0 : 1.5, pb: 1.5 }}>{artifactType === 'RestApi' ? <ArtifactApiDefinition {...tabProps} /> : <ServiceResources {...tabProps} />}</Box>
+        )}
+        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Listeners') && <Box sx={{ px: 2, py: 1.5 }}><ServiceListeners {...tabProps} /></Box>}
         {artifactType === 'ProxyService' && (
           <Box sx={{ px: 2, py: 1.5 }}>
             <ProxyApiReference {...tabProps} />
@@ -462,6 +504,11 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
       <Snackbar open={triggerSuccessMessage !== null} autoHideDuration={4000} onClose={() => setTriggerSuccessMessage(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
         <Alert onClose={() => setTriggerSuccessMessage(null)} severity="success" sx={{ width: '100%' }}>
           {triggerSuccessMessage}
+        </Alert>
+      </Snackbar>
+      <Snackbar open={listenerToggleError !== null} autoHideDuration={6000} onClose={() => setListenerToggleError(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        <Alert onClose={() => setListenerToggleError(null)} severity="error" sx={{ width: '100%' }}>
+          {listenerToggleError}
         </Alert>
       </Snackbar>
       {startWorkflowOpen && <StartWorkflowDialog scope={{ componentId, environmentId: envId }} initialWorkflowType={artifactName} onClose={() => setStartWorkflowOpen(false)} onToast={setWorkflowToast} />}
@@ -482,6 +529,7 @@ function EntryPointsList({
   componentType,
   isOnline,
   onOpenDrawer,
+  onSelectionChange,
 }: {
   envId: string;
   componentId: string;
@@ -489,6 +537,7 @@ function EntryPointsList({
   componentType: string;
   isOnline: boolean;
   onOpenDrawer: (a: GqlArtifact, type: string, envId: string, tab: string) => void;
+  onSelectionChange?: (entry: { artifact: GqlArtifact; type: string } | null) => void;
 }) {
   const [selectedKey, setSelectedKey] = useState('');
   const navigate = useNavigate();
@@ -500,11 +549,10 @@ function EntryPointsList({
   const { data: inboundEps = [], isLoading: loadingInbound } = useArtifacts('InboundEndpoint', envId, componentId, { enabled: isMI, active: isOnline });
   const { data: tasks = [], isLoading: loadingTasks } = useArtifacts('Task', envId, componentId, { enabled: isMI, active: isOnline });
   const { data: services = [], isLoading: loadingServices } = useArtifacts('Service', envId, componentId, { enabled: !isMI, active: isOnline });
-  const { data: listeners = [], isLoading: loadingListeners } = useArtifacts('Listener', envId, componentId, { enabled: !isMI, active: isOnline });
   const { data: automations = [], isLoading: loadingAutomations } = useArtifacts('Automation', envId, componentId, { enabled: !isMI, active: isOnline });
   const { data: workflows = [], isLoading: loadingWorkflows } = useArtifacts('Workflow', envId, componentId, { enabled: !isMI, active: isOnline });
 
-  const isLoading = isMI ? loadingApis || loadingProxies || loadingInbound || loadingTasks : loadingServices || loadingListeners || loadingAutomations || loadingWorkflows;
+  const isLoading = isMI ? loadingApis || loadingProxies || loadingInbound || loadingTasks : loadingServices || loadingAutomations || loadingWorkflows;
 
   const allEntryPoints = useMemo(
     () =>
@@ -512,11 +560,10 @@ function EntryPointsList({
         ? [...apis.map((a) => ({ artifact: a, type: 'RestApi' })), ...proxies.map((a) => ({ artifact: a, type: 'ProxyService' })), ...inboundEps.map((a) => ({ artifact: a, type: 'InboundEndpoint' })), ...tasks.map((a) => ({ artifact: a, type: 'Task' }))]
         : [
             ...services.map((a) => ({ artifact: a, type: 'Service' })),
-            ...listeners.map((a) => ({ artifact: a, type: 'Listener' })),
             ...workflows.map((a) => ({ artifact: a, type: 'Workflow' })),
             ...automations.map((a) => ({ artifact: a, type: 'Automation' })),
           ],
-    [isMI, apis, proxies, inboundEps, tasks, services, listeners, workflows, automations],
+    [isMI, apis, proxies, inboundEps, tasks, services, workflows, automations],
   );
 
   const allKeys = new Set(
@@ -536,6 +583,10 @@ function EntryPointsList({
     [allEntryPoints, activeKey],
   );
 
+  useEffect(() => {
+    onSelectionChange?.(selectedEntry ? { artifact: selectedEntry.artifact, type: selectedEntry.type } : null);
+  }, [selectedEntry, onSelectionChange]);
+
   if (isLoading) return <CircularProgress size={24} sx={{ display: 'block', mx: 'auto', py: 4 }} />;
   if (allEntryPoints.length === 0)
     return (
@@ -551,76 +602,90 @@ function EntryPointsList({
       </Stack>
     );
 
+  // Which pair of fields to show depends on the selected entry's artifact type: Tasks have
+  // no URL/Context, only group/class; Proxies have neither; the remaining MI types (API/Inbound) do.
+  const isTask = selectedEntry?.type === 'Task';
+  const isProxy = selectedEntry?.type === 'ProxyService';
+  const primaryLabel = isProxy ? '' : isTask ? 'Class' : isMI ? 'URL' : 'Package';
+  const secondaryLabel = isProxy ? '' : isTask ? 'Group' : isMI ? 'Context' : 'API';
+
   return (
     <>
-      <Autocomplete
-        value={selectedEntry ?? null}
-        onChange={(_, newValue) => {
-          if (!newValue) {
-            setSelectedKey('');
-            return;
-          }
-          const artifactKey = newValue.type === 'Automation' ? newValue.artifact.packageName : newValue.artifact.name;
-          setSelectedKey(`${newValue.type}::${artifactKey}`);
-        }}
-        options={allEntryPoints}
-        autoHighlight
-        fullWidth
-        getOptionLabel={(option) => {
-          const cfg = ENTRY_POINT_CONFIG[option.type];
-          if (cfg?.primaryDisplay && cfg.metaField) return option.artifact[cfg.metaField]?.toString() ?? option.artifact.name?.toString() ?? '';
-          const displayName = option.type === 'Automation' ? option.artifact.packageName : option.artifact.name;
-          return displayName?.toString() ?? '';
-        }}
-        isOptionEqualToValue={(a, b) => {
-          const aName = a.type === 'Automation' ? a.artifact.packageName : a.artifact.name;
-          const bName = b.type === 'Automation' ? b.artifact.packageName : b.artifact.name;
-          return a.type === b.type && aName === bName;
-        }}
-        renderOption={(props, { artifact: a, type }) => {
-          const { key, ...optionProps } = props;
-          const cfg = ENTRY_POINT_CONFIG[type];
-          const meta = cfg?.metaField ? a[cfg.metaField]?.toString() : undefined;
-          const useMeta = cfg?.primaryDisplay && !!meta;
-          const displayName = useMeta ? meta : type === 'Automation' ? a.packageName?.toString() : a.name?.toString();
+      {/* Endpoint / Package / API grid — mirrors devant's endpoint panel layout. MI components
+          don't have a package/API concept, so they show URL/Context instead (or group/class for Tasks). */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: '220px 1fr 1fr', columnGap: 2, rowGap: 0.75, alignItems: 'start', mb: 2 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+          Endpoint
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+          {primaryLabel}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+          {secondaryLabel}
+        </Typography>
+
+        <Select
+          size="small"
+          value={activeKey}
+          onChange={(e) => setSelectedKey(e.target.value)}
+          sx={{ fontSize: '13px', width: '100%' }}
+          renderValue={(val) => {
+            const entry = allEntryPoints.find(({ artifact: a, type }) => `${type}::${type === 'Automation' ? a.packageName : a.name}` === val);
+            if (!entry) return '';
+            const cfg = ENTRY_POINT_CONFIG[entry.type];
+            const raw = (cfg?.primaryDisplay && cfg.metaField ? entry.artifact[cfg.metaField]?.toString() ?? entry.artifact.name?.toString() : entry.type === 'Automation' ? entry.artifact.packageName?.toString() : entry.artifact.name?.toString()) ?? '';
+            // Chip is intentionally omitted here (closed box) — it would eat into the fixed-width
+            // box's space and truncate long names. It only shows in the open dropdown list below.
+            return raw.replace(/^\//, '');
+          }}>
+          {allEntryPoints.map(({ artifact: a, type }) => {
+            const cfg = ENTRY_POINT_CONFIG[type];
+            const rawLabel = (cfg?.primaryDisplay && cfg.metaField ? a[cfg.metaField]?.toString() ?? a.name?.toString() : type === 'Automation' ? a.packageName?.toString() : a.name?.toString()) ?? '';
+            const label = rawLabel.replace(/^\//, '');
+            const key = `${type}::${type === 'Automation' ? a.packageName : a.name}`;
+            return (
+              <MenuItem key={key} value={key} sx={{ fontSize: '13px' }}>
+                {isMI ? (
+                  <Stack direction="row" alignItems="center" gap={1}>
+                    <EntryTypeChip cfg={cfg} />
+                    <span>{label}</span>
+                  </Stack>
+                ) : (
+                  label
+                )}
+              </MenuItem>
+            );
+          })}
+        </Select>
+
+        {(() => {
+          if (isProxy) return <><Box /><Box /></>;
+          const primaryValue = (isTask ? selectedEntry?.artifact.class : isMI ? selectedEntry?.artifact.url : selectedEntry?.artifact.package)?.toString();
+          const secondaryValue = (isTask ? selectedEntry?.artifact.group : isMI ? selectedEntry?.artifact.context : selectedEntry?.artifact.name)?.toString();
           return (
-            <Box key={key} component="li" sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }} {...optionProps}>
-              <Chip label={cfg?.label} size="small" sx={{ bgcolor: cfg?.bgColor, color: cfg?.color, fontWeight: 700, fontSize: 11, minWidth: 60, justifyContent: 'center' }} />
-              <Typography variant="body2" sx={{ fontWeight: 500, flex: 1 }}>
-                {displayName}
-              </Typography>
-              {!useMeta && meta && (
-                <Typography variant="body2" color="text.secondary">
-                  {meta}
+            <>
+              <Stack direction="row" alignItems="center" gap={0.75} sx={{ minWidth: 0, alignSelf: 'center' }}>
+                <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
+                  {isTask ? <Layers size={15} /> : isMI ? <LinkIcon size={15} /> : <Package size={15} />}
+                </Box>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {primaryValue ?? '—'}
                 </Typography>
-              )}
-            </Box>
+                {primaryValue ? <CopyButton value={primaryValue} label={primaryLabel} /> : null}
+              </Stack>
+
+              <Stack direction="row" alignItems="center" gap={0.75} sx={{ alignSelf: 'center' }}>
+                <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
+                  <Tag size={15} />
+                </Box>
+                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                  {secondaryValue ?? '—'}
+                </Typography>
+              </Stack>
+            </>
           );
-        }}
-        renderInput={(params) => {
-          const cfg = selectedEntry ? ENTRY_POINT_CONFIG[selectedEntry.type] : undefined;
-          const chipAdornment = cfg ? (
-            <InputAdornment position="start">
-              <Chip label={cfg.label} size="small" sx={{ bgcolor: cfg.bgColor, color: cfg.color, fontWeight: 700, fontSize: 11, minWidth: 60, justifyContent: 'center' }} />
-            </InputAdornment>
-          ) : null;
-          return (
-            <TextField
-              {...params}
-              placeholder="Search entry points..."
-              InputProps={{
-                ...params.InputProps,
-                startAdornment: (
-                  <>
-                    {chipAdornment}
-                    {params.InputProps.startAdornment}
-                  </>
-                ),
-              }}
-            />
-          );
-        }}
-      />
+        })()}
+      </Box>
       {selectedEntry && <EntryPointDetail selected={{ artifact: selectedEntry.artifact, artifactType: selectedEntry.type, envId, componentId, projectId }} onOpenDrawerTab={(tab) => onOpenDrawer(selectedEntry.artifact, selectedEntry.type, envId, tab)} />}
     </>
   );
@@ -646,6 +711,7 @@ export default function Environment({
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [viewMode, setViewMode] = useState<'entryPoints' | 'allArtifacts'>('entryPoints');
   const [settingsPanelOpen, setSettingsPanelOpen] = useState(false);
+  const [currentEntryPoint, setCurrentEntryPoint] = useState<{ artifact: GqlArtifact; type: string } | null>(null);
 
   // MI users state
   const [selectedRuntimeId, setSelectedRuntimeId] = useState('');
@@ -689,16 +755,46 @@ export default function Environment({
   const onlineCount = runtimes.filter((r) => r.status === 'RUNNING').length;
   const totalCount = runtimes.length;
   const isOnline = onlineCount > 0;
+  const showSourceButton = currentEntryPoint ? ['RestApi', 'ProxyService', 'InboundEndpoint', 'Task'].includes(currentEntryPoint.type) : false;
 
   return (
     <Card variant="outlined" sx={{ mb: 3 }}>
       <CardContent>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
-          <Typography variant="h5" component="h2" sx={{ fontWeight: 600, textTransform: 'capitalize' }}>
-            {env.name}
-          </Typography>
-          <Stack direction="row" alignItems="center" gap={1}>
-            {totalCount > 0 && <Chip label={`${onlineCount}/${totalCount} ${isOnline ? 'Online' : 'Offline'}`} size="small" color={isOnline ? 'success' : 'default'} />}
+        <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap">
+          <Stack direction="row" alignItems="center" gap={1.5} sx={{ minWidth: 0 }}>
+            <Typography variant="h5" component="h2" sx={{ fontWeight: 600, textTransform: 'capitalize', flexShrink: 0 }}>
+              {env.name}
+            </Typography>
+            {totalCount > 0 && (
+              <Stack direction="row" alignItems="center" gap={0.75} sx={{ flexShrink: 0 }}>
+                <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: isOnline ? 'success.main' : 'text.disabled', flexShrink: 0 }} />
+                <Typography variant="body2" color="text.secondary">
+                  {`${onlineCount}/${totalCount} Active`}
+                </Typography>
+              </Stack>
+            )}
+          </Stack>
+          <Stack direction="row" alignItems="center" gap={1} sx={{ flexShrink: 0 }}>
+            {currentEntryPoint && showSourceButton && (componentType !== 'MI' || viewMode === 'entryPoints') && (
+              <Button
+                variant="text"
+                size="small"
+                startIcon={<Code size={14} />}
+                onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Source')}
+                sx={{ textTransform: 'none' }}>
+                View Source
+              </Button>
+            )}
+            {currentEntryPoint && (componentType !== 'MI' || viewMode === 'entryPoints') && (
+              <Button
+                variant="text"
+                size="small"
+                startIcon={<Server size={14} />}
+                onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Runtimes')}
+                sx={{ textTransform: 'none' }}>
+                View Runtimes
+              </Button>
+            )}
             <IconButton size="small" onClick={handleRefresh} disabled={isRefreshing} aria-label="Refresh">
               <RefreshCw
                 size={16}
@@ -957,7 +1053,9 @@ export default function Environment({
             </Stack>
           </Stack>
         )}
-        {(componentType !== 'MI' || viewMode === 'entryPoints') && <EntryPointsList envId={env.id} componentId={componentId} projectId={projectId} componentType={componentType} isOnline={isOnline} onOpenDrawer={onOpenDrawerForTab} />}
+        {(componentType !== 'MI' || viewMode === 'entryPoints') && (
+          <EntryPointsList envId={env.id} componentId={componentId} projectId={projectId} componentType={componentType} isOnline={isOnline} onOpenDrawer={onOpenDrawerForTab} onSelectionChange={setCurrentEntryPoint} />
+        )}
         {componentType === 'MI' && viewMode === 'allArtifacts' && <ArtifactTypeSelector envId={env.id} componentId={componentId} onSelectArtifact={onSelectArtifact} />}
       </CardContent>
     </Card>

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -342,109 +342,109 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
         {/* Header row — hidden when this artifact type has no controls (e.g. a BI service) */}
         {hasHeaderControls && (
           <Stack direction="row" alignItems="center" gap={1.5} sx={{ px: 2, py: 1.5 }}>
-          {compositeApp && <Chip label={`Composite App: ${compositeApp}`} size="small" variant="outlined" sx={{ bgcolor: '#e8eaf6', color: '#3949ab', fontSize: 11 }} />}
-          {compositeApp && <Divider orientation="vertical" flexItem />}
-          {showStatusChip && artifactState && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-              <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>
-                Status
-              </Typography>
-              {artifactType === 'Listener' || artifactType === 'RestApi' ? (
-                <Stack direction="row" alignItems="center" gap={0.75}>
-                  <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: toEnabled(artifact.state) ? 'success.main' : 'text.disabled' }} />
-                  <Typography variant="body2">{toEnabled(artifact.state) ? 'Enabled' : 'Disabled'}</Typography>
-                </Stack>
-              ) : (
-                <Chip label={artifactState.charAt(0).toUpperCase() + artifactState.slice(1).toLowerCase()} size="small" variant="outlined" color={toEnabled(artifact.state) ? 'success' : 'default'} sx={{ fontSize: '0.875rem' }} />
-              )}
-            </Box>
-          )}
-          {showStatusChip && artifactState && (showStatusToggle || showTracingToggle || showStatisticsToggle || showListenerToggle) && <Divider orientation="vertical" flexItem />}
-          {showStatusToggle && <SyncSwitch name="status" label="Status" checked={statusEnabled} inSync={artifact.stateInSync as boolean | null} onChange={handleToggleStatus} disabled={updateArtifactStatus.isPending} />}
-          {showStatusToggle && showTracingToggle && <Divider orientation="vertical" flexItem />}
-          {showTracingToggle && <SyncSwitch label="Tracing" checked={tracingEnabled} inSync={artifact.tracingInSync as boolean | null} onChange={handleToggleTracing} disabled={updateTracingStatus.isPending} />}
-          {showTracingToggle && showStatisticsToggle && <Divider orientation="vertical" flexItem />}
-          {showStatisticsToggle && <SyncSwitch label="Statistics" checked={statisticsEnabled} inSync={artifact.statisticsInSync as boolean | null} onChange={handleToggleStatistics} disabled={updateStatisticsStatus.isPending} />}
-          {showListenerToggle && !listenerEnabled && (
-            <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Enable listener'}>
-              <span style={{ marginLeft: 'auto' }}>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  color="success"
-                  startIcon={pendingListenerAction === 'START' ? <CircularProgress size={12} color="inherit" /> : <Play size={14} />}
-                  disabled={pendingListenerAction !== null || !hasRuntimes}
-                  onClick={() => handleToggleListener(true)}>
-                  {pendingListenerAction === 'START' ? 'Enabling…' : 'Enable'}
-                </Button>
-              </span>
-            </Tooltip>
-          )}
-          {showListenerToggle && listenerEnabled && (
-            <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Disable listener'}>
-              <span style={{ marginLeft: 'auto' }}>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  color="error"
-                  startIcon={pendingListenerAction === 'STOP' ? <CircularProgress size={12} color="inherit" /> : <Square size={14} />}
-                  disabled={pendingListenerAction !== null || !hasRuntimes}
-                  onClick={() => handleToggleListener(false)}>
-                  {pendingListenerAction === 'STOP' ? 'Disabling…' : 'Disable'}
-                </Button>
-              </span>
-            </Tooltip>
-          )}
-          {showTaskToggle && (
-            <>
-              {hasPrecedingControls && <Divider orientation="vertical" flexItem />}
-              <SyncSwitch label="Status" checked={statusEnabled} inSync={artifact.stateInSync as boolean | null} onChange={handleToggleStatus} disabled={updateArtifactStatus.isPending || !hasRuntimes} />
-            </>
-          )}
-          {showTaskTrigger && (
-            <>
-              {(hasPrecedingControls || showTaskToggle) && <Divider orientation="vertical" flexItem />}
-              <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Trigger task'}>
-                <Box>
-                  <IconButton size="small" onClick={handleTriggerTask} disabled={triggerTask.isPending || !hasRuntimes} aria-label="Trigger task" sx={{ color: hasRuntimes ? 'primary.main' : 'text.disabled' }}>
-                    <Play size={16} />
-                  </IconButton>
-                </Box>
+            {compositeApp && <Chip label={`Composite App: ${compositeApp}`} size="small" variant="outlined" sx={{ bgcolor: '#e8eaf6', color: '#3949ab', fontSize: 11 }} />}
+            {compositeApp && <Divider orientation="vertical" flexItem />}
+            {showStatusChip && artifactState && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ fontSize: 11 }}>
+                  Status
+                </Typography>
+                {artifactType === 'Listener' || artifactType === 'RestApi' ? (
+                  <Stack direction="row" alignItems="center" gap={0.75}>
+                    <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: toEnabled(artifact.state) ? 'success.main' : 'text.disabled' }} />
+                    <Typography variant="body2">{toEnabled(artifact.state) ? 'Enabled' : 'Disabled'}</Typography>
+                  </Stack>
+                ) : (
+                  <Chip label={artifactState.charAt(0).toUpperCase() + artifactState.slice(1).toLowerCase()} size="small" variant="outlined" color={toEnabled(artifact.state) ? 'success' : 'default'} sx={{ fontSize: '0.875rem' }} />
+                )}
+              </Box>
+            )}
+            {showStatusChip && artifactState && (showStatusToggle || showTracingToggle || showStatisticsToggle || showListenerToggle) && <Divider orientation="vertical" flexItem />}
+            {showStatusToggle && <SyncSwitch name="status" label="Status" checked={statusEnabled} inSync={artifact.stateInSync as boolean | null} onChange={handleToggleStatus} disabled={updateArtifactStatus.isPending} />}
+            {showStatusToggle && showTracingToggle && <Divider orientation="vertical" flexItem />}
+            {showTracingToggle && <SyncSwitch label="Tracing" checked={tracingEnabled} inSync={artifact.tracingInSync as boolean | null} onChange={handleToggleTracing} disabled={updateTracingStatus.isPending} />}
+            {showTracingToggle && showStatisticsToggle && <Divider orientation="vertical" flexItem />}
+            {showStatisticsToggle && <SyncSwitch label="Statistics" checked={statisticsEnabled} inSync={artifact.statisticsInSync as boolean | null} onChange={handleToggleStatistics} disabled={updateStatisticsStatus.isPending} />}
+            {showListenerToggle && !listenerEnabled && (
+              <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Enable listener'}>
+                <span style={{ marginLeft: 'auto' }}>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    color="success"
+                    startIcon={pendingListenerAction === 'START' ? <CircularProgress size={12} color="inherit" /> : <Play size={14} />}
+                    disabled={pendingListenerAction !== null || !hasRuntimes}
+                    onClick={() => handleToggleListener(true)}>
+                    {pendingListenerAction === 'START' ? 'Enabling…' : 'Enable'}
+                  </Button>
+                </span>
               </Tooltip>
-            </>
-          )}
-          {showParametersButton && (
-            <Button variant="contained" size="small" startIcon={<Sliders size={14} />} onClick={() => onOpenDrawerTab('Parameters')} sx={{ ml: 'auto' }}>
-              View Parameters
-            </Button>
-          )}
-          {showWsdlButton && (
-            <Button variant="text" size="small" startIcon={<LinkIcon size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ textTransform: 'none', ml: showParametersButton ? 0 : 'auto' }}>
-              View Endpoints
-            </Button>
-          )}
-          {showWsdlButton && (
-            <Button variant="text" size="small" startIcon={<FileText size={14} />} onClick={() => onOpenDrawerTab('WSDL')} sx={{ textTransform: 'none' }}>
-              View WSDL
-            </Button>
-          )}
-          {showInstancesButton && (
-            <Button
-              variant="contained"
-              size="small"
-              startIcon={<LayoutGrid size={14} />}
-              onClick={() => navigate(`${resourceUrl(scope, 'workflows')}?tab=admin&type=${encodeURIComponent(artifactName)}&env=${encodeURIComponent(envId)}`)}
-              sx={{ ml: showParametersButton || showWsdlButton ? 0 : 'auto' }}>
-              View Instances
-            </Button>
-          )}
-          {showInstancesButton && (
-            <Authorized permissions={[Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
-              <Button variant="contained" size="small" startIcon={<Play size={14} />} onClick={() => setStartWorkflowOpen(true)}>
-                Start Workflow
+            )}
+            {showListenerToggle && listenerEnabled && (
+              <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Disable listener'}>
+                <span style={{ marginLeft: 'auto' }}>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    color="error"
+                    startIcon={pendingListenerAction === 'STOP' ? <CircularProgress size={12} color="inherit" /> : <Square size={14} />}
+                    disabled={pendingListenerAction !== null || !hasRuntimes}
+                    onClick={() => handleToggleListener(false)}>
+                    {pendingListenerAction === 'STOP' ? 'Disabling…' : 'Disable'}
+                  </Button>
+                </span>
+              </Tooltip>
+            )}
+            {showTaskToggle && (
+              <>
+                {hasPrecedingControls && <Divider orientation="vertical" flexItem />}
+                <SyncSwitch label="Status" checked={statusEnabled} inSync={artifact.stateInSync as boolean | null} onChange={handleToggleStatus} disabled={updateArtifactStatus.isPending || !hasRuntimes} />
+              </>
+            )}
+            {showTaskTrigger && (
+              <>
+                {(hasPrecedingControls || showTaskToggle) && <Divider orientation="vertical" flexItem />}
+                <Tooltip title={!hasRuntimes ? 'No runtimes available' : 'Trigger task'}>
+                  <Box>
+                    <IconButton size="small" onClick={handleTriggerTask} disabled={triggerTask.isPending || !hasRuntimes} aria-label="Trigger task" sx={{ color: hasRuntimes ? 'primary.main' : 'text.disabled' }}>
+                      <Play size={16} />
+                    </IconButton>
+                  </Box>
+                </Tooltip>
+              </>
+            )}
+            {showParametersButton && (
+              <Button variant="contained" size="small" startIcon={<Sliders size={14} />} onClick={() => onOpenDrawerTab('Parameters')} sx={{ ml: 'auto' }}>
+                View Parameters
               </Button>
-            </Authorized>
-          )}
+            )}
+            {showWsdlButton && (
+              <Button variant="text" size="small" startIcon={<LinkIcon size={14} />} onClick={() => onOpenDrawerTab('Endpoints')} sx={{ textTransform: 'none', ml: showParametersButton ? 0 : 'auto' }}>
+                View Endpoints
+              </Button>
+            )}
+            {showWsdlButton && (
+              <Button variant="text" size="small" startIcon={<FileText size={14} />} onClick={() => onOpenDrawerTab('WSDL')} sx={{ textTransform: 'none' }}>
+                View WSDL
+              </Button>
+            )}
+            {showInstancesButton && (
+              <Button
+                variant="contained"
+                size="small"
+                startIcon={<LayoutGrid size={14} />}
+                onClick={() => navigate(`${resourceUrl(scope, 'workflows')}?tab=admin&type=${encodeURIComponent(artifactName)}&env=${encodeURIComponent(envId)}`)}
+                sx={{ ml: showParametersButton || showWsdlButton ? 0 : 'auto' }}>
+                View Instances
+              </Button>
+            )}
+            {showInstancesButton && (
+              <Authorized permissions={[Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
+                <Button variant="contained" size="small" startIcon={<Play size={14} />} onClick={() => setStartWorkflowOpen(true)}>
+                  Start Workflow
+                </Button>
+              </Authorized>
+            )}
           </Stack>
         )}
         {/* Overview columns */}
@@ -489,7 +489,11 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
         {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Resources') && (
           <Box sx={{ px: 2, pt: artifactType === 'Service' ? 0 : 1.5, pb: 1.5 }}>{artifactType === 'RestApi' ? <ArtifactApiDefinition {...tabProps} /> : <ServiceResources {...tabProps} />}</Box>
         )}
-        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Listeners') && <Box sx={{ px: 2, py: 1.5 }}><ServiceListeners {...tabProps} /></Box>}
+        {(ENTRY_POINT_DETAIL_TABS[artifactType] ?? []).includes('Listeners') && (
+          <Box sx={{ px: 2, py: 1.5 }}>
+            <ServiceListeners {...tabProps} />
+          </Box>
+        )}
         {artifactType === 'ProxyService' && (
           <Box sx={{ px: 2, py: 1.5 }}>
             <ProxyApiReference {...tabProps} />
@@ -558,11 +562,7 @@ function EntryPointsList({
     () =>
       isMI
         ? [...apis.map((a) => ({ artifact: a, type: 'RestApi' })), ...proxies.map((a) => ({ artifact: a, type: 'ProxyService' })), ...inboundEps.map((a) => ({ artifact: a, type: 'InboundEndpoint' })), ...tasks.map((a) => ({ artifact: a, type: 'Task' }))]
-        : [
-            ...services.map((a) => ({ artifact: a, type: 'Service' })),
-            ...workflows.map((a) => ({ artifact: a, type: 'Workflow' })),
-            ...automations.map((a) => ({ artifact: a, type: 'Automation' })),
-          ],
+        : [...services.map((a) => ({ artifact: a, type: 'Service' })), ...workflows.map((a) => ({ artifact: a, type: 'Workflow' })), ...automations.map((a) => ({ artifact: a, type: 'Automation' }))],
     [isMI, apis, proxies, inboundEps, tasks, services, workflows, automations],
   );
 
@@ -633,14 +633,14 @@ function EntryPointsList({
             const entry = allEntryPoints.find(({ artifact: a, type }) => `${type}::${type === 'Automation' ? a.packageName : a.name}` === val);
             if (!entry) return '';
             const cfg = ENTRY_POINT_CONFIG[entry.type];
-            const raw = (cfg?.primaryDisplay && cfg.metaField ? entry.artifact[cfg.metaField]?.toString() ?? entry.artifact.name?.toString() : entry.type === 'Automation' ? entry.artifact.packageName?.toString() : entry.artifact.name?.toString()) ?? '';
+            const raw = (cfg?.primaryDisplay && cfg.metaField ? (entry.artifact[cfg.metaField]?.toString() ?? entry.artifact.name?.toString()) : entry.type === 'Automation' ? entry.artifact.packageName?.toString() : entry.artifact.name?.toString()) ?? '';
             // Chip is intentionally omitted here (closed box) — it would eat into the fixed-width
             // box's space and truncate long names. It only shows in the open dropdown list below.
             return raw.replace(/^\//, '');
           }}>
           {allEntryPoints.map(({ artifact: a, type }) => {
             const cfg = ENTRY_POINT_CONFIG[type];
-            const rawLabel = (cfg?.primaryDisplay && cfg.metaField ? a[cfg.metaField]?.toString() ?? a.name?.toString() : type === 'Automation' ? a.packageName?.toString() : a.name?.toString()) ?? '';
+            const rawLabel = (cfg?.primaryDisplay && cfg.metaField ? (a[cfg.metaField]?.toString() ?? a.name?.toString()) : type === 'Automation' ? a.packageName?.toString() : a.name?.toString()) ?? '';
             const label = rawLabel.replace(/^\//, '');
             const key = `${type}::${type === 'Automation' ? a.packageName : a.name}`;
             return (
@@ -659,7 +659,13 @@ function EntryPointsList({
         </Select>
 
         {(() => {
-          if (isProxy) return <><Box /><Box /></>;
+          if (isProxy)
+            return (
+              <>
+                <Box />
+                <Box />
+              </>
+            );
           const primaryValue = (isTask ? selectedEntry?.artifact.class : isMI ? selectedEntry?.artifact.url : selectedEntry?.artifact.package)?.toString();
           const secondaryValue = (isTask ? selectedEntry?.artifact.group : isMI ? selectedEntry?.artifact.context : selectedEntry?.artifact.name)?.toString();
           return (
@@ -776,22 +782,12 @@ export default function Environment({
           </Stack>
           <Stack direction="row" alignItems="center" gap={1} sx={{ flexShrink: 0 }}>
             {currentEntryPoint && showSourceButton && (componentType !== 'MI' || viewMode === 'entryPoints') && (
-              <Button
-                variant="text"
-                size="small"
-                startIcon={<Code size={14} />}
-                onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Source')}
-                sx={{ textTransform: 'none' }}>
+              <Button variant="text" size="small" startIcon={<Code size={14} />} onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Source')} sx={{ textTransform: 'none' }}>
                 View Source
               </Button>
             )}
             {currentEntryPoint && (componentType !== 'MI' || viewMode === 'entryPoints') && (
-              <Button
-                variant="text"
-                size="small"
-                startIcon={<Server size={14} />}
-                onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Runtimes')}
-                sx={{ textTransform: 'none' }}>
+              <Button variant="text" size="small" startIcon={<Server size={14} />} onClick={() => onOpenDrawerForTab(currentEntryPoint.artifact, currentEntryPoint.type, env.id, 'Runtimes')} sx={{ textTransform: 'none' }}>
                 View Runtimes
               </Button>
             )}

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -84,11 +84,14 @@ function CopyButton({ value, label }: { value: string; label: string }) {
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(resetTimer.current), []);
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      clearTimeout(resetTimer.current);
-      resetTimer.current = setTimeout(() => setCopied(false), 2000);
-    });
+    void navigator.clipboard
+      ?.writeText(value)
+      .then(() => {
+        setCopied(true);
+        clearTimeout(resetTimer.current);
+        resetTimer.current = setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => setCopied(false));
   }, [value]);
   return (
     <Tooltip title={copied ? 'Copied!' : `Copy ${label}`}>
@@ -628,6 +631,7 @@ function EntryPointsList({
           size="small"
           value={activeKey}
           onChange={(e) => setSelectedKey(e.target.value)}
+          inputProps={{ 'aria-label': 'Endpoint' }}
           sx={{ fontSize: '13px', width: '100%' }}
           renderValue={(val) => {
             const entry = allEntryPoints.find(({ artifact: a, type }) => `${type}::${type === 'Automation' ? a.packageName : a.name}` === val);

--- a/frontend/src/components/artifact-config.tsx
+++ b/frontend/src/components/artifact-config.tsx
@@ -74,11 +74,11 @@ export const ARTIFACT_TABS: Record<string, string[]> = {
 export const DEFAULT_ARTIFACT_TABS = ['Source', 'Runtimes'];
 
 export const ENTRY_POINT_CONFIG: Record<string, { label: string; detailLabel: string; color: string; bgColor: string; metaField?: string; primaryDisplay?: boolean; overviewFields?: string }> = {
-  RestApi: { label: 'API', detailLabel: 'REST API', color: '#1565c0', bgColor: '#e3f2fd', metaField: 'context', overviewFields: 'context, url' },
+  RestApi: { label: 'API', detailLabel: 'REST API', color: '#1565c0', bgColor: '#e3f2fd', metaField: 'context' },
   ProxyService: { label: 'Proxy', detailLabel: 'PROXY SERVICE', color: '#e65100', bgColor: '#fff3e0' },
   InboundEndpoint: { label: 'Inbound', detailLabel: 'INBOUND ENDPOINT', color: '#2e7d32', bgColor: '#e8f5e9', metaField: 'protocol', overviewFields: 'protocol, sequence, onError' },
-  Task: { label: 'Task', detailLabel: 'TASK', color: '#00695c', bgColor: '#e0f2f1', overviewFields: 'group, class' },
-  Service: { label: 'Service', detailLabel: 'SERVICE', color: '#4a148c', bgColor: '#f3e5f5', metaField: 'basePath', primaryDisplay: true, overviewFields: 'package, basePath, type' },
+  Task: { label: 'Task', detailLabel: 'TASK', color: '#00695c', bgColor: '#e0f2f1' },
+  Service: { label: 'Service', detailLabel: 'SERVICE', color: '#4a148c', bgColor: '#f3e5f5', metaField: 'basePath', primaryDisplay: true, overviewFields: 'package, type' },
   Listener: { label: 'Listener', detailLabel: 'LISTENER', color: '#bf360c', bgColor: '#fbe9e7', metaField: 'port', primaryDisplay: true, overviewFields: 'package, protocol, host, port' },
   Automation: { label: 'Automation', detailLabel: 'AUTOMATION', color: '#f57c00', bgColor: '#fff3e0', metaField: 'packageVersion', overviewFields: 'packageOrg, packageName, packageVersion' },
   Workflow: { label: 'Workflow', detailLabel: 'WORKFLOW', color: '#00838f', bgColor: '#e0f7fa', overviewFields: 'state, workerCount' },
@@ -89,7 +89,7 @@ export const ENTRY_POINT_DETAIL_TABS: Record<string, string[]> = {
   ProxyService: ['Overview', 'Runtimes'],
   InboundEndpoint: ['Overview', 'Runtimes'],
   Task: ['Runtimes'],
-  Service: ['Overview', 'Resources', 'Runtimes'],
+  Service: ['Overview', 'Resources', 'Listeners', 'Runtimes'],
   Listener: ['Overview', 'Runtimes'],
   Workflow: ['Overview', 'Runtimes'],
 };

--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -684,6 +684,7 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns string?|error
 isolated function insertRuntimeArtifacts(string runtimeId, types:Heartbeat heartbeat) returns error? {
     // Delete existing BI services and resources for this runtime before inserting
     _ = check dbClient->execute(`DELETE FROM bi_service_resource_artifacts WHERE runtime_id = ${runtimeId}`);
+    _ = check dbClient->execute(`DELETE FROM bi_service_listener_bindings WHERE runtime_id = ${runtimeId}`);
     _ = check dbClient->execute(`DELETE FROM bi_service_artifacts WHERE runtime_id = ${runtimeId}`);
 
     // Insert services
@@ -697,6 +698,24 @@ isolated function insertRuntimeArtifacts(string runtimeId, types:Heartbeat heart
                 ${serviceDetail.state}
             )
         `);
+
+        // Persist which listener(s) this service is attached to (dedup by name).
+        // The heartbeat sends serviceDetail.listeners as name-only entries; we key
+        // them to bi_runtime_listener_artifacts by (runtime_id, listener_name).
+        string[] boundListenerNames = [];
+        foreach types:Listener boundListener in serviceDetail.listeners {
+            if boundListenerNames.indexOf(boundListener.name) is () {
+                boundListenerNames.push(boundListener.name);
+                _ = check dbClient->execute(`
+                    INSERT INTO bi_service_listener_bindings (
+                        runtime_id, service_name, service_package, listener_name
+                    ) VALUES (
+                        ${runtimeId}, ${serviceDetail.name},
+                        ${serviceDetail.package}, ${boundListener.name}
+                    )
+                `);
+            }
+        }
 
         // Group resources by URL and merge methods to handle duplicates
         map<string[]> resourcesByUrl = {};

--- a/icp_server/modules/storage/runtime_repository.bal
+++ b/icp_server/modules/storage/runtime_repository.bal
@@ -983,6 +983,23 @@ public isolated function mapToService(types:ServiceRecordInDB serviceRecord, str
             resourceList.push(resourceItem);
         };
 
+    // Fetch the listener(s) this service is attached to, enriched with full listener
+    // detail. Column list mirrors getListenersForRuntime so rows map into types:Listener.
+    types:Listener[] serviceListeners = [];
+    stream<types:Listener, sql:Error?> boundListenerStream = dbClient->query(`
+        SELECT l.listener_name, l.listener_package, l.protocol, l.state, l.listener_host, l.listener_port
+        FROM bi_service_listener_bindings b
+        JOIN bi_runtime_listener_artifacts l
+            ON l.runtime_id = b.runtime_id AND l.listener_name = b.listener_name
+        WHERE b.runtime_id = ${runtimeId}
+            AND b.service_name = ${serviceName}
+            AND b.service_package = ${serviceRecord.service_package}
+    `);
+    check from types:Listener boundListener in boundListenerStream
+        do {
+            serviceListeners.push(boundListener);
+        };
+
     return {
         name: serviceRecord.service_name,
         package: serviceRecord.service_package,
@@ -990,7 +1007,7 @@ public isolated function mapToService(types:ServiceRecordInDB serviceRecord, str
         state: "enabled", // Default state
         'type: "API", // Default type
         resources: resourceList,
-        listeners: [] // Empty listeners array
+        listeners: serviceListeners
     };
 }
 

--- a/icp_server/resources/db/init-scripts/h2_init.sql
+++ b/icp_server/resources/db/init-scripts/h2_init.sql
@@ -815,6 +815,23 @@ CREATE INDEX idx_bi_runtime_listener_artifacts_protocol ON bi_runtime_listener_a
 
 CREATE INDEX idx_bi_runtime_listener_artifacts_state ON bi_runtime_listener_artifacts (state);
 
+-- Service-to-listener bindings: which listener(s) each service is attached to.
+-- Populated from heartbeat.artifacts.services[].listeners (name-only) and keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name).
+CREATE TABLE bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package);
+
+CREATE INDEX idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name);
+
 -- Automation artifacts (main function) for BI integrations
 CREATE TABLE bi_automation_artifacts (
     runtime_id CHAR(36) NOT NULL,

--- a/icp_server/resources/db/init-scripts/mssql_init.sql
+++ b/icp_server/resources/db/init-scripts/mssql_init.sql
@@ -1089,6 +1089,24 @@ END;
 GO
 
 -- Listeners bound to a runtime (e.g., HTTP/HTTPS)
+CREATE TABLE bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name NVARCHAR (100) NOT NULL,
+    service_package NVARCHAR (200) NOT NULL,
+    listener_name NVARCHAR (100) NOT NULL,
+    created_at DATETIME2 NOT NULL DEFAULT GETDATE (),
+    PRIMARY KEY (
+        runtime_id,
+        service_name,
+        service_package,
+        listener_name
+    ),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE,
+    INDEX idx_slb_service (runtime_id, service_name, service_package),
+    INDEX idx_slb_listener (runtime_id, listener_name)
+);
+GO
+
 CREATE TABLE bi_runtime_listener_artifacts (
     runtime_id CHAR(36) NOT NULL,
     listener_name NVARCHAR (100) NOT NULL,

--- a/icp_server/resources/db/init-scripts/mysql_init.sql
+++ b/icp_server/resources/db/init-scripts/mysql_init.sql
@@ -639,6 +639,22 @@ CREATE TABLE bi_runtime_listener_artifacts (
     INDEX idx_state (state)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 
+-- Service-to-listener bindings: which listener(s) each service is attached to.
+-- Populated from heartbeat.artifacts.services[].listeners (name-only) and keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+CREATE TABLE bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE,
+    INDEX idx_slb_service (runtime_id, service_name, service_package),
+    INDEX idx_slb_listener (runtime_id, listener_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
 -- Automation artifacts (main function) for BI integrations
 CREATE TABLE bi_automation_artifacts (
     runtime_id CHAR(36) NOT NULL,

--- a/icp_server/resources/db/init-scripts/oracle_init.sql
+++ b/icp_server/resources/db/init-scripts/oracle_init.sql
@@ -768,6 +768,18 @@ END;
 /
 
 -- Listeners bound to a runtime (e.g., HTTP/HTTPS)
+CREATE TABLE bi_service_listener_bindings (
+  runtime_id       CHAR(36) NOT NULL,
+  service_name     VARCHAR2(100 CHAR) NOT NULL,
+  service_package  VARCHAR2(200 CHAR) NOT NULL,
+  listener_name    VARCHAR2(100 CHAR) NOT NULL,
+  created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+  CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package);
+CREATE INDEX idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name);
+
 CREATE TABLE bi_runtime_listener_artifacts (
     runtime_id CHAR(36) NOT NULL,
     listener_name VARCHAR2(100 CHAR) NOT NULL,

--- a/icp_server/resources/db/init-scripts/postgresql_init.sql
+++ b/icp_server/resources/db/init-scripts/postgresql_init.sql
@@ -668,6 +668,18 @@ CREATE TRIGGER update_bi_service_resource_artifacts_updated_at BEFORE UPDATE ON 
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- Listeners bound to a runtime (e.g., HTTP/HTTPS)
+CREATE TABLE bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes(runtime_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_slb_service ON bi_service_listener_bindings(runtime_id, service_name, service_package);
+CREATE INDEX idx_slb_listener ON bi_service_listener_bindings(runtime_id, listener_name);
+
 CREATE TABLE bi_runtime_listener_artifacts (
     runtime_id CHAR(36) NOT NULL,
     listener_name VARCHAR(100) NOT NULL,

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_h2.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_h2.sql
@@ -1,0 +1,21 @@
+-- Migration: service-to-listener bindings (H2)
+-- Adds the bi_service_listener_bindings table, which records which listener(s)
+-- each service is attached to. The binding arrives in the runtime heartbeat
+-- (heartbeat.artifacts.services[].listeners) and is keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+-- Idempotent - safe to re-run. Fresh installs get this from h2_init.sql.
+-- Run once against the main ICP DB.
+
+CREATE TABLE IF NOT EXISTS bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package);
+CREATE INDEX IF NOT EXISTS idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name);

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_mssql.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_mssql.sql
@@ -1,0 +1,22 @@
+-- Migration: service-to-listener bindings (Microsoft SQL Server)
+-- Adds the bi_service_listener_bindings table, which records which listener(s)
+-- each service is attached to. The binding arrives in the runtime heartbeat
+-- (heartbeat.artifacts.services[].listeners) and is keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+-- Idempotent - safe to re-run. Fresh installs get this from mssql_init.sql.
+-- Run once against the main ICP DB.
+
+IF OBJECT_ID('bi_service_listener_bindings', 'U') IS NULL
+CREATE TABLE bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name NVARCHAR (100) NOT NULL,
+    service_package NVARCHAR (200) NOT NULL,
+    listener_name NVARCHAR (100) NOT NULL,
+    created_at DATETIME2 NOT NULL DEFAULT GETDATE (),
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE,
+    INDEX idx_slb_service (runtime_id, service_name, service_package),
+    INDEX idx_slb_listener (runtime_id, listener_name)
+);
+GO

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_mysql.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_mysql.sql
@@ -1,0 +1,20 @@
+-- Migration: service-to-listener bindings (MySQL / MariaDB)
+-- Adds the bi_service_listener_bindings table, which records which listener(s)
+-- each service is attached to. The binding arrives in the runtime heartbeat
+-- (heartbeat.artifacts.services[].listeners) and is keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+-- Idempotent - safe to re-run. Fresh installs get this from mysql_init.sql.
+-- Run once against the main ICP DB.
+
+CREATE TABLE IF NOT EXISTS bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE,
+    INDEX idx_slb_service (runtime_id, service_name, service_package),
+    INDEX idx_slb_listener (runtime_id, listener_name)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_oracle.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_oracle.sql
@@ -1,0 +1,47 @@
+-- Migration: service-to-listener bindings (Oracle 19c+)
+-- Adds the bi_service_listener_bindings table, which records which listener(s)
+-- each service is attached to. The binding arrives in the runtime heartbeat
+-- (heartbeat.artifacts.services[].listeners) and is keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+-- Idempotent - safe to re-run. Fresh installs get this from oracle_init.sql.
+-- Run once against the main ICP DB (as the ICP schema owner).
+-- (ORA-00955 = name already used by an existing object; ignored for idempotency.)
+
+DECLARE
+    e_exists EXCEPTION;
+    PRAGMA EXCEPTION_INIT(e_exists, -955);
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE TABLE bi_service_listener_bindings (
+        runtime_id CHAR(36) NOT NULL,
+        service_name VARCHAR2(100 CHAR) NOT NULL,
+        service_package VARCHAR2(200 CHAR) NOT NULL,
+        listener_name VARCHAR2(100 CHAR) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+        CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+    )';
+EXCEPTION
+    WHEN e_exists THEN NULL;
+END;
+/
+
+DECLARE
+    e_exists EXCEPTION;
+    PRAGMA EXCEPTION_INIT(e_exists, -955);
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package)';
+EXCEPTION
+    WHEN e_exists THEN NULL;
+END;
+/
+
+DECLARE
+    e_exists EXCEPTION;
+    PRAGMA EXCEPTION_INIT(e_exists, -955);
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name)';
+EXCEPTION
+    WHEN e_exists THEN NULL;
+END;
+/

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_oracle.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_oracle.sql
@@ -6,42 +6,45 @@
 -- a service may bind multiple listeners; a listener may serve multiple services.
 -- Idempotent - safe to re-run. Fresh installs get this from oracle_init.sql.
 -- Run once against the main ICP DB (as the ICP schema owner).
--- (ORA-00955 = name already used by an existing object; ignored for idempotency.)
+--
+-- Idempotency checks the specific expected object in the data dictionary before
+-- creating it. A name collision with a DIFFERENT object type is NOT swallowed:
+-- the CREATE then raises ORA-00955 so incompatible schema state surfaces.
 
 DECLARE
-    e_exists EXCEPTION;
-    PRAGMA EXCEPTION_INIT(e_exists, -955);
+    v_exists NUMBER;
 BEGIN
-    EXECUTE IMMEDIATE 'CREATE TABLE bi_service_listener_bindings (
-        runtime_id CHAR(36) NOT NULL,
-        service_name VARCHAR2(100 CHAR) NOT NULL,
-        service_package VARCHAR2(200 CHAR) NOT NULL,
-        listener_name VARCHAR2(100 CHAR) NOT NULL,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-        PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
-        CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
-    )';
-EXCEPTION
-    WHEN e_exists THEN NULL;
+    SELECT COUNT(*) INTO v_exists FROM user_tables WHERE table_name = 'BI_SERVICE_LISTENER_BINDINGS';
+    IF v_exists = 0 THEN
+        EXECUTE IMMEDIATE 'CREATE TABLE bi_service_listener_bindings (
+            runtime_id CHAR(36) NOT NULL,
+            service_name VARCHAR2(100 CHAR) NOT NULL,
+            service_package VARCHAR2(200 CHAR) NOT NULL,
+            listener_name VARCHAR2(100 CHAR) NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+            CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+        )';
+    END IF;
 END;
 /
 
 DECLARE
-    e_exists EXCEPTION;
-    PRAGMA EXCEPTION_INIT(e_exists, -955);
+    v_exists NUMBER;
 BEGIN
-    EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package)';
-EXCEPTION
-    WHEN e_exists THEN NULL;
+    SELECT COUNT(*) INTO v_exists FROM user_indexes WHERE index_name = 'IDX_SLB_SERVICE';
+    IF v_exists = 0 THEN
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package)';
+    END IF;
 END;
 /
 
 DECLARE
-    e_exists EXCEPTION;
-    PRAGMA EXCEPTION_INIT(e_exists, -955);
+    v_exists NUMBER;
 BEGIN
-    EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name)';
-EXCEPTION
-    WHEN e_exists THEN NULL;
+    SELECT COUNT(*) INTO v_exists FROM user_indexes WHERE index_name = 'IDX_SLB_LISTENER';
+    IF v_exists = 0 THEN
+        EXECUTE IMMEDIATE 'CREATE INDEX idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name)';
+    END IF;
 END;
 /

--- a/icp_server/resources/db/migration-scripts/add_service_listener_bindings_postgresql.sql
+++ b/icp_server/resources/db/migration-scripts/add_service_listener_bindings_postgresql.sql
@@ -1,0 +1,21 @@
+-- Migration: service-to-listener bindings (PostgreSQL)
+-- Adds the bi_service_listener_bindings table, which records which listener(s)
+-- each service is attached to. The binding arrives in the runtime heartbeat
+-- (heartbeat.artifacts.services[].listeners) and is keyed to
+-- bi_runtime_listener_artifacts by (runtime_id, listener_name). Many-to-many:
+-- a service may bind multiple listeners; a listener may serve multiple services.
+-- Idempotent - safe to re-run. Fresh installs get this from postgresql_init.sql.
+-- Run once against the main ICP DB.
+
+CREATE TABLE IF NOT EXISTS bi_service_listener_bindings (
+    runtime_id CHAR(36) NOT NULL,
+    service_name VARCHAR(100) NOT NULL,
+    service_package VARCHAR(200) NOT NULL,
+    listener_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (runtime_id, service_name, service_package, listener_name),
+    CONSTRAINT fk_bi_slb_runtime FOREIGN KEY (runtime_id) REFERENCES runtimes (runtime_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_slb_service ON bi_service_listener_bindings (runtime_id, service_name, service_package);
+CREATE INDEX IF NOT EXISTS idx_slb_listener ON bi_service_listener_bindings (runtime_id, listener_name);

--- a/icp_server/schema_graphql.graphql
+++ b/icp_server/schema_graphql.graphql
@@ -290,6 +290,7 @@ type Service {
   basePath: String!
   state: ArtifactState!
   resources: [Resource!]!
+  listeners: [Listener!]!
   runtimes: [ArtifactRuntimeInfo]
 }
 

--- a/icp_server/schema_graphql.graphql
+++ b/icp_server/schema_graphql.graphql
@@ -301,6 +301,8 @@ type Listener {
   name: String!
   package: String!
   protocol: String!
+  host: String
+  port: Int
   state: ArtifactState!
   runtimes: [ArtifactRuntimeInfo]
 }

--- a/icp_server/tests/heartbeat_tests.bal
+++ b/icp_server/tests/heartbeat_tests.bal
@@ -35,6 +35,9 @@ const string HB_REPLICA3_ID = "aa000001-test-test-test-000000000003";
 const string HB_RESTART_OLD_ID = "aa000001-test-test-test-000000000007";
 const string HB_RESTART_NEW_ID = "aa000001-test-test-test-000000000008";
 const string HB_RESTART_NAME = "hb-restart-test-unique-runtime";
+// Service-listener binding test: dedicated ID cleaned up via an AfterGroups
+// teardown so rows never leak when an assertion aborts the test.
+const string HB_SERVICE_LISTENER_ID = "aa000001-test-test-test-000000000010";
 
 // =============================================================================
 // Helpers
@@ -92,7 +95,7 @@ function cleanupRuntime(string runtimeId) {
     groups: ["heartbeat", "service-listener"]
 }
 function testServiceListenerBindingRoundTrip() returns error? {
-    string runtimeId = "aa000001-test-test-test-000000000010";
+    string runtimeId = HB_SERVICE_LISTENER_ID;
     cleanupRuntime(runtimeId);
 
     types:Heartbeat heartbeat = buildHeartbeat(runtimeId, "hb-service-listener-runtime");
@@ -137,8 +140,14 @@ function testServiceListenerBindingRoundTrip() returns error? {
         test:assertEquals(svc.listeners[0].port, 8080,
                 string `Service ${svc.name} listener should carry the enriched port`);
     }
+    // Cleanup is handled by afterServiceListenerTests (runs even if an assert aborts).
+}
 
-    cleanupRuntime(runtimeId);
+@test:AfterGroups {
+    value: ["service-listener"]
+}
+function afterServiceListenerTests() {
+    cleanupRuntime(HB_SERVICE_LISTENER_ID);
 }
 
 // =============================================================================

--- a/icp_server/tests/heartbeat_tests.bal
+++ b/icp_server/tests/heartbeat_tests.bal
@@ -92,7 +92,7 @@ function cleanupRuntime(string runtimeId) {
     groups: ["heartbeat", "service-listener"]
 }
 function testServiceListenerBindingRoundTrip() returns error? {
-    string runtimeId = "aa000001-test-test-test-000000000009";
+    string runtimeId = "aa000001-test-test-test-000000000010";
     cleanupRuntime(runtimeId);
 
     types:Heartbeat heartbeat = buildHeartbeat(runtimeId, "hb-service-listener-runtime");

--- a/icp_server/tests/heartbeat_tests.bal
+++ b/icp_server/tests/heartbeat_tests.bal
@@ -80,6 +80,68 @@ function cleanupRuntime(string runtimeId) {
 }
 
 // =============================================================================
+// Test: service -> listener binding round-trips through the heartbeat.
+//
+// A BI heartbeat reports each service with the listener(s) it is attached to
+// (serviceDetail.listeners). This must be persisted and returned by
+// getServicesForRuntime, enriched with the listener's full detail (port, etc.).
+// Covers the many-to-many case the team lead called out: two services attached
+// to the SAME listener must both report it.
+// =============================================================================
+@test:Config {
+    groups: ["heartbeat", "service-listener"]
+}
+function testServiceListenerBindingRoundTrip() returns error? {
+    string runtimeId = "aa000001-test-test-test-000000000009";
+    cleanupRuntime(runtimeId);
+
+    types:Heartbeat heartbeat = buildHeartbeat(runtimeId, "hb-service-listener-runtime");
+    heartbeat.artifacts = {
+        listeners: [
+            {name: "httpListenerA", package: "app", protocol: "HTTP", host: "0.0.0.0", port: 8080, state: "enabled"},
+            {name: "httpListenerB", package: "app", protocol: "HTTP", host: "0.0.0.0", port: 8081, state: "enabled"}
+        ],
+        services: [
+            {
+                name: "orderService",
+                package: "app",
+                basePath: "/orders",
+                'type: "API",
+                resources: [],
+                // heartbeat sends listeners name-only (as the runtime bridge does)
+                listeners: [{name: "httpListenerA"}]
+            },
+            {
+                name: "inventoryService",
+                package: "app",
+                basePath: "/inventory",
+                'type: "API",
+                resources: [],
+                listeners: [{name: "httpListenerA"}] // same listener -> many-to-one
+            }
+        ]
+    };
+
+    types:HeartbeatResponse resp = check storage:processHeartbeat(heartbeat, preResolved = true);
+    test:assertTrue(resp.acknowledged, "Heartbeat should be acknowledged");
+
+    types:Service[] services = check storage:getServicesForRuntime(runtimeId);
+    test:assertEquals(services.length(), 2, "Both services should be stored");
+
+    foreach types:Service svc in services {
+        test:assertEquals(svc.listeners.length(), 1,
+                string `Service ${svc.name} should have exactly one bound listener`);
+        test:assertEquals(svc.listeners[0].name, "httpListenerA",
+                string `Service ${svc.name} should be bound to httpListenerA`);
+        // Enriched from the listener table, not just the name sent by the heartbeat.
+        test:assertEquals(svc.listeners[0].port, 8080,
+                string `Service ${svc.name} listener should carry the enriched port`);
+    }
+
+    cleanupRuntime(runtimeId);
+}
+
+// =============================================================================
 // Test 1: multi-replica null names — replicas must not delete each other
 //
 // Regression test for: https://github.com/wso2/product-integrator/issues/1780


### PR DESCRIPTION
### UI
- Devant-style entry-point selector with a metadata grid
- MI View Source / View Runtimes moved to the header, resources shown as method-badge rows
- New Service "Listeners" tab (enable/disable + details drawer)

### Backend - service→listener bindings
- New bi_service_listener_bindings table (H2 + MySQL init + migration)
- Persist bindings on heartbeat, expose listeners on the Service GraphQL type.