### PR TITLE
[Devant migration] Enforce API-security with api-key by default and drop subscription-key model

### DIFF
--- a/ipaas/src/api/cloud/consumers.ts
+++ b/ipaas/src/api/cloud/consumers.ts
@@ -105,7 +105,9 @@ export const setEndpointSecurity = (ref: EndpointRef, cfg: SecurityConfig): Prom
 /** A masked api-key mapped onto the Consumer view-model (application = the key's identity). */
 const keyToConsumer = (k: ApiKeySummary, restApiId: string): Consumer => ({
   application: { id: k.name, displayName: k.displayName ?? k.name },
-  subscription: { id: k.name, applicationId: k.name, restApiId, status: k.status, createdAt: k.expiresAt },
+  // ApiKeySummary has no creation timestamp; leave createdAt unset rather than
+  // mislabelling the key's expiry as its creation time.
+  subscription: { id: k.name, applicationId: k.name, restApiId, status: k.status },
 });
 
 /** A freshly-minted key mapped onto a Subscription — `token` carries the plaintext api-key (once). */

--- a/ipaas/src/api/cloud/consumers.ts
+++ b/ipaas/src/api/cloud/consumers.ts
@@ -30,9 +30,9 @@
  *     the token re-read the subscription (see `fetchSubscription`).
  */
 
-import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, ConsumerApplication, CreateApiKeyInput, CreateConsumerInput, EndpointRef, Subscription } from '../../types/consumers';
+import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, CreateApiKeyInput, CreateConsumerInput, EndpointRef, SecurityConfig, Subscription } from '../../types/consumers';
 import { userFacingError } from '../../utils/apiSecurity';
-import { bff, items, q, seg, type ListResponse } from './_client';
+import { bff, items, seg, type ListResponse } from './_client';
 
 /** Tolerates both the bare-array (spec) and `{ items: [] }` (BFF house style) list shapes. */
 const asList = <T>(r: T[] | ListResponse<T> | null | undefined): T[] => (Array.isArray(r) ? r : items(r));
