### PR TITLE
[Devant migration] Fix environment creation and project updates in the cloud variant

### DIFF
--- a/ipaas/src/api/cloud/deploymentPipelines.ts
+++ b/ipaas/src/api/cloud/deploymentPipelines.ts
@@ -108,15 +108,47 @@ const promotionPathsToTree = (paths: BffPromotionPath[]): PromotionTreeNode => {
   return { name: 'Root', children: roots.map((r) => build(r, new Set())) };
 };
 
+// OpenChoreo has no default flag; the well-known "default" pipeline stands in.
+const DEFAULT_PIPELINE_NAME = 'default';
+
 const toDeploymentPipeline = (p: BffDeploymentPipeline): DeploymentPipeline => ({
   id: p.name,
   created_at: p.createdAt ?? '',
   organization_uuid: '',
   name: p.displayName || p.name,
   promotion_tree: promotionPathsToTree(p.promotionPaths ?? []),
-  // OpenChoreo has no default flag; the well-known "default" pipeline stands in.
-  is_default: p.name === 'default',
+  is_default: p.name === DEFAULT_PIPELINE_NAME,
 });
+
+/**
+ * Append `envSlug` to the end of the default pipeline's promotion chain, so a
+ * freshly created environment is actually deployable — an environment that sits
+ * outside every promotion path can never be promoted into.
+ *
+ * The insertion point is the chain's terminal environment: the one promoted *to*
+ * but never *from*. A pipeline with no paths, or a branching chain with several
+ * terminals, is left untouched — there is no single correct place to insert and
+ * guessing would rewrite a topology someone built deliberately.
+ *
+ * Returns whether the pipeline was updated.
+ */
+export const appendEnvironmentToDefaultPipeline = async (envSlug: string): Promise<boolean> => {
+  const pipeline = items(await bff.get<ListResponse<BffDeploymentPipeline>>('/deploymentpipelines')).find((p) => p.name === DEFAULT_PIPELINE_NAME);
+  if (!pipeline) return false;
+
+  const paths = pipeline.promotionPaths ?? [];
+  const sources = new Set(paths.map((p) => p.sourceEnvironment));
+  const targets = new Set(paths.flatMap((p) => p.targetEnvironments));
+  if (sources.has(envSlug) || targets.has(envSlug)) return false; // already in the chain
+
+  const terminals = [...targets].filter((t) => !sources.has(t));
+  if (terminals.length !== 1) return false;
+
+  await bff.put<BffDeploymentPipeline>(`/deploymentpipelines/${seg(pipeline.name)}`, {
+    promotionPaths: [...paths, { sourceEnvironment: terminals[0], targetEnvironments: [envSlug] }],
+  });
+  return true;
+};
 
 // OpenChoreo models no environment templates — the promotion chain is built over
 // environments directly, so each environment is projected into an EnvTemplate.

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -18,15 +18,10 @@
 
 /** Cloud (OpenChoreo) environment / dataplane API. Calls the ipaas-service BFF. */
 
-import type { CloudDataPlane, CreateEnvironmentData, EnvDeletionEligibility, EnvironmentTemplate, Environment, EnvironmentInput, Logger, UpdateLogLevelInput } from '../../types/environment';
+import type { CloudDataPlane, CreateEnvironmentData, EnvDeletionEligibility, EnvironmentTemplate, Environment, EnvironmentInput, Logger, ProjectDeployedComponents, UpdateLogLevelInput } from '../../types/environment';
 import { toHandler } from '../../utils/string';
+import { appendEnvironmentToDefaultPipeline } from './deploymentPipelines';
 import { bff, items, q, seg, type ListResponse, type MessageResponse } from './_client';
-
-// The devops REST template/create/delete flow is a wip-only surface; cloud manages
-// environments through the BFF functions above.
-const ni = (name: string): never => {
-  throw new Error(`[cloud] environments.${name}: not implemented`);
-};
 
 // _orgUuid is kept for devant contract parity; cloud derives the org from the token.
 
@@ -93,15 +88,34 @@ export const fetchLoggers = (environmentId: string, componentId: string): Promis
 
 export const updateLogLevel = (input: UpdateLogLevelInput): Promise<{ success: boolean; message: string; commandIds: string[] }> => bff.put<{ success: boolean; message: string; commandIds: string[] }>(`/components/${seg(input.componentName)}/loggers`, input);
 
