### PR TITLE
[Devant migration] Send sourceEnvironmentId when promoting in the cloud variant

### DIFF
--- a/ipaas/src/components/EnvironmentCard/PromoteButton.tsx
+++ b/ipaas/src/components/EnvironmentCard/PromoteButton.tsx
@@ -22,6 +22,7 @@ import type { ReactNode } from 'react';
 import { useComponentDeployment } from '../../hooks/useDeployments';
 import { usePromote } from '../../hooks/useDeployments';
 import { useOrgUuid } from '../../hooks/useOrgUuid';
+import { IS_CLOUD } from '../../features';
 import Authorized from '../Authorized';
 import { Permissions } from '../../constants/permissions';
 
@@ -48,14 +49,19 @@ export default function PromoteButton({ orgHandler, componentId, versionId, depl
   const sourceReleaseId = sourceDeployment?.releaseId;
   const alreadyPromoted = !deploymentsLoading && !!buildId && buildId === targetDeployment?.build?.buildId;
 
+  const missingPipeline = IS_CLOUD && !deploymentPipelineId;
+  const canPromote = !!buildId && !!sourceReleaseId && !missingPipeline && !alreadyPromoted;
+
   const handlePromote = () => {
-    if (!buildId || !sourceReleaseId || alreadyPromoted) return;
+    if (!canPromote || !sourceReleaseId) return;
     onPromoteStarted?.();
     promote.mutate(
       {
         componentId,
         apiVersionId: versionId,
         sourceReleaseId,
+        // The BFF validates this source→target hop against the pipeline's promotion paths.
+        sourceEnvironmentId: sourceEnvId,
         targetEnvironmentId: targetEnvId,
         deploymentPipelineId,
       },
@@ -63,13 +69,13 @@ export default function PromoteButton({ orgHandler, componentId, versionId, depl
     );
   };
 
-  const tooltipTitle = !buildId ? 'No build available to promote' : alreadyPromoted ? 'Already deployed in target environment' : '';
+  const tooltipTitle = !buildId ? 'No build available to promote' : alreadyPromoted ? 'Already deployed in target environment' : missingPipeline ? 'No deployment pipeline configured for this project' : '';
 
   return (
     <Authorized permissions={Permissions.ENVIRONMENT_MANAGE}>
       <Tooltip title={tooltipTitle}>
         <span>
-          <Button variant="outlined" size="small" startIcon={icon ?? <ArrowDown size={14} />} disabled={deploymentsLoading || !buildId || !sourceReleaseId || alreadyPromoted || promote.isPending} onClick={handlePromote}>
+          <Button variant="outlined" size="small" startIcon={icon ?? <ArrowDown size={14} />} disabled={deploymentsLoading || !canPromote || promote.isPending} onClick={handlePromote}>
             {promote.isPending ? 'Promoting…' : 'Promote'}
           </Button>
         </span>

--- a/ipaas/src/types/deployment.ts
+++ b/ipaas/src/types/deployment.ts
@@ -128,6 +128,7 @@ export interface PromoteInput {
   componentId: string;
   apiVersionId: string;
   sourceReleaseId: string;
+  sourceEnvironmentId: string;
   targetEnvironmentId: string;
   deploymentPipelineId: string;
 }


### PR DESCRIPTION
## Purpose
Promoting between environments failed with 400 "deploymentPipelineId, sourceEnvironmentId, targetEnvironmentId, and sourceReleaseId are required". The cloud BFF needs the source environment to validate the source->target hop against the deployment pipeline's promotion paths, but PromoteInput had no such field, and promote() posts the input object verbatim.

The type was authored against the wip GraphQL contract, whose Promote input derives the source from sourceReleaseId and genuinely does not take a source environment, so the cloud slice inherited a shape that is a strict subset of what the BFF requires. PromoteButton already had sourceEnvId as a prop and used it to fetch the source deployment — it just never reached the payload.

The field is inert outside cloud: the wip mutation builds its promoteSchema field by field and does not forward it, and icp's promote is a stub.

Also disable the button when the project has no pipeline ref, since the BFF rejects an empty deploymentPipelineId with the same 400. That guard is cloud-only — wip passes the id into a GraphQL Promote! input whose empty-value behaviour is the devant backend's to define, and gating avoids newly disabling a button that works there today.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.