### PR TITLE
Gate workflow features on management API reachability

### DIFF
--- a/icp_server/workflow_proxy_service.bal
+++ b/icp_server/workflow_proxy_service.bal
@@ -116,7 +116,8 @@ isolated function resolveWorkflowApiKey(string? keyId) returns string? {
 
 // Fetches workflow definitions live from the runtime's GET /workflow/definitions API for the
 // given component+environment and maps them to the Workflow artifact shape used by the frontend.
-// Returns [] when no running runtime advertises a workflow callback URL. Used by the GraphQL
+// Returns [] when no running runtime advertises a workflow callback URL, or when the runtime's
+// workflow management API is not reachable (see below). Used by the GraphQL
 // `workflowsByEnvironmentAndComponent` resolver (definitions are no longer carried in heartbeats).
 isolated function fetchWorkflowDefinitions(string componentId, string environmentId) returns types:Workflow[]|error {
     types:WorkflowTarget?|error target = storage:getRuntimeWorkflowTarget(componentId, environmentId);
@@ -133,7 +134,17 @@ isolated function fetchWorkflowDefinitions(string componentId, string environmen
         headers["X-API-Key"] = apiKey;
     }
     http:Client wfClient = check getWorkflowClient(target.callbackUrl);
-    http:Response resp = check wfClient->get("/workflow/definitions", headers);
+    // The runtime now always reports a callbackUrl, so its presence no longer indicates that workflow
+    // management is enabled — reachability does. The management API listener only runs when the runtime
+    // sets `[ballerina.workflow.management] enableManagementApi = true`; otherwise this call fails at the
+    // connection level. Treat that as "no workflows" so the feature is hidden gracefully rather than
+    // surfacing an error. (A reachable-but-erroring API still returns a non-200 error below.)
+    http:Response|error resp = wfClient->get("/workflow/definitions", headers);
+    if resp is error {
+        log:printDebug("Workflow management API not reachable; treating component as having no workflows",
+                componentId = componentId, environmentId = environmentId, callbackUrl = target.callbackUrl, 'error = resp);
+        return [];
+    }
     if resp.statusCode != 200 {
         // Keep the upstream payload out of the client-facing error; log it for diagnosis.
         json|error errBody = resp.getJsonPayload();
@@ -266,15 +277,20 @@ function proxyWorkflowRequest(string componentId, string environmentId, string[]
         req.setHeader("X-API-Key", apiKey);
     }
 
-    // 6. Forward (method + body preserved) and relay the upstream response.
+    // 6. Forward (method + body preserved) and relay the upstream response. A connection-level
+    //    failure means the runtime's workflow management API isn't running (it starts only when the
+    //    runtime sets `[ballerina.workflow.management] enableManagementApi = true`). The runtime now
+    //    always reports a callbackUrl, so reachability — not its presence — tells us the feature is on.
+    //    Surface that as 503 (same as "no workflow runtime"), which the frontend treats as the feature
+    //    being unavailable, rather than 502 which reads as an upstream fault.
     http:Client|error wfClient = getWorkflowClient(target.callbackUrl);
     if wfClient is error {
-        return workflowErrorResponse(502, "Failed to connect to workflow runtime: " + wfClient.message());
+        return workflowErrorResponse(503, "Workflow management is not available for this environment");
     }
     http:Response|error upstream = wfClient->forward(targetPath, req);
     if upstream is error {
-        log:printError("Workflow proxy forward failed", upstream, targetPath = targetPath);
-        return workflowErrorResponse(502, "Workflow runtime request failed: " + upstream.message());
+        log:printDebug("Workflow management API not reachable; forward failed", targetPath = targetPath, 'error = upstream);
+        return workflowErrorResponse(503, "Workflow management is not available for this environment");
     }
     return upstream;
 }


### PR DESCRIPTION
## Purpose

The runtime bridge now **always** reports a `workflowCallbackUrl`, so its presence can no longer be used to decide whether a runtime offers workflow management. The workflow management API listener only runs when the runtime enables it:

```toml
[ballerina.workflow.management]
enableManagementApi = true
```

This changes ICP to gate the workflow features on the management API actually being **reachable**, rather than on the callback URL being non-empty.

## Approach

Lazy graceful degradation — reachability is determined at the point we already call the runtime's management API, so a connection-level failure (listener not running) means the feature is off:

- **`fetchWorkflowDefinitions`** (drives the per-component Workflow entry point via GraphQL `workflowsByEnvironmentAndComponent`): on a connection failure, return `[]` instead of erroring, so the Workflow entry point is hidden gracefully — matching the previous empty-`callbackUrl` behavior. A *reachable* API that returns a non-200 still surfaces its error (that's a real misconfiguration, not "disabled").
- **`proxyWorkflowRequest`** (`/icp/workflow` proxy for human tasks, instances, lifecycle, execution graph): on a connection failure, return **503** ("Workflow management is not available for this environment") instead of 502, which the frontend renders as a clean "not available" state.

Net effect: reachability, not the mere presence of `callback_url`, now gates every workflow surface — consistent whether a runtime never had the feature or has it turned off.

## Notes

- Each check is a live call, so it's always current. If a runtime *host* is unreachable in a way that hangs (firewall drop rather than a refused connection), the call waits up to the workflow proxy timeout before falling back; a normal "API disabled but host up" case is a refused connection and fails immediately.
- No DB or frontend changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