-// Every environment must bind to a data plane. This deployment registers data
-// planes cluster-scoped (ClusterDataPlane); there is no namespaced DataPlane for
-// OpenChoreo's empty-ref default to resolve, so omitting the ref fails with
-// "DataPlane not found". We name the conventional cluster data plane explicitly;
-// the BFF maps this name onto a ClusterDataPlane ref. Name is slugged to satisfy
-// the RFC 1123 metadata.name rule.
+// Every environment must bind to a data plane. Omitting the ref makes OpenChoreo
+// look for a DataPlane named "default" in the namespace and fail with "DataPlane
+// not found" when it is absent, so the name is always sent explicitly; the BFF
+// wraps it in a namespaced DataPlane ref (the kind `GET /dataplanes` lists). The
+// ref is immutable once set, so an environment bound to the wrong plane can only
+// be fixed by recreating it. Name is slugged to satisfy the RFC 1123
+// metadata.name rule.
 const DEFAULT_DATA_PLANE = 'default';
-export const createEnvironment = (input: EnvironmentInput): Promise<Environment> =>
-  bff.post<BffEnvironment>('/environments', { name: toHandler(input.name), displayName: input.name, description: input.description, isProduction: input.critical, dataPlaneRef: DEFAULT_DATA_PLANE }).then(toEnvironment);
+export const createEnvironment = async (input: EnvironmentInput, dataPlaneName?: string): Promise<Environment> => {
+  const created = await bff.post<BffEnvironment>('/environments', {
+    name: toHandler(input.name),
+    displayName: input.name,
+    description: input.description,
+    isProduction: input.critical,
+    dataPlaneRef: dataPlaneName || DEFAULT_DATA_PLANE,
+  });
+  const environment = toEnvironment(created);
+
+  // Best effort: an environment outside every promotion chain cannot be deployed
+  // to. The environment itself already exists at this point and the CD Pipelines
+  // editor is the recovery path, so a failure here must not read as a failed create.
+  try {
+    await appendEnvironmentToDefaultPipeline(environment.id);
+  } catch (err) {
+    console.warn(`[cloud] environment '${environment.id}' created but not added to the default pipeline`, err);
+  }
+  return environment;
+};
 
 // The BFF update accepts only displayName/description/isProduction — the slug
 // (name) is the immutable identity, so a rename edits the label only.
@@ -118,6 +132,42 @@ export const fetchEnvironmentTemplates = (_orgId: string): Promise<EnvironmentTe
     }),
   );
 
-export const createOrgEnvironment = (_orgUuid: string, _input: CreateEnvironmentData & { vhost: string }): Promise<void> => ni('createOrgEnvironment');
-export const getEnvDeleteEligibility = (_orgUuid: string, _templateId: string): Promise<EnvDeletionEligibility> => ni('getEnvDeleteEligibility');
-export const deleteEnvironmentTemplate = (_orgUuid: string, _templateId: string): Promise<void> => ni('deleteEnvironmentTemplate');
+// The org-environment surface is what the Environments settings page drives. In
+// cloud it is the same BFF environment, so this maps onto createEnvironment
+// rather than the devops REST flow. `dnsPrefix`/`vhost` have no OpenChoreo
+// counterpart — the gateway host is fixed at deploy time — and are ignored.
+export const createOrgEnvironment = async (_orgUuid: string, input: CreateEnvironmentData & { vhost: string }): Promise<void> => {
+  await createEnvironment({ name: input.name, description: input.description ?? '', critical: input.isProd }, input.dataplaneId);
+};
+
+// An environment template id is the environment slug (see fetchEnvironmentTemplates).
+export const deleteEnvironmentTemplate = async (_orgUuid: string, templateId: string): Promise<void> => {
+  await deleteEnvironment(templateId);
+};
+
+// OpenChoreo has no "what is deployed here" query, so eligibility is derived by
+// walking projects -> components -> that component's deployment in this
+// environment. That is O(projects + components) requests, which is acceptable on
+// a settings page opened on demand. Deleting an Environment cascades and takes
+// running workloads with it, so a component that fails to report is treated as
+// deployed rather than waved through.
+export const getEnvDeleteEligibility = async (_orgUuid: string, templateId: string): Promise<EnvDeletionEligibility> => {
+  const projects = items(await bff.get<ListResponse<{ name: string; displayName?: string }>>('/projects'));
+
+  const deployedComponentsDetails = (
+    await Promise.all(
+      projects.map(async (project): Promise<ProjectDeployedComponents> => {
+        const components = items(await bff.get<ListResponse<{ name: string; displayName?: string }>>(`/projects/${seg(project.name)}/components`));
+        const deployed = await Promise.all(
+          components.map(async (component) => {
+            const deployment = await bff.get<{ environmentId?: string } | null>(`/components/${seg(component.name)}/deployments${q({ environmentId: templateId })}`);
+            return deployment ? { componentId: component.name, componentName: component.displayName || component.name } : null;
+          }),
+        );
+        return { projectId: project.name, projectName: project.displayName || project.name, components: deployed.filter((c) => c != null) };
+      }),
+    )
+  ).filter((p) => (p.components?.length ?? 0) > 0);
+
+  return { templateId, envName: templateId, deletable: deployedComponentsDetails.length === 0, deployedComponentsDetails };
+};

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -145,29 +145,70 @@ export const deleteEnvironmentTemplate = async (_orgUuid: string, templateId: st
   await deleteEnvironment(templateId);
 };
 
