### PR TITLE
Advertise supported optional heartbeat fields to bridges

### DIFF
--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -317,6 +317,14 @@ public type Node record {
     int usedMemory?;
 };
 
+// Optional Heartbeat fields this server release understands. Advertised in every
+// HeartbeatResponse as `supportedHeartbeatFields` so a bridge can self-limit to what the
+// connected server actually supports instead of relying on a shared version number —
+// older bridges/servers that predate this negotiation simply never see the field and stay
+// on the baseline heartbeat shape. Update this list whenever an optional field is added to
+// Heartbeat below.
+final string[] & readonly SUPPORTED_HEARTBEAT_FIELDS = ["workflowCallbackUrl", "tryItHost", "openApiDefinitions"];
+
 // Heartbeat that includes all runtime information for registration/updates.
 // Open record so parsing tolerates fields from a newer agent that this server
 // version doesn't yet know about (e.g. a future addition sent before a rolling
@@ -399,6 +407,7 @@ public type HeartbeatResponse record {
     boolean fullHeartbeatRequired?;
     ControlCommand[] commands?;
     string[] errors?;
+    string[] supportedHeartbeatFields = SUPPORTED_HEARTBEAT_FIELDS;
 };
 
 public enum MIControlAction {

--- a/icp_server/modules/types/types.bal
+++ b/icp_server/modules/types/types.bal
@@ -407,7 +407,7 @@ public type HeartbeatResponse record {
     boolean fullHeartbeatRequired?;
     ControlCommand[] commands?;
     string[] errors?;
-    string[] supportedHeartbeatFields = SUPPORTED_HEARTBEAT_FIELDS;
+    string[] & readonly supportedHeartbeatFields = SUPPORTED_HEARTBEAT_FIELDS;
 };
 
 public enum MIControlAction {


### PR DESCRIPTION
## Summary
- Adds `supportedHeartbeatFields` to `HeartbeatResponse`, defaulted to a new `SUPPORTED_HEARTBEAT_FIELDS` constant (`workflowCallbackUrl`, `tryItHost`, `openApiDefinitions`) so every heartbeat ack this server sends advertises which optional `Heartbeat` fields it understands.
- Lets bridges self-limit to fields the connected server actually supports instead of relying on a shared version number — older/patched ICP releases that predate this simply never send the field, so a bridge correctly falls back to the baseline heartbeat shape.
- Companion bridge-side change: wso2/icp-runtime-bridge#40, which reads this field and only sends the advanced fields once advertised.
- https://github.com/wso2-enterprise/integration-engineering/issues/2135

## Test plan
- [x] `bal build icp_server`
- [ ] `bal test icp_server` — not run in this environment (a local process was already bound to port 9450, unrelated to this change); no existing test asserts on the full `HeartbeatResponse` JSON shape, so the new defaulted field shouldn't affect them.