@@ -88,107 +88,63 @@ export const setEndpointApiKeyAuth = (ref: EndpointRef, enabled: boolean, option
 
 export const setEndpointJwtAuth = (ref: EndpointRef, enabled: boolean): Promise<boolean> => bff.put<AuthToggleResponse>(`${endpointPath(ref)}/security/jwt`, { enabled }).then(toggled(enabled));
 
-export const setEndpointSubscriptionValidation = (ref: EndpointRef, enabled: boolean, header?: string): Promise<boolean> =>
-  bff.put<AuthToggleResponse>(`${endpointPath(ref)}/security/subscription`, { enabled, ...(header ? { header } : {}) }).then(toggled(enabled));
+/** Read the single active auth mode (+ options) of the exposed API. */
+export const getEndpointSecurity = (ref: EndpointRef): Promise<SecurityConfig> => bff.get<SecurityConfig>(`${endpointPath(ref)}/security`);
+
+/** Set the single active auth mode. The BFF clears the other mode + redeploys. */
+export const setEndpointSecurity = (ref: EndpointRef, cfg: SecurityConfig): Promise<SecurityConfig> => bff.put<SecurityConfig>(`${endpointPath(ref)}/security`, cfg);
 
 // ---------------------------------------------------------------------------
-// Consumer applications + subscriptions
+// Consumers — a consumer is a named api-key on the exposed endpoint.
+//
+// There is no subscription-token flow. The gateway enforces the api-key when the
+// endpoint's security mode is "api-key"; the plaintext key is shown once at
+// creation and is the credential the consumer sends (default header X-API-Key).
 // ---------------------------------------------------------------------------
 
-export const fetchApplications = (projectName: string): Promise<ConsumerApplication[]> => bff.get<ConsumerApplication[] | ListResponse<ConsumerApplication>>(`/applications${q({ projectName })}`).then(asList);
+/** A masked api-key mapped onto the Consumer view-model (application = the key's identity). */
+const keyToConsumer = (k: ApiKeySummary, restApiId: string): Consumer => ({
+  application: { id: k.name, displayName: k.displayName ?? k.name },
+  subscription: { id: k.name, applicationId: k.name, restApiId, status: k.status, createdAt: k.expiresAt },
+});
 
-export const fetchSubscriptions = (applicationId: string): Promise<Subscription[]> => bff.get<Subscription[] | ListResponse<Subscription>>(`/applications/${seg(applicationId)}/subscriptions`).then(asList);
+/** A freshly-minted key mapped onto a Subscription — `token` carries the plaintext api-key (once). */
+const resultToSubscription = (r: ApiKeyResult, restApiId: string): Subscription => ({
+  id: r.keyId,
+  applicationId: r.keyId,
+  restApiId,
+  token: r.apiKey,
+  status: 'active',
+});
 
-export const fetchSubscription = (applicationId: string, subscriptionId: string): Promise<Subscription> => bff.get<Subscription>(`/applications/${seg(applicationId)}/subscriptions/${seg(subscriptionId)}`);
-
-export const deleteApplication = (applicationId: string): Promise<void> => bff.delete<void>(`/applications/${seg(applicationId)}`);
-
-const createApplication = (input: { displayName: string; projectName: string; description?: string }): Promise<ConsumerApplication> => bff.post<ConsumerApplication>('/applications', input);
-
-/** Subscribe by the component/environment/endpoint triple — the BFF derives the handle. */
-const createSubscription = (applicationId: string, ref: EndpointRef): Promise<Subscription> => bff.post<Subscription>(`/applications/${seg(applicationId)}/subscriptions`, ref);
-
-const deleteSubscription = (applicationId: string, subscriptionId: string): Promise<void> => bff.delete<void>(`/applications/${seg(applicationId)}/subscriptions/${seg(subscriptionId)}`);
-
-// ---------------------------------------------------------------------------
-// Composite reads/writes backing the Consumers panel
-// ---------------------------------------------------------------------------
-
-/**
- * Applications in the project that are subscribed to this endpoint's API.
- * Applications are org-scoped and can subscribe to many APIs, so the panel
- * shows the ones whose subscription targets this endpoint's handle.
- *
- * A per-application subscription read that fails (e.g. an application deleted
- * mid-flight) is skipped rather than failing the whole list.
- *
- * Scalability limitation: the BFF has no batch or `restApiId`-scoped
- * subscriptions query, so this issues one subscriptions request per application
- * in the project — N+1, all in flight at once. Fine for the handful of
- * applications a project has today; if projects grow to hundreds, this needs a
- * server-side filter (e.g. `GET /subscriptions?restApiId=…`) rather than a
- * wider client-side fan-out.
- */
-export async function fetchConsumers(projectName: string, ref: EndpointRef): Promise<Consumer[]> {
+export async function fetchConsumers(ref: EndpointRef): Promise<Consumer[]> {
   const restApiId = deriveRestApiId(ref);
-  const applications = await fetchApplications(projectName);
-  const perApp = await Promise.all(
-    applications.map(async (application): Promise<Consumer[]> => {
-      try {
-        const subscriptions = await fetchSubscriptions(application.id);
-        return subscriptions.filter((s) => s.restApiId === restApiId).map((subscription) => ({ application, subscription }));
-      } catch {
-        return [];
-      }
-    }),
-  );
-  return perApp.flat();
+  const keys = await listEndpointApiKeys(ref);
+  return keys.map((k) => keyToConsumer(k, restApiId));
 }
 
-/**
- * Create the consumer application and subscribe it to this API. If the
- * subscription fails the just-created application is removed, so a half-created
- * consumer never shows up in the list.
- */
 export async function createConsumer(input: CreateConsumerInput): Promise<Consumer> {
-  const { projectName, appName, description, componentName, environmentName, endpointName } = input;
-  const application = await createApplication({ displayName: appName, projectName, description });
-  try {
-    const subscription = await createSubscription(application.id, { componentName, environmentName, endpointName });
-    return { application, subscription };
-  } catch (err) {
-    // A failed rollback leaves an unsubscribed application behind. The
-    // subscription error is what the user needs, so it still propagates — but
-    // the orphan is logged rather than discarded so it is diagnosable.
-    await deleteApplication(application.id).catch((rollbackErr: unknown) => {
-      console.error(`[cloud] createConsumer: rolling back application ${application.id} failed; it may be left unsubscribed:`, rollbackErr);
-    });
-    throw err;
-  }
+  const { appName, description, componentName, environmentName, endpointName } = input;
+  const ref: EndpointRef = { componentName, environmentName, endpointName };
+  const result = await createEndpointApiKey(ref, { displayName: appName });
+  return {
+    application: { id: result.keyId, displayName: appName, description },
+    subscription: resultToSubscription(result, deriveRestApiId(ref)),
+  };
 }
 
 /**
- * Re-issue the subscription token. The BFF has no rotate route, so this
- * unsubscribes and resubscribes — the old `Subscription-Key` stops working the
- * moment the delete lands.
- *
- * The delete is not reversible, so a failed re-subscribe is retried once. If
- * that also fails the application is left unsubscribed, which the caller must
- * be told plainly: the generic "could not regenerate" wording would imply
- * nothing changed while the old key is in fact already dead.
+ * Re-issue a consumer's api-key: revoke the old key, then mint a new one under the same name.
+ * The old key stops working the moment the revoke lands; the new plaintext is returned once.
  */
-export async function regenerateConsumerToken(applicationId: string, subscriptionId: string, ref: EndpointRef): Promise<Subscription> {
-  await deleteSubscription(applicationId, subscriptionId);
+export async function regenerateConsumerToken(ref: EndpointRef, keyName: string, displayName: string): Promise<Subscription> {
+  await revokeEndpointApiKey(ref, keyName);
   try {
-    return await createSubscription(applicationId, ref);
-  } catch (firstErr) {
-    try {
-      return await createSubscription(applicationId, ref);
-    } catch (retryErr) {
-      console.error(`[cloud] regenerateConsumerToken: re-subscribing application ${applicationId} failed twice; it is now unsubscribed:`, retryErr);
-      throw userFacingError(`The old subscription key was revoked, but a new one could not be issued — “${applicationId}” is now unsubscribed from this API. Close this dialog and subscribe it again.`, firstErr);
-    }
+    const result = await createEndpointApiKey(ref, { displayName });
+    return resultToSubscription(result, deriveRestApiId(ref));
+  } catch (err) {
+    throw userFacingError(`The old API key was revoked, but a new one could not be issued for “${displayName}”. Close this dialog and create the consumer again.`, err);
   }
 }
 
-export const revokeConsumer = (applicationId: string, subscriptionId: string): Promise<void> => deleteSubscription(applicationId, subscriptionId);
+export const revokeConsumer = (ref: EndpointRef, keyName: string): Promise<void> => revokeEndpointApiKey(ref, keyName);

--- a/ipaas/src/api/contracts.ts
+++ b/ipaas/src/api/contracts.ts
@@ -36,7 +36,7 @@
 import type { AlertComponentType } from '../constants/alerts';
 import type { AlertHistoryResponse, AlertRule, AlertRuleCountUsage } from '../types/alerts';
 import type { ApimApiInfo, GeneratedTestKey, DeploySettingsV2Payload, LifecycleState, LifecycleHistory, MarketplaceService } from '../types/apim';
-import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, ConsumerApplication, CreateApiKeyInput, CreateConsumerInput, EndpointRef, Subscription } from '../types/consumers';
+import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, CreateApiKeyInput, CreateConsumerInput, EndpointRef, SecurityConfig, Subscription } from '../types/consumers';
 import type { ArtifactType, Artifact, ArtifactParam, ArtifactStatusInput, ListenerStateInput, ArtifactToggleStatusInput, ArtifactToggleKind, TriggerTaskInput } from '../types/artifact';
 import type {
   User,
@@ -260,21 +260,20 @@ export interface ConsumersApi {
   // Endpoint security — enforcement policies
   setEndpointApiKeyAuth(ref: EndpointRef, enabled: boolean, options?: ApiKeyAuthOptions): Promise<boolean>;
   setEndpointJwtAuth(ref: EndpointRef, enabled: boolean): Promise<boolean>;
-  setEndpointSubscriptionValidation(ref: EndpointRef, enabled: boolean, header?: string): Promise<boolean>;
+  /** Read the single active auth mode (+ options) of the exposed API. */
+  getEndpointSecurity(ref: EndpointRef): Promise<SecurityConfig>;
+  /** Set the single active auth mode (none/api-key/jwt); the BFF clears the other + redeploys. */
+  setEndpointSecurity(ref: EndpointRef, cfg: SecurityConfig): Promise<SecurityConfig>;
 
-  // Consumer applications + subscriptions
-  fetchApplications(projectName: string): Promise<ConsumerApplication[]>;
-  fetchSubscriptions(applicationId: string): Promise<Subscription[]>;
-  fetchSubscription(applicationId: string, subscriptionId: string): Promise<Subscription>;
-  deleteApplication(applicationId: string): Promise<void>;
-
-  /** Applications in `projectName` that are subscribed to the API exposed for `ref`. */
-  fetchConsumers(projectName: string, ref: EndpointRef): Promise<Consumer[]>;
+  // Consumers — a consumer is a named api-key on the exposed endpoint (no subscription-token flow).
+  /** Consumers (named api-keys) of the API exposed for `ref`. */
+  fetchConsumers(ref: EndpointRef): Promise<Consumer[]>;
+  /** Create a consumer: mint a named api-key on the endpoint. The plaintext key is returned once. */
   createConsumer(input: CreateConsumerInput): Promise<Consumer>;
-  /** Re-issue a consumer's subscription token (unsubscribe + resubscribe). */
-  regenerateConsumerToken(applicationId: string, subscriptionId: string, ref: EndpointRef): Promise<Subscription>;
-  /** Unsubscribe the application — the application itself is left in place. */
-  revokeConsumer(applicationId: string, subscriptionId: string): Promise<void>;
+  /** Re-issue a consumer's api-key (revoke + mint). The new plaintext key is returned once. */
+  regenerateConsumerToken(ref: EndpointRef, keyName: string, displayName: string): Promise<Subscription>;
+  /** Revoke a consumer's api-key. */
+  revokeConsumer(ref: EndpointRef, keyName: string): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/ipaas/src/api/icp/consumers.ts
+++ b/ipaas/src/api/icp/consumers.ts
@@ -20,7 +20,7 @@
 // owns it); the icp UI is gated on IS_CLOUD and never reaches these. They throw
 // via ni() so an unsupported call can never look successful.
 // TODO: implement using icp APIs
-import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, ConsumerApplication, CreateApiKeyInput, CreateConsumerInput, EndpointRef, Subscription } from '../../types/consumers';
+import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, CreateApiKeyInput, CreateConsumerInput, EndpointRef, SecurityConfig, Subscription } from '../../types/consumers';
 
 const ni = (name: string): never => {
   throw new Error(`[icp] consumers.${name}: not implemented`);
@@ -36,14 +36,10 @@ export const createEndpointTestKey = (_ref: EndpointRef): Promise<ApiKeyResult> 
 
 export const setEndpointApiKeyAuth = (_ref: EndpointRef, _enabled: boolean, _options?: ApiKeyAuthOptions): Promise<boolean> => ni('setEndpointApiKeyAuth');
 export const setEndpointJwtAuth = (_ref: EndpointRef, _enabled: boolean): Promise<boolean> => ni('setEndpointJwtAuth');
-export const setEndpointSubscriptionValidation = (_ref: EndpointRef, _enabled: boolean, _header?: string): Promise<boolean> => ni('setEndpointSubscriptionValidation');
+export const getEndpointSecurity = (_ref: EndpointRef): Promise<SecurityConfig> => ni('getEndpointSecurity');
+export const setEndpointSecurity = (_ref: EndpointRef, _cfg: SecurityConfig): Promise<SecurityConfig> => ni('setEndpointSecurity');
 
-export const fetchApplications = (_projectName: string): Promise<ConsumerApplication[]> => ni('fetchApplications');
-export const fetchSubscriptions = (_applicationId: string): Promise<Subscription[]> => ni('fetchSubscriptions');
-export const fetchSubscription = (_applicationId: string, _subscriptionId: string): Promise<Subscription> => ni('fetchSubscription');
-export const deleteApplication = (_applicationId: string): Promise<void> => ni('deleteApplication');
-
-export const fetchConsumers = (_projectName: string, _ref: EndpointRef): Promise<Consumer[]> => ni('fetchConsumers');
+export const fetchConsumers = (_ref: EndpointRef): Promise<Consumer[]> => ni('fetchConsumers');
 export const createConsumer = (_input: CreateConsumerInput): Promise<Consumer> => ni('createConsumer');
-export const regenerateConsumerToken = (_applicationId: string, _subscriptionId: string, _ref: EndpointRef): Promise<Subscription> => ni('regenerateConsumerToken');
-export const revokeConsumer = (_applicationId: string, _subscriptionId: string): Promise<void> => ni('revokeConsumer');
+export const regenerateConsumerToken = (_ref: EndpointRef, _keyName: string, _displayName: string): Promise<Subscription> => ni('regenerateConsumerToken');
+export const revokeConsumer = (_ref: EndpointRef, _keyName: string): Promise<void> => ni('revokeConsumer');

--- a/ipaas/src/api/wip/consumers.ts
+++ b/ipaas/src/api/wip/consumers.ts
@@ -20,7 +20,7 @@
 // owns it); the wip UI is gated on IS_CLOUD and never reaches these. They throw
 // via ni() so an unsupported call can never look successful.
 // TODO: implement using wip APIs
-import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, ConsumerApplication, CreateApiKeyInput, CreateConsumerInput, EndpointRef, Subscription } from '../../types/consumers';
+import type { ApiExposure, ApiKeyAuthOptions, ApiKeyResult, ApiKeySummary, Consumer, CreateApiKeyInput, CreateConsumerInput, EndpointRef, SecurityConfig, Subscription } from '../../types/consumers';
 
 const ni = (name: string): never => {
   throw new Error(`[wip] consumers.${name}: not implemented`);
@@ -36,14 +36,10 @@ export const createEndpointTestKey = (_ref: EndpointRef): Promise<ApiKeyResult> 
 
 export const setEndpointApiKeyAuth = (_ref: EndpointRef, _enabled: boolean, _options?: ApiKeyAuthOptions): Promise<boolean> => ni('setEndpointApiKeyAuth');
 export const setEndpointJwtAuth = (_ref: EndpointRef, _enabled: boolean): Promise<boolean> => ni('setEndpointJwtAuth');
-export const setEndpointSubscriptionValidation = (_ref: EndpointRef, _enabled: boolean, _header?: string): Promise<boolean> => ni('setEndpointSubscriptionValidation');
+export const getEndpointSecurity = (_ref: EndpointRef): Promise<SecurityConfig> => ni('getEndpointSecurity');
+export const setEndpointSecurity = (_ref: EndpointRef, _cfg: SecurityConfig): Promise<SecurityConfig> => ni('setEndpointSecurity');
 
-export const fetchApplications = (_projectName: string): Promise<ConsumerApplication[]> => ni('fetchApplications');
-export const fetchSubscriptions = (_applicationId: string): Promise<Subscription[]> => ni('fetchSubscriptions');
-export const fetchSubscription = (_applicationId: string, _subscriptionId: string): Promise<Subscription> => ni('fetchSubscription');
-export const deleteApplication = (_applicationId: string): Promise<void> => ni('deleteApplication');
-
-export const fetchConsumers = (_projectName: string, _ref: EndpointRef): Promise<Consumer[]> => ni('fetchConsumers');
+export const fetchConsumers = (_ref: EndpointRef): Promise<Consumer[]> => ni('fetchConsumers');
 export const createConsumer = (_input: CreateConsumerInput): Promise<Consumer> => ni('createConsumer');
-export const regenerateConsumerToken = (_applicationId: string, _subscriptionId: string, _ref: EndpointRef): Promise<Subscription> => ni('regenerateConsumerToken');
-export const revokeConsumer = (_applicationId: string, _subscriptionId: string): Promise<void> => ni('revokeConsumer');
+export const regenerateConsumerToken = (_ref: EndpointRef, _keyName: string, _displayName: string): Promise<Subscription> => ni('regenerateConsumerToken');
+export const revokeConsumer = (_ref: EndpointRef, _keyName: string): Promise<void> => ni('revokeConsumer');

--- a/ipaas/src/components/Overview/integration-as-api/ApiSecurityDrawer.tsx
+++ b/ipaas/src/components/Overview/integration-as-api/ApiSecurityDrawer.tsx
@@ -49,6 +49,12 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
   const [apiKeyHeader, setApiKeyHeader] = useState(DEFAULT_API_KEY_HEADER);
   const [error, setError] = useState<string | null>(null);
 
+  // Drop the endpoint override when the drawer closes, so reopening derives the endpoint from
+  // activeEndpointName instead of a stale prior selection.
+  useEffect(() => {
+    if (!open) setUserSelectedIdx(null);
+  }, [open]);
+
   const matchedIdx = useMemo(() => {
     const i = endpoints.findIndex((ep) => ep.name === activeEndpointName);
     return i >= 0 ? i : 0;
@@ -64,7 +70,7 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
 
   // Seed the local checkboxes from the fetched state once per (endpoint, open) — later user edits
   // stick even if the query re-settles.
-  const syncKey = `${selectedEndpoint?.name ?? ''}:${open ? 1 : 0}`;
+  const syncKey = JSON.stringify({ componentName, environmentName: envName, endpointName: selectedEndpoint?.name ?? '', open });
   const syncedRef = useRef('');
   useEffect(() => {
     if (!open) {
@@ -192,7 +198,7 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
           <Button variant="outlined" onClick={handleCancel} disabled={saving}>
             Cancel
           </Button>
-          <Button variant="contained" onClick={() => void handleApply()} disabled={saving || !selectedEndpoint || loadingSecurity}>
+          <Button variant="contained" onClick={() => void handleApply()} disabled={saving || !selectedEndpoint || loadingSecurity || Boolean(securityError)}>
             {saving ? <CircularProgress size={16} color="inherit" /> : 'Apply'}
           </Button>
         </Box>

--- a/ipaas/src/components/Overview/integration-as-api/ApiSecurityDrawer.tsx
+++ b/ipaas/src/components/Overview/integration-as-api/ApiSecurityDrawer.tsx
@@ -18,10 +18,10 @@
 
 import { Alert, Box, Button, Checkbox, CircularProgress, Drawer, FormControlLabel, IconButton, MenuItem, Select, Stack, Table, TableBody, TableCell, TableHead, TableRow, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { X } from '@wso2/oxygen-ui-icons-react';
-import { useMemo, useState, type JSX } from 'react';
-import { API_KEY_SCHEME_DESCRIPTION, COMING_SOON_OAUTH, COMING_SOON_UPSTREAM_ATTRS, DEFAULT_API_KEY_HEADER, OAUTH_HEADER, OAUTH_SCHEME_DESCRIPTION } from '../../../constants/apiConsumption';
-import { useSetEndpointApiKeyAuth } from '../../../hooks/useConsumers';
-import type { EndpointOption, EndpointRef } from '../../../types/consumers';
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react';
+import { API_KEY_SCHEME_DESCRIPTION, COMING_SOON_UPSTREAM_ATTRS, DEFAULT_API_KEY_HEADER, OAUTH_HEADER, OAUTH_SCHEME_DESCRIPTION } from '../../../constants/apiConsumption';
+import { useEndpointSecurity, useSetEndpointSecurity } from '../../../hooks/useConsumers';
+import type { EndpointOption, EndpointRef, SecurityConfig, SecurityMode } from '../../../types/consumers';
 import { friendlyApiError } from '../../../utils/apiSecurity';
 import * as styles from './apiConsumption.styles';
 
@@ -42,29 +42,12 @@ interface ApiSecurityDrawerProps {
  * Cloud-only "Configure Security" drawer for one exposed endpoint API. Mirrors
  * the APIM SecurityDrawer's layout (endpoint selector + security-scheme table)
  * minus the Resources section, which has no cloud equivalent.
- *
- * Applying writes the `api-key-auth` gateway policy. OAuth is listed but not
- * selectable yet — the BFF's jwt-auth policy is not wired into this flow. The
- * gateway exposes no route to read the policies currently in force, so the
- * checkboxes start from the documented post-expose default (API Key on).
  */
 export default function ApiSecurityDrawer({ open, onClose, componentName, envName, endpoints, activeEndpointName }: ApiSecurityDrawerProps): JSX.Element {
   const [userSelectedIdx, setUserSelectedIdx] = useState<number | null>(null);
-  const [wasOpen, setWasOpen] = useState(false);
-  const [isApiKey, setIsApiKey] = useState(true);
+  const [mode, setMode] = useState<SecurityMode>('none');
   const [apiKeyHeader, setApiKeyHeader] = useState(DEFAULT_API_KEY_HEADER);
   const [error, setError] = useState<string | null>(null);
-
-  // Each open resets to the env card's active endpoint (reset during render).
-  if (open !== wasOpen) {
-    setWasOpen(open);
-    if (open) {
-      setUserSelectedIdx(null);
-      setIsApiKey(true);
-      setApiKeyHeader(DEFAULT_API_KEY_HEADER);
-      setError(null);
-    }
-  }
 
   const matchedIdx = useMemo(() => {
     const i = endpoints.findIndex((ep) => ep.name === activeEndpointName);
@@ -75,14 +58,40 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
 
   const endpointRef: EndpointRef | null = useMemo(() => (selectedEndpoint ? { componentName, environmentName: envName, endpointName: selectedEndpoint.name } : null), [componentName, envName, selectedEndpoint]);
 
-  const apiKeyAuthMutation = useSetEndpointApiKeyAuth(endpointRef);
-  const saving = apiKeyAuthMutation.isPending;
+  const { data: security, isLoading: loadingSecurity, error: securityError } = useEndpointSecurity(endpointRef, open);
+  const setSecurityMutation = useSetEndpointSecurity(endpointRef);
+  const saving = setSecurityMutation.isPending;
+
+  // Seed the local checkboxes from the fetched state once per (endpoint, open) — later user edits
+  // stick even if the query re-settles.
+  const syncKey = `${selectedEndpoint?.name ?? ''}:${open ? 1 : 0}`;
+  const syncedRef = useRef('');
+  useEffect(() => {
+    if (!open) {
+      syncedRef.current = '';
+      return;
+    }
+    if (security && syncedRef.current !== syncKey) {
+      syncedRef.current = syncKey;
+      setMode(security.mode);
+      setApiKeyHeader(security.apiKey?.header || DEFAULT_API_KEY_HEADER);
+      setError(null);
+    }
+  }, [open, security, syncKey]);
+
+  const isApiKey = mode === 'api-key';
+  const isOAuth = mode === 'jwt';
+
+  // Mutually exclusive: turning one scheme on turns the other off; turning it off opens the API.
+  const toggleApiKey = () => setMode((m) => (m === 'api-key' ? 'none' : 'api-key'));
+  const toggleOAuth = () => setMode((m) => (m === 'jwt' ? 'none' : 'jwt'));
 
   const handleApply = async () => {
     if (!endpointRef) return;
     setError(null);
+    const cfg: SecurityConfig = mode === 'api-key' ? { mode, apiKey: { header: apiKeyHeader.trim() || DEFAULT_API_KEY_HEADER } } : mode === 'jwt' ? { mode, jwt: {} } : { mode: 'none' };
     try {
-      await apiKeyAuthMutation.mutateAsync({ enabled: isApiKey, options: { key: apiKeyHeader.trim() || DEFAULT_API_KEY_HEADER, in: 'header' } });
+      await setSecurityMutation.mutateAsync(cfg);
       onClose();
     } catch (err) {
       setError(friendlyApiError(err, 'Could not save the security configuration.'));
@@ -112,6 +121,7 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
           ) : (
             <Stack gap={2.5}>
               {error && <Alert severity="error">{error}</Alert>}
+              {securityError && !error && <Alert severity="warning">{friendlyApiError(securityError, 'Could not read the current security configuration.')}</Alert>}
 
               <Stack direction="row" alignItems="center" gap={2}>
                 <Typography variant="body2" fontWeight={500}>
@@ -130,42 +140,44 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
                 )}
               </Stack>
 
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell sx={styles.tableHeadCell}>Security Scheme</TableCell>
-                    <TableCell sx={styles.tableHeadCell}>Security Header</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  <TableRow>
-                    <TableCell sx={styles.schemeCell}>
-                      <FormControlLabel control={<Checkbox checked={isApiKey} onChange={() => setIsApiKey((v) => !v)} size="small" />} label="API Key" />
-                    </TableCell>
-                    <TableCell>
-                      <TextField size="small" value={apiKeyHeader} onChange={(e) => setApiKeyHeader(e.target.value)} disabled={!isApiKey} fullWidth />
-                      <Typography variant="caption" color="text.secondary" sx={styles.schemeDescription}>
-                        {API_KEY_SCHEME_DESCRIPTION}
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell sx={styles.schemeCell}>
-                      <Tooltip title={COMING_SOON_OAUTH}>
-                        <Box component="span" sx={styles.disabledTooltipTarget}>
-                          <FormControlLabel control={<Checkbox checked={false} size="small" disabled />} label="OAuth" disabled />
-                        </Box>
-                      </Tooltip>
-                    </TableCell>
-                    <TableCell>
-                      <TextField size="small" value={OAUTH_HEADER} disabled fullWidth />
-                      <Typography variant="caption" color="text.secondary" sx={styles.schemeDescription}>
-                        {OAUTH_SCHEME_DESCRIPTION}
-                      </Typography>
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
+              {loadingSecurity ? (
+                <Box sx={styles.loadingRow}>
+                  <CircularProgress size={20} />
+                </Box>
+              ) : (
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={styles.tableHeadCell}>Security Scheme</TableCell>
+                      <TableCell sx={styles.tableHeadCell}>Security Header</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    <TableRow>
+                      <TableCell sx={styles.schemeCell}>
+                        <FormControlLabel control={<Checkbox checked={isApiKey} onChange={toggleApiKey} size="small" />} label="API Key" />
+                      </TableCell>
+                      <TableCell>
+                        <TextField size="small" value={apiKeyHeader} onChange={(e) => setApiKeyHeader(e.target.value)} disabled={!isApiKey} fullWidth />
+                        <Typography variant="caption" color="text.secondary" sx={styles.schemeDescription}>
+                          {API_KEY_SCHEME_DESCRIPTION}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell sx={styles.schemeCell}>
+                        <FormControlLabel control={<Checkbox checked={isOAuth} onChange={toggleOAuth} size="small" />} label="OAuth" />
+                      </TableCell>
+                      <TableCell>
+                        <TextField size="small" value={OAUTH_HEADER} disabled fullWidth />
+                        <Typography variant="caption" color="text.secondary" sx={styles.schemeDescription}>
+                          {OAUTH_SCHEME_DESCRIPTION}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              )}
 
               <Tooltip title={COMING_SOON_UPSTREAM_ATTRS}>
                 <Box component="span" sx={styles.disabledTooltipTarget}>
@@ -180,7 +192,7 @@ export default function ApiSecurityDrawer({ open, onClose, componentName, envNam
           <Button variant="outlined" onClick={handleCancel} disabled={saving}>
             Cancel
           </Button>
-          <Button variant="contained" onClick={() => void handleApply()} disabled={saving || !selectedEndpoint}>
+          <Button variant="contained" onClick={() => void handleApply()} disabled={saving || !selectedEndpoint || loadingSecurity}>
             {saving ? <CircularProgress size={16} color="inherit" /> : 'Apply'}
           </Button>
         </Box>

--- a/ipaas/src/components/Overview/integration-as-api/ConsumerDrawer.tsx
+++ b/ipaas/src/components/Overview/integration-as-api/ConsumerDrawer.tsx
@@ -19,8 +19,8 @@
 import { Alert, Box, Button, Chip, CircularProgress, Drawer, IconButton, Stack, TextField, Tooltip, Typography } from '@wso2/oxygen-ui';
 import { Eye, EyeOff, X } from '@wso2/oxygen-ui-icons-react';
 import { useEffect, useState, type JSX } from 'react';
-import { REGENERATE_SUBSCRIPTION_WARNING, SUBSCRIPTION_KEY_HEADER, TOKEN_MASK, UNSUBSCRIBE_WARNING } from '../../../constants/apiConsumption';
-import { useCreateConsumer, useRegenerateConsumerToken, useRevokeConsumer, useSubscription } from '../../../hooks/useConsumers';
+import { DEFAULT_API_KEY_HEADER, REGENERATE_SUBSCRIPTION_WARNING, TOKEN_MASK, UNSUBSCRIBE_WARNING } from '../../../constants/apiConsumption';
+import { useCreateConsumer, useRegenerateConsumerToken, useRevokeConsumer } from '../../../hooks/useConsumers';
 import type { Consumer, EndpointRef } from '../../../types/consumers';
 import { consumerDisplayName } from '../../../utils/apiConsumption';
 import { friendlyApiError } from '../../../utils/apiSecurity';
@@ -64,10 +64,9 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
   const consumerInView = consumer ?? createMutation.data ?? null;
   const subscription = regenMutation.data ?? consumerInView?.subscription ?? null;
 
-  // Create and regenerate return the token; the list route does not, so an
-  // existing consumer's token has to be re-read from the single subscription.
-  const { data: fetchedSubscription, isLoading: loadingToken, error: tokenError } = useSubscription(consumerInView?.application.id, subscription?.id, open && !!subscription && !subscription.token);
-  const token = subscription?.token ?? fetchedSubscription?.token ?? '';
+  // The plaintext api-key is returned only once (on create/regenerate). A consumer opened from
+  // the list has no retrievable key — the user regenerates to issue a fresh one.
+  const token = subscription?.token ?? '';
 
   useEffect(() => {
     if (!open) return;
@@ -94,19 +93,19 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
 
   const handleConfirm = async () => {
     if (!consumerInView || !subscription) return;
-    const target = { applicationId: consumerInView.application.id, subscriptionId: subscription.id };
+    const keyName = subscription.id;
     setError(null);
     try {
       if (confirm === 'regenerate') {
-        await regenMutation.mutateAsync(target);
+        await regenMutation.mutateAsync({ keyName, displayName: consumerDisplayName(consumerInView) });
         setRevealToken(false);
       } else {
-        await revokeMutation.mutateAsync(target);
+        await revokeMutation.mutateAsync({ keyName });
         onClose();
       }
       setConfirm(null);
     } catch (err) {
-      setError(friendlyApiError(err, confirm === 'regenerate' ? 'Could not regenerate the subscription key.' : 'Could not unsubscribe this application.'));
+      setError(friendlyApiError(err, confirm === 'regenerate' ? 'Could not regenerate the API key.' : 'Could not revoke this API key.'));
     }
   };
 
@@ -164,17 +163,13 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
               <Typography sx={styles.fieldLabel}>Header</Typography>
               <Box sx={styles.credField}>
                 <Typography component="span" sx={styles.credValue}>
-                  {SUBSCRIPTION_KEY_HEADER}
+                  {DEFAULT_API_KEY_HEADER}
                 </Typography>
-                <CopyButton value={SUBSCRIPTION_KEY_HEADER} />
+                <CopyButton value={DEFAULT_API_KEY_HEADER} />
               </Box>
 
               <Typography sx={styles.nextFieldLabel}>API Key</Typography>
-              {loadingToken ? (
-                <Box sx={styles.centredRow}>
-                  <CircularProgress size={18} />
-                </Box>
-              ) : token ? (
+              {token ? (
                 <Box sx={styles.credField}>
                   <Typography component="span" sx={styles.credValue}>
                     {revealToken ? token : TOKEN_MASK}
@@ -187,7 +182,7 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
                   <CopyButton value={token} />
                 </Box>
               ) : (
-                <Alert severity="warning">{friendlyApiError(tokenError, 'The subscription key could not be read. Regenerate it to issue a new one.')}</Alert>
+                <Alert severity="info">The API key is shown only once, when it is created. Regenerate to issue a new key.</Alert>
               )}
             </Box>
           )}
@@ -201,7 +196,7 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
                   Regenerate
                 </Button>
                 <Button variant="outlined" color="error" onClick={() => setConfirm('unsubscribe')} disabled={busy}>
-                  Unsubscribe
+                  Revoke
                 </Button>
               </Stack>
               <Button variant="contained" onClick={onClose} disabled={busy}>
@@ -223,12 +218,12 @@ export default function ConsumerDrawer({ open, onClose, projectName, endpointRef
 
       {confirm && (
         <ConfirmDeleteDialog
-          title={confirm === 'regenerate' ? 'Regenerate subscription key?' : 'Unsubscribe this application?'}
+          title={confirm === 'regenerate' ? 'Regenerate API key?' : 'Revoke this API key?'}
           onConfirm={() => void handleConfirm()}
           onClose={() => setConfirm(null)}
           isPending={busy}
-          confirmLabel={confirm === 'regenerate' ? 'Regenerate' : 'Unsubscribe'}
-          pendingLabel={confirm === 'regenerate' ? 'Regenerating…' : 'Unsubscribing…'}
+          confirmLabel={confirm === 'regenerate' ? 'Regenerate' : 'Revoke'}
+          pendingLabel={confirm === 'regenerate' ? 'Regenerating…' : 'Revoking…'}
           maxWidth="xs">
           <Typography variant="body2" color="text.secondary">
             {confirm === 'regenerate' ? REGENERATE_SUBSCRIPTION_WARNING : UNSUBSCRIBE_WARNING}

--- a/ipaas/src/hooks/useConsumers.ts
+++ b/ipaas/src/hooks/useConsumers.ts
@@ -17,8 +17,8 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { createConsumer, createEndpointTestKey, fetchConsumers, fetchSubscription, regenerateConsumerToken, revokeConsumer, setEndpointApiKeyAuth } from '#api/consumers';
-import type { ApiKeyAuthOptions, ApiKeyResult, Consumer, CreateConsumerInput, EndpointRef, Subscription } from '../types/consumers';
+import { createConsumer, createEndpointTestKey, fetchConsumers, getEndpointSecurity, regenerateConsumerToken, revokeConsumer, setEndpointSecurity } from '#api/consumers';
+import type { ApiKeyResult, Consumer, CreateConsumerInput, EndpointRef, SecurityConfig, Subscription } from '../types/consumers';
 
 /** Endpoint refs are only usable once every segment is known. */
 const isCompleteRef = (ref: EndpointRef | null | undefined): ref is EndpointRef => !!ref?.componentName && !!ref.environmentName && !!ref.endpointName;
@@ -28,35 +28,21 @@ const refKey = (ref: EndpointRef | null | undefined) => [ref?.componentName ?? '
 const consumersKey = (projectName: string | null | undefined, ref: EndpointRef | null | undefined) => ['consumers', projectName ?? '', ...refKey(ref)] as const;
 
 // ---------------------------------------------------------------------------
-// Consumers (applications subscribed to the exposed API)
+// Consumers (named api-keys on the exposed API)
 // ---------------------------------------------------------------------------
 
-/** Consumer applications in the project subscribed to this endpoint's API. */
+/** Consumers (named api-keys) of this endpoint's exposed API. */
 export function useConsumers(projectName: string | null | undefined, ref: EndpointRef | null | undefined) {
   return useQuery<Consumer[]>({
     queryKey: consumersKey(projectName, ref),
-    queryFn: () => fetchConsumers(projectName!, ref!),
-    enabled: !!projectName && isCompleteRef(ref),
+    queryFn: () => fetchConsumers(ref!),
+    enabled: isCompleteRef(ref),
     staleTime: 30_000,
     retry: false,
   });
 }
 
-/**
- * The subscription token is not returned by the list route, so the dialog
- * re-reads the single subscription to reveal the `Subscription-Key`.
- */
-export function useSubscription(applicationId: string | null | undefined, subscriptionId: string | null | undefined, enabled = true) {
-  return useQuery<Subscription>({
-    queryKey: ['subscription', applicationId ?? '', subscriptionId ?? ''],
-    queryFn: () => fetchSubscription(applicationId!, subscriptionId!),
-    enabled: enabled && !!applicationId && !!subscriptionId,
-    staleTime: 30_000,
-    retry: false,
-  });
-}
-
-/** Create a consumer application and subscribe it to this API in one step. */
+/** Create a consumer: mint a named api-key on this endpoint. The plaintext is returned once. */
 export function useCreateConsumer(projectName: string | null | undefined) {
   const qc = useQueryClient();
   return useMutation<Consumer, Error, CreateConsumerInput>({
@@ -67,52 +53,55 @@ export function useCreateConsumer(projectName: string | null | undefined) {
   });
 }
 
-/** Re-issue a consumer's subscription token (unsubscribe + resubscribe). */
+/** Re-issue a consumer's api-key (revoke + mint). The new plaintext is returned once. */
 export function useRegenerateConsumerToken(projectName: string | null | undefined, ref: EndpointRef | null | undefined) {
   const qc = useQueryClient();
-  return useMutation<Subscription, Error, { applicationId: string; subscriptionId: string }>({
-    mutationFn: ({ applicationId, subscriptionId }) => regenerateConsumerToken(applicationId, subscriptionId, ref!),
-    onSuccess: (data, vars) => {
-      qc.removeQueries({ queryKey: ['subscription', vars.applicationId, vars.subscriptionId] });
-      qc.setQueryData(['subscription', vars.applicationId, data.id], data);
-      qc.invalidateQueries({ queryKey: consumersKey(projectName, ref) });
-    },
-    // Regenerating deletes before it re-creates, so even on failure the old
-    // subscription is gone — the cached list must not keep showing it.
-    onError: (_err, vars) => {
-      qc.removeQueries({ queryKey: ['subscription', vars.applicationId, vars.subscriptionId] });
+  return useMutation<Subscription, Error, { keyName: string; displayName: string }>({
+    mutationFn: ({ keyName, displayName }) => regenerateConsumerToken(ref!, keyName, displayName),
+    // Regenerating revokes before it re-mints, so even on failure the old key is gone — the
+    // cached list must not keep showing it.
+    onSettled: () => {
       qc.invalidateQueries({ queryKey: consumersKey(projectName, ref) });
     },
   });
 }
 
-/** Unsubscribe a consumer. The application itself is left in place. */
+/** Revoke a consumer's api-key. */
 export function useRevokeConsumer(projectName: string | null | undefined, ref: EndpointRef | null | undefined) {
   const qc = useQueryClient();
-  return useMutation<void, Error, { applicationId: string; subscriptionId: string }>({
-    mutationFn: ({ applicationId, subscriptionId }) => revokeConsumer(applicationId, subscriptionId),
-    onSuccess: (_data, vars) => {
-      qc.removeQueries({ queryKey: ['subscription', vars.applicationId, vars.subscriptionId] });
+  return useMutation<void, Error, { keyName: string }>({
+    mutationFn: ({ keyName }) => revokeConsumer(ref!, keyName),
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: consumersKey(projectName, ref) });
     },
   });
 }
 
 // ---------------------------------------------------------------------------
-// Endpoint security — enforcement policies
+// Endpoint security — single active auth mode
 // ---------------------------------------------------------------------------
 
-/**
- * Apply the `api-key-auth` gateway policy. There is no route to read the current
- * policy state, so the caller owns the displayed state and applies the
- * server-echoed result on success.
- *
- * The remaining spec routes (jwt-auth, subscription-validation, expose/unexpose,
- * long-lived API keys) exist in the API layer but no UI drives them yet.
- */
-export function useSetEndpointApiKeyAuth(ref: EndpointRef | null | undefined) {
-  return useMutation<boolean, Error, { enabled: boolean; options?: ApiKeyAuthOptions }>({
-    mutationFn: ({ enabled, options }) => setEndpointApiKeyAuth(ref!, enabled, options),
+const securityKey = (ref: EndpointRef | null | undefined) => ['endpoint-security', ...refKey(ref)] as const;
+
+/** Read the exposed API's active auth mode so the security drawer reflects real state. */
+export function useEndpointSecurity(ref: EndpointRef | null | undefined, enabled = true) {
+  return useQuery<SecurityConfig>({
+    queryKey: securityKey(ref),
+    queryFn: () => getEndpointSecurity(ref!),
+    enabled: enabled && isCompleteRef(ref),
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+/** Set the exposed API's active auth mode (none/api-key/jwt). */
+export function useSetEndpointSecurity(ref: EndpointRef | null | undefined) {
+  const qc = useQueryClient();
+  return useMutation<SecurityConfig, Error, SecurityConfig>({
+    mutationFn: (cfg) => setEndpointSecurity(ref!, cfg),
+    onSuccess: (data) => {
+      qc.setQueryData(securityKey(ref), data);
+    },
   });
 }
 

--- a/ipaas/src/types/consumers.ts
+++ b/ipaas/src/types/consumers.ts
@@ -97,6 +97,29 @@ export interface ApiKeyAuthOptions {
   in?: string;
 }
 
+/**
+ * The single active auth mode of an exposed API. The gateway ANDs auth policies with no
+ * fallback, so exactly one mode is active at a time (they are mutually exclusive):
+ *  - `none`    — open, no auth.
+ *  - `api-key` — api-key-auth (the default for a newly exposed endpoint).
+ *  - `jwt`     — jwt-auth (OAuth2 bearer, validated against the org key manager).
+ */
+export type SecurityMode = 'none' | 'api-key' | 'jwt';
+
+/** The active security configuration of an exposed endpoint API (GET/PUT `.../security`). */
+export interface SecurityConfig {
+  mode: SecurityMode;
+  apiKey?: {
+    /** Request header carrying the key (default `X-API-Key`). */
+    header?: string;
+  };
+  jwt?: {
+    /** Gateway key-manager names to trust; empty defaults to the org key manager. */
+    issuers?: string[];
+    audiences?: string[];
+  };
+}
+
 /** A consumer application. Org-scoped and shared across the org. */
 export interface ConsumerApplication {
   id: string;


### PR DESCRIPTION
## Purpose
- ApiSecurityDrawer: two mutually-exclusive checkboxes (API Key + OAuth, OAuth now wired) that initialise from GET .../security and apply via a single PUT .../security. Removes the hardcoded "API Key on" default that never reflected real gateway state.
- Consumers: a consumer is now a named api-key on the exposed endpoint (ConsumerDrawer reveals the api-key once; Regenerate/Revoke), replacing the subscription-token flow whose routes were removed.
- API layer: add getEndpointSecurity/setEndpointSecurity to the contract and all three implementations (cloud/icp/wip); drop setEndpointSubscriptionValidation and the subscription/application fetch helpers. New useEndpointSecurity / useSetEndpointSecurity hooks; consumer hooks moved to the api-key routes.


> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.