+/** A `{ name, displayName }` BFF row — projects and components share the shape here. */
+interface BffNamed {
+  name: string;
+  displayName?: string;
+}
+
+/**
+ * Stands in for a component whose deployment state could not be read. It has to
+ * be a real entry in `deployedComponentsDetails`, not just `deletable: false`,
+ * because the delete dialog gates its confirm button on that list alone.
+ */
+const UNVERIFIED_COMPONENT = 'unknown (deployment state could not be read)';
+
+/** Components of `project` deployed to `environmentId`. Never rejects. */
+const deployedInProject = async (project: BffNamed, environmentId: string): Promise<ProjectDeployedComponents> => {
+  const detail = { projectId: project.name, projectName: project.displayName || project.name };
+
+  let components: BffNamed[];
+  try {
+    components = items(await bff.get<ListResponse<BffNamed>>(`/projects/${seg(project.name)}/components`));
+  } catch {
+    return { ...detail, components: [{ componentName: UNVERIFIED_COMPONENT }] };
+  }
+
+  const deployed = await Promise.all(
+    components.map(async (component) => {
+      const entry = { componentId: component.name, componentName: component.displayName || component.name };
+      try {
+        // "Not deployed" is 200 with a null body, so only a genuine failure lands
+        // in the catch — an unreadable component is unknown, not empty.
+        return (await bff.get<unknown>(`/components/${seg(component.name)}/deployments${q({ environmentId })}`)) ? entry : null;
+      } catch {
+        return entry;
+      }
+    }),
+  );
+  return { ...detail, components: deployed.filter((c) => c != null) };
+};
+
 // OpenChoreo has no "what is deployed here" query, so eligibility is derived by
 // walking projects -> components -> that component's deployment in this
 // environment. That is O(projects + components) requests, which is acceptable on
-// a settings page opened on demand. Deleting an Environment cascades and takes
-// running workloads with it, so a component that fails to report is treated as
-// deployed rather than waved through.
+// a settings page opened on demand.
+//
+// Deleting an Environment cascades and takes running workloads with it, so this
+// fails closed: anything that cannot be verified is reported as deployed. That
+// also means the function must never reject — a rejected query leaves the dialog
+// with no data at all, which it reads as "nothing deployed" and enables delete.
 export const getEnvDeleteEligibility = async (_orgUuid: string, templateId: string): Promise<EnvDeletionEligibility> => {
-  const projects = items(await bff.get<ListResponse<{ name: string; displayName?: string }>>('/projects'));
+  const blockAll = (reason: string): EnvDeletionEligibility => ({
+    templateId,
+    envName: templateId,
+    deletable: false,
+    deployedComponentsDetails: [{ projectName: reason, components: [{ componentName: UNVERIFIED_COMPONENT }] }],
+  });
 
-  const deployedComponentsDetails = (
-    await Promise.all(
-      projects.map(async (project): Promise<ProjectDeployedComponents> => {
-        const components = items(await bff.get<ListResponse<{ name: string; displayName?: string }>>(`/projects/${seg(project.name)}/components`));
-        const deployed = await Promise.all(
-          components.map(async (component) => {
-            const deployment = await bff.get<{ environmentId?: string } | null>(`/components/${seg(component.name)}/deployments${q({ environmentId: templateId })}`);
-            return deployment ? { componentId: component.name, componentName: component.displayName || component.name } : null;
-          }),
-        );
-        return { projectId: project.name, projectName: project.displayName || project.name, components: deployed.filter((c) => c != null) };
-      }),
-    )
-  ).filter((p) => (p.components?.length ?? 0) > 0);
+  let projects: BffNamed[];
+  try {
+    projects = items(await bff.get<ListResponse<BffNamed>>('/projects'));
+  } catch {
+    return blockAll('All projects');
+  }
+
+  const deployedComponentsDetails = (await Promise.all(projects.map((project) => deployedInProject(project, templateId)))).filter((p) => (p.components?.length ?? 0) > 0);
 
   return { templateId, envName: templateId, deletable: deployedComponentsDetails.length === 0, deployedComponentsDetails };
 };

--- a/ipaas/src/api/cloud/projects.ts
+++ b/ipaas/src/api/cloud/projects.ts
@@ -92,7 +92,10 @@ const toBffCreateMonoRepoProjectBody = async (input: CreateMonoRepoProjectInput)
 
 export const createProject = async (input: CreateProjectInput): Promise<Project> => bff.post<Project>('/projects', await toBffCreateProjectBody(input));
 
-export const updateProject = (input: UpdateProjectInput): Promise<Project> => bff.put<Project>(`/projects/${seg(input.id)}`, { name: input.name, description: input.description, version: input.version });
+// The BFF update takes `displayName` — `name` is the immutable K8s metadata.name
+// and is not a settable field, so sending it here silently dropped the rename.
+// `version` has no OpenChoreo counterpart and is ignored upstream.
+export const updateProject = (input: UpdateProjectInput): Promise<Project> => bff.put<Project>(`/projects/${seg(input.id)}`, { displayName: input.name, description: input.description });
 
 export const deleteProject = (projectId: string): Promise<void> => bff.delete<void>(`/projects/${seg(projectId)}`);
 

--- a/ipaas/src/hooks/useEnvironments.ts
+++ b/ipaas/src/hooks/useEnvironments.ts
@@ -92,7 +92,13 @@ export function useAddEnvironment() {
       const { orgUuid, ...request } = input;
       return createOrgEnvironment(orgUuid, request);
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['environment-templates'] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['environment-templates'] });
+      // In cloud a template *is* an environment, so the environment lists and the
+      // pipeline the new environment was appended to go stale too.
+      qc.invalidateQueries({ queryKey: ['environments'] });
+      qc.invalidateQueries({ queryKey: ['deploymentPipelines'] });
+    },
   });
 }
 
@@ -109,6 +115,9 @@ export function useDeleteEnvironmentTemplate() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (input: { orgUuid: string; templateId: string }) => deleteEnvironmentTemplate(input.orgUuid, input.templateId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['environment-templates'] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['environment-templates'] });
+      qc.invalidateQueries({ queryKey: ['environments'] });
+    },
   });
 }

--- a/ipaas/src/pages/CreateEnvironment.tsx
+++ b/ipaas/src/pages/CreateEnvironment.tsx
@@ -23,6 +23,7 @@ import { useNavigate } from 'react-router';
 import { useDataPlanes } from '../hooks/useDataPlanes';
 import { useAddEnvironment } from '../hooks/useEnvironments';
 import { useOrgUuid } from '../hooks/useOrgUuid';
+import { IS_CLOUD } from '../features';
 import { buildEnvironmentVhost, EnvironmentValidationError } from '../utils/environment';
 import { resourceUrl, type OrgScope } from '../nav';
 
@@ -34,6 +35,7 @@ export default function CreateEnvironment(scope: OrgScope): JSX.Element {
   const create = useAddEnvironment();
 
   const [name, setName] = useState('My-New-Environment');
+  const [description, setDescription] = useState('');
   const [dnsPrefix, setDnsPrefix] = useState('my-env');
   const [dataplaneId, setDataplaneId] = useState('');
   const [critical, setCritical] = useState(false);
@@ -44,8 +46,10 @@ export default function CreateEnvironment(scope: OrgScope): JSX.Element {
     if (dataPlanes.length) setDataplaneId((prev) => (prev && dataPlanes.some((d) => d.id === prev) ? prev : dataPlanes[0].id));
   }, [dataPlanes]);
 
+  // OpenChoreo derives no per-environment hostname — the gateway host is fixed at
+  // deploy time — so cloud collects a description instead of a DNS prefix.
   const selectedDataPlane = useMemo(() => dataPlanes.find((d) => d.id === dataplaneId), [dataPlanes, dataplaneId]);
-  const vhostPreview = orgUuid && dnsPrefix.trim() ? buildEnvironmentVhost(orgUuid, dnsPrefix.trim(), selectedDataPlane?.externalGatewayVirtualHost) : '';
+  const vhostPreview = !IS_CLOUD && orgUuid && dnsPrefix.trim() ? buildEnvironmentVhost(orgUuid, dnsPrefix.trim(), selectedDataPlane?.externalGatewayVirtualHost) : '';
 
   const submit = () => {
     setError(null);
@@ -54,7 +58,15 @@ export default function CreateEnvironment(scope: OrgScope): JSX.Element {
       return;
     }
     create.mutate(
-      { orgUuid, name: name.trim(), dataplaneId, dnsPrefix: dnsPrefix.trim(), isProd: critical, vhost: buildEnvironmentVhost(orgUuid, dnsPrefix.trim(), selectedDataPlane?.externalGatewayVirtualHost) },
+      {
+        orgUuid,
+        name: name.trim(),
+        dataplaneId,
+        dnsPrefix: dnsPrefix.trim(),
+        isProd: critical,
+        vhost: IS_CLOUD ? '' : buildEnvironmentVhost(orgUuid, dnsPrefix.trim(), selectedDataPlane?.externalGatewayVirtualHost),
+        ...(IS_CLOUD ? { description: description.trim() } : {}),
+      },
       {
         onSuccess: () => navigate(listUrl, { state: { success: true, environmentName: name.trim() } }),
         onError: (err) => {
@@ -68,7 +80,7 @@ export default function CreateEnvironment(scope: OrgScope): JSX.Element {
     );
   };
 
-  const canSubmit = !!name.trim() && !!dnsPrefix.trim() && !!dataplaneId && !create.isPending;
+  const canSubmit = !!name.trim() && (IS_CLOUD || !!dnsPrefix.trim()) && !!dataplaneId && !create.isPending;
 
   return (
     <PageContent>
@@ -117,14 +129,18 @@ export default function CreateEnvironment(scope: OrgScope): JSX.Element {
             </Select>
           )}
         </Box>
-        <Box>
-          <TextField label="DNS Prefix" required placeholder="e.g., staging" value={dnsPrefix} onChange={(e) => setDnsPrefix(e.target.value)} fullWidth />
-          {vhostPreview && (
-            <Alert severity="info" sx={{ mt: 1.5 }}>
-              DNS for the environment will be created as {vhostPreview}. URL customization will be enabled for the new environment after provisioning, which can take about 5 minutes.
-            </Alert>
-          )}
-        </Box>
+        {IS_CLOUD ? (
+          <TextField label="Description" placeholder="What this environment is for" value={description} onChange={(e) => setDescription(e.target.value)} fullWidth multiline minRows={2} />
+        ) : (
+          <Box>
+            <TextField label="DNS Prefix" required placeholder="e.g., staging" value={dnsPrefix} onChange={(e) => setDnsPrefix(e.target.value)} fullWidth />
+            {vhostPreview && (
+              <Alert severity="info" sx={{ mt: 1.5 }}>
+                DNS for the environment will be created as {vhostPreview}. URL customization will be enabled for the new environment after provisioning, which can take about 5 minutes.
+              </Alert>
+            )}
+          </Box>
+        )}
         <FormControlLabel control={<Checkbox checked={critical} onChange={(_, v) => setCritical(v)} />} label="Mark as Critical Environment" />
       </Stack>
 

--- a/ipaas/src/types/environment.ts
+++ b/ipaas/src/types/environment.ts
@@ -70,6 +70,8 @@ export interface CreateEnvironmentData {
   dataplaneId: string;
   dnsPrefix: string;
   isProd: boolean;
+  /** Cloud only — OpenChoreo stores it as an annotation; the devops API has no such field. */
+  description?: string;
 }
 
 export interface DeployedComponent {


### PR DESCRIPTION
Creating an environment failed in the cloud (OpenChoreo) variant because the Create Environment page is wired to createOrgEnvironment(), whose cloud implementation was an ni() stub that throws. The working BFF-backed createEnvironment() next to it was never called by anything. The page caught the throw and rendered the generic "Failed to create the environment".

Implement the org-environment surface on top of createEnvironment, passing the data plane selected in the form. dnsPrefix/vhost have no OpenChoreo counterpart (the gateway host is fixed at deploy time), so the form now collects a description instead when running as cloud.

A newly created environment that sits outside every promotion chain can never be promoted into, so append it to the default pipeline's terminal environment. This is best effort: the environment already exists by then and the CD Pipelines editor is the recovery path, so a failure must not read as a failed create. A pipeline that is empty or branches into several terminals is left alone rather than guessing where to insert.

Also wire environment delete, which was backed by two more ni() stubs so the delete dialog threw on open. Eligibility is derived by walking projects -> components -> that component's deployment in this environment; deleting an Environment cascades and takes running workloads with it, so a component that fails to report is treated as deployed rather than waved through.

Finally, updateProject sent `name`, which the BFF has no field for — the rename silently no-oped. Send displayName instead.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.