### PR TITLE
Sync 1.2.x with support-1.2.0.x-full: faulty data services support and startup login URL fix

### DIFF
--- a/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
+++ b/components/org.wso2.ei.dashboard.bootstrap/src/main/java/org/wso2/ei/dashboard/bootstrap/DashboardServer.java
@@ -83,6 +83,7 @@ public class DashboardServer {
     private static final String SECURITY_DIR = "security";
     private static final String TOML_CONF_PORT = "server_config.port";
     private static final String TOML_CONF_PROTOCOL = "server_config.protocol";
+    private static final String TOML_CONF_HOSTNAME = "server_config.hostname";
     private static final String TOML_MI_USERNAME = "mi_super_admin.username";
     private static final String TOML_MI_PASSWORD = "mi_super_admin.password";
     private static final String MI_USERNAME = "mi_username";
@@ -134,12 +135,14 @@ public class DashboardServer {
     public void startServerWithConfigs() {
         int serverPort = 9743;
         String serverProtocol = HTTPS_PROTOCOL;
+        String serverHostName = null;
         String tomlFilePath = DASHBOARD_HOME + File.separator + CONF_DIR + File.separator + DEPLOYMENT_TOML;
 
         try {
             Map<String, Object> parsedConfigs = parseConfigJS(tomlFilePath);
             serverPort = getServerPort(parsedConfigs, serverPort);
             serverProtocol = getServerProtocol(parsedConfigs);
+            serverHostName = getServerHostName(parsedConfigs);
 
             initSecureVault(parsedConfigs);
             loadConfigurations(parsedConfigs);
@@ -156,7 +159,7 @@ public class DashboardServer {
         Server server = new Server();
         configureServer(server, serverPort, serverProtocol);
         try {
-            startAndMonitorServer(server, serverPort, serverProtocol);
+            startAndMonitorServer(server, serverPort, serverProtocol, serverHostName);
         } catch (Exception ex) {
             logger.error("Error while starting up the server", ex);
         }
@@ -169,6 +172,17 @@ public class DashboardServer {
             return ((Long) serverPortConfig).intValue();
         }
         return defaultPort;
+    }
+
+    private String getServerHostName(Map<String, Object> parsedConfigs) {
+        Object serverHostNameConfig = parsedConfigs.get(TOML_CONF_HOSTNAME);
+        if (serverHostNameConfig instanceof String) {
+            String hostName = ((String) serverHostNameConfig).trim();
+            if (!hostName.isEmpty()) {
+                return hostName;
+            }
+        }
+        return null;
     }
 
     private String getServerProtocol(Map<String, Object> parsedConfigs) throws ConfigParserException {
@@ -195,10 +209,11 @@ public class DashboardServer {
         addShutdownHook();
     }
 
-    private void startAndMonitorServer(Server server, int serverPort, String serverProtocol) throws Exception {
+    private void startAndMonitorServer(Server server, int serverPort, String serverProtocol, String serverHostName)
+            throws Exception {
         server.start();
         writePID(DASHBOARD_HOME);
-        printServerStartupLog(serverPort, serverProtocol);
+        printServerStartupLog(serverPort, serverProtocol, serverHostName);
         server.join();
     }
 
@@ -283,14 +298,16 @@ public class DashboardServer {
         server.setHandler(handlers);
     }
 
-    private void printServerStartupLog(int serverPort, String serverProtocol) {
+    private void printServerStartupLog(int serverPort, String serverProtocol, String serverHostName) {
         InetAddress localHost;
-        String hostName;
-        try {
-            localHost = InetAddress.getLocalHost();
-            hostName = localHost.getHostName();
-        } catch (UnknownHostException e) {
-            hostName = "127.0.0.1";
+        String hostName = serverHostName;
+        if (hostName == null) {
+            try {
+                localHost = InetAddress.getLocalHost();
+                hostName = localHost.getHostName();
+            } catch (UnknownHostException e) {
+                hostName = "127.0.0.1";
+            }
         }
         String loginUrl = serverProtocol + "://" + hostName + ":" + serverPort + "/login";
         logger.info("WSO2 Integration Control Plane started.");

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/GroupsApi.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/GroupsApi.java
@@ -43,6 +43,7 @@ import org.wso2.ei.dashboard.core.rest.model.AddUserRequest;
 import org.wso2.ei.dashboard.core.rest.model.ArtifactUpdateRequest;
 import org.wso2.ei.dashboard.core.rest.model.ArtifactsResourceResponse;
 import org.wso2.ei.dashboard.core.rest.model.CAppArtifacts;
+import org.wso2.ei.dashboard.core.rest.model.DataServiceFaultDetails;
 import org.wso2.ei.dashboard.core.rest.model.DatasourceList;
 import org.wso2.ei.dashboard.core.rest.model.Error;
 import org.wso2.ei.dashboard.core.rest.model.GroupList;
@@ -427,6 +428,32 @@ public class GroupsApi {
         CarbonAppsDelegate cappsDelegate = new CarbonAppsDelegate();
         CAppArtifacts cAppArtifactList = cappsDelegate.getCAppArtifactList(groupId, nodeId, cappName);
         ResponseBuilder responseBuilder = Response.ok().entity(cAppArtifactList);
+        HttpUtils.setHeaders(responseBuilder);
+        return responseBuilder.build();
+    }
+
+    @GET
+    @Path("/{group-id}/nodes/{node-id}/data-services/{service-name}/faultDetails")
+    @Produces({"application/json"})
+    @Operation(summary = "Get fault details of a faulty data service by node id", description = "",
+            tags = {"data-services"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Fault details of the faulty data service",
+                    content = @Content(schema = @Schema(implementation = DataServiceFaultDetails.class))),
+            @ApiResponse(responseCode = "404", description = "Data service not found or not faulty",
+                    content = @Content(schema = @Schema(implementation = Error.class))),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(schema = @Schema(implementation = Error.class)))
+    })
+    public Response getDataServiceFaultDetails(
+            @PathParam("group-id") @Parameter(description = "Group ID of the node") String groupId,
+            @PathParam("node-id") @Parameter(description = "Node ID") String nodeId,
+            @PathParam("service-name") @Parameter(description = "Data service name") String serviceName)
+            throws ManagementApiException {
+        DataServicesDelegate dataServicesDelegate = new DataServicesDelegate();
+        DataServiceFaultDetails faultDetails = dataServicesDelegate.getDataServiceFaultDetails(groupId, nodeId, serviceName);
+        ResponseBuilder responseBuilder = Response.ok().entity(faultDetails);
         HttpUtils.setHeaders(responseBuilder);
         return responseBuilder.build();
     }

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/DataServiceFaultDetails.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/DataServiceFaultDetails.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+
+package org.wso2.ei.dashboard.core.rest.model;
+
+import javax.validation.Valid;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DataServiceFaultDetails {
+    private @Valid String serviceName = null;
+    private @Valid String errorMessage = null;
+    private @Valid String faultStackTrace = null;
+
+    public DataServiceFaultDetails serviceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("serviceName")
+    public String getServiceName() {
+        return serviceName;
+    }
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public DataServiceFaultDetails errorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("errorMessage")
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public DataServiceFaultDetails faultStackTrace(String faultStackTrace) {
+        this.faultStackTrace = faultStackTrace;
+        return this;
+    }
+
+    @ApiModelProperty(value = "")
+    @JsonProperty("faultStackTrace")
+    public String getFaultStackTrace() {
+        return faultStackTrace;
+    }
+    public void setFaultStackTrace(String faultStackTrace) {
+        this.faultStackTrace = faultStackTrace;
+    }
+
+    @Override
+    public boolean equals(java.lang.Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DataServiceFaultDetails dataServiceFaultDetails = (DataServiceFaultDetails) o;
+        return Objects.equals(serviceName, dataServiceFaultDetails.serviceName) &&
+                Objects.equals(errorMessage, dataServiceFaultDetails.errorMessage) &&
+                Objects.equals(faultStackTrace, dataServiceFaultDetails.faultStackTrace);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serviceName, errorMessage, faultStackTrace);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DataServiceFaultDetails {\n");
+        sb.append("    serviceName: ").append(toIndentedString(serviceName)).append("\n");
+        sb.append("    errorMessage: ").append(toIndentedString(errorMessage)).append("\n");
+        sb.append("    faultStackTrace: ").append(toIndentedString(faultStackTrace)).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/commons/DelegatesUtil.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/commons/DelegatesUtil.java
@@ -83,6 +83,10 @@ public class DelegatesUtil {
                 boolean isSIArtifact = isSIArtifact(artifactType);
                 if (artifactType.equals(Constants.CARBON_APPLICATIONS)) {
                     artifactDetails = getArtifactDetails(nodeId, artifact);
+                } else if (artifactType.equals(Constants.DATA_SERVICES)
+                        && artifact.has("status")
+                        && "faulty".equals(artifact.get("status").getAsString())) {
+                    artifactDetails = getArtifactDetails(nodeId, artifact);
                 } else if (isSIArtifact) {
                     artifactDetails = new ArtifactDetails();
                     artifactDetails.setNodeId(nodeId);
@@ -218,6 +222,21 @@ public class DelegatesUtil {
                 allCApps.add(app);
             }
             return allCApps;
+        } else if (type.equals(Constants.DATA_SERVICES)) {
+            JsonArray activeArray = artifacts.get("list").getAsJsonArray();
+            JsonArray allDS = new JsonArray();
+            for (JsonElement ds : activeArray) {
+                ds.getAsJsonObject().addProperty("status", "active");
+                allDS.add(ds);
+            }
+            if (artifacts.has("faultyList") && !artifacts.get("faultyList").isJsonNull()) {
+                JsonArray faultyArray = artifacts.get("faultyList").getAsJsonArray();
+                for (JsonElement ds : faultyArray) {
+                    ds.getAsJsonObject().addProperty("status", "faulty");
+                    allDS.add(ds);
+                }
+            }
+            return allDS;
         } else {
             return artifacts.get("list").getAsJsonArray();
         }

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/delegates/DataServicesDelegate.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/micro/integrator/delegates/DataServicesDelegate.java
@@ -20,16 +20,27 @@
 
 package org.wso2.ei.dashboard.micro.integrator.delegates;
 
+import com.google.gson.JsonObject;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.wso2.ei.dashboard.core.commons.Constants;
+import org.wso2.ei.dashboard.core.commons.utils.HttpUtils;
+import org.wso2.ei.dashboard.core.commons.utils.ManagementApiUtils;
+import org.wso2.ei.dashboard.core.data.manager.DataManager;
+import org.wso2.ei.dashboard.core.data.manager.DataManagerSingleton;
 import org.wso2.ei.dashboard.core.exception.ManagementApiException;
 import org.wso2.ei.dashboard.core.rest.delegates.ArtifactDelegate;
 import org.wso2.ei.dashboard.core.rest.model.Ack;
 import org.wso2.ei.dashboard.core.rest.model.ArtifactUpdateRequest;
 import org.wso2.ei.dashboard.core.rest.model.ArtifactsResourceResponse;
+import org.wso2.ei.dashboard.core.rest.model.DataServiceFaultDetails;
 import org.wso2.ei.dashboard.micro.integrator.commons.DelegatesUtil;
+import org.wso2.ei.dashboard.micro.integrator.commons.Utils;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -37,14 +48,42 @@ import java.util.List;
  */
 public class DataServicesDelegate implements ArtifactDelegate {
     private static final Log logger = LogFactory.getLog(DataServicesDelegate.class);
+    private final DataManager dataManager = DataManagerSingleton.getDataManager();
 
     @Override
-    public ArtifactsResourceResponse getPaginatedArtifactsResponse(String groupId, List<String> nodeList, 
-        String searchKey, String lowerLimit, String upperLimit, String order, String orderBy, String isUpdate) 
+    public ArtifactsResourceResponse getPaginatedArtifactsResponse(String groupId, List<String> nodeList,
+        String searchKey, String lowerLimit, String upperLimit, String order, String orderBy, String isUpdate)
         throws ManagementApiException {
         DelegatesUtil.logDebugLogs(Constants.DATA_SERVICES, groupId, lowerLimit, upperLimit, order, orderBy, isUpdate);
-        return DelegatesUtil.getPaginatedArtifactResponse(groupId, nodeList, Constants.DATA_SERVICES, 
+        return DelegatesUtil.getPaginatedArtifactResponse(groupId, nodeList, Constants.DATA_SERVICES,
             searchKey, lowerLimit, upperLimit, order, orderBy, isUpdate);
+    }
+
+    public DataServiceFaultDetails getDataServiceFaultDetails(String groupId, String nodeId, String serviceName)
+            throws ManagementApiException {
+        logger.debug("Fetching fault details for data service from management console");
+        String mgtApiUrl = ManagementApiUtils.getMgtApiUrl(groupId, nodeId);
+        String accessToken = dataManager.getAccessToken(groupId, nodeId);
+        try {
+            String encodedServiceName = URLEncoder.encode(serviceName, StandardCharsets.UTF_8.name()).replace("+", "%20");
+            String url = mgtApiUrl.concat("data-services/").concat(encodedServiceName).concat("/fault");
+            try (CloseableHttpResponse httpResponse = Utils.doGet(groupId, nodeId, accessToken, url)) {
+                int statusCode = httpResponse.getStatusLine().getStatusCode();
+                if (statusCode != 200) {
+                    throw new ManagementApiException(
+                            "Error while retrieving fault details for data service: upstream returned " + statusCode,
+                            statusCode);
+                }
+                JsonObject jsonResponse = HttpUtils.getJsonResponse(httpResponse);
+                DataServiceFaultDetails faultDetails = new DataServiceFaultDetails();
+                faultDetails.setServiceName(jsonResponse.has("serviceName") ? jsonResponse.get("serviceName").getAsString() : null);
+                faultDetails.setErrorMessage(jsonResponse.has("errorMessage") ? jsonResponse.get("errorMessage").getAsString() : null);
+                faultDetails.setFaultStackTrace(jsonResponse.has("faultStackTrace") ? jsonResponse.get("faultStackTrace").getAsString() : null);
+                return faultDetails;
+            }
+        } catch (IOException e) {
+            throw new ManagementApiException("Error while retrieving fault details for data service", 500);
+        }
     }
 
     @Override

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/TableRowCreator.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/TableRowCreator.js
@@ -72,7 +72,12 @@ export default function TableRowCreator(props) {
 
             // Proxy Services and dataservices
             case 'wsdlUrl':
-                return <TableCell><table>{data.nodes.map(node=><LinkCell data={node.details.wsdl1_1} />)}</table></TableCell>
+                return <TableCell><table>{data.nodes.map(node => node.details.wsdl1_1
+                    ? <LinkCell key={node.nodeId} data={node.details.wsdl1_1} />
+                    : <tr key={node.nodeId}><td>—</td></tr>
+                )}</table></TableCell>
+            case 'dsStatus':
+                return <TableCell><table>{data.nodes.map(node=><StatusIcon key={node.nodeId} status={node.details.status === 'faulty' ? 'disabled' : 'enabled'} />)}</table></TableCell>
 
             // Proxy Services
             case 'isRunning':

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/sideDrawers/DataServicesSideDrawer.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/commons/sideDrawers/DataServicesSideDrawer.js
@@ -19,6 +19,7 @@
  */
 
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
@@ -27,16 +28,44 @@ import { Table, TableCell, TableRow, TableBody } from '@material-ui/core';
 import HeadingSection from './commons/HeadingSection'
 import SourceViewSection from './commons/SourceViewSection'
 import Typography from '@material-ui/core/Typography';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import EnabledIcon from '@material-ui/icons/CheckCircleOutlineOutlined';
+import DisabledIcon from '@material-ui/icons/BlockOutlined';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import HTTPClient from '../../utils/HTTPClient';
 
 export default function DataServicesSideDrawer(props) {
+    const globalGroupId = useSelector(state => state.groupId);
     var nodeData = props.nodeData;
-    const artifactName = nodeData.details.serviceName;
+    const isFaulty = nodeData.details.status === 'faulty';
+    const artifactName = nodeData.details.serviceName || nodeData.details.name;
     const nodeId = nodeData.nodeId;
     const classes = useStyles();
+
+    if (isFaulty) {
+        return (
+            <div className={classes.root}>
+                <Grid container spacing={3}>
+                    <Grid item xs={12}>
+                        <HeadingSection name={artifactName} nodeId={nodeId} />
+                        <Paper className={classes.paper} elevation={0} square>
+                            <FaultyDataServiceDetailTable nodeData={nodeData.details} />
+                        </Paper>
+                        <Box pl={2} pr={2} pt={1}>
+                            <StackTraceSection
+                                groupId={globalGroupId}
+                                nodeId={nodeId}
+                                serviceName={artifactName}
+                            />
+                        </Box>
+                    </Grid>
+                </Grid>
+            </div>
+        );
+    }
 
     return (
         <div className={classes.root}>
@@ -65,6 +94,79 @@ export default function DataServicesSideDrawer(props) {
     );
 }
 
+function FaultyDataServiceDetailTable(props) {
+    const nodeData = props.nodeData;
+    return <Table>
+        <TableBody>
+            <TableRow>
+                <TableCell>Data Service Name</TableCell>
+                <TableCell>{nodeData.name}</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Status</TableCell>
+                <TableCell>
+                    <span style={{display:'flex', alignItems:'center', gap:4, color:'red'}}>
+                        <DisabledIcon fontSize="small"/> FAULTY
+                    </span>
+                </TableCell>
+            </TableRow>
+            {nodeData.errorMessage && (
+                <TableRow>
+                    <TableCell>Error Message</TableCell>
+                    <TableCell style={{color: 'red'}}>{nodeData.errorMessage}</TableCell>
+                </TableRow>
+            )}
+        </TableBody>
+    </Table>
+}
+
+function StackTraceSection({ groupId, nodeId, serviceName }) {
+    const [expanded, setExpanded] = React.useState(false);
+    const [stackTrace, setStackTrace] = React.useState(null);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState(null);
+    const [hasFetched, setHasFetched] = React.useState(false);
+
+    const handleChange = (event, isExpanded) => {
+        if (isExpanded && !hasFetched && !loading) {
+            setLoading(true);
+            setError(null);
+            HTTPClient.getDataServiceFaultDetails(groupId, nodeId, serviceName)
+                .then(res => {
+                    setStackTrace(res.data.faultStackTrace || null);
+                    setHasFetched(true);
+                    setLoading(false);
+                })
+                .catch(() => {
+                    setError('Failed to load stack trace.');
+                    setHasFetched(true);
+                    setLoading(false);
+                });
+        }
+        setExpanded(isExpanded);
+    };
+
+    return (
+        <ExpansionPanel expanded={expanded} onChange={handleChange}>
+            <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>Stack Trace</Typography>
+            </ExpansionPanelSummary>
+            <ExpansionPanelDetails>
+                {loading && <CircularProgress size={20} />}
+                {error && <Typography color="error">{error}</Typography>}
+                {!loading && !error && stackTrace && (
+                    <pre style={{ overflowX: 'auto', maxHeight: 300, fontSize: 12, width: '100%', whiteSpace: 'pre' }}>
+                        {stackTrace}
+                    </pre>
+                )}
+                {!loading && !error && !stackTrace && (
+                    <Typography variant="body2" color="textSecondary">No stack trace available.</Typography>
+                )}
+            </ExpansionPanelDetails>
+        </ExpansionPanel>
+    );
+}
+
 function DataServicesDetailTable(props) {
     const nodeData = props.nodeData;
     const wsdl1_1 = nodeData.wsdl1_1;
@@ -75,6 +177,14 @@ function DataServicesDetailTable(props) {
             <TableRow>
                 <TableCell>Data Service Name</TableCell>
                 <TableCell>{nodeData.serviceName}</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Status</TableCell>
+                <TableCell>
+                    <span style={{display:'flex', alignItems:'center', gap:4, color:'green'}}>
+                        <EnabledIcon fontSize="small"/> ACTIVE
+                    </span>
+                </TableCell>
             </TableRow>
             <TableRow>
                 <TableCell>WSDL 1.1</TableCell>

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/pages/DataServices.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/pages/DataServices.js
@@ -28,7 +28,8 @@ export default function DataServices() {
         headCells: [
             {id: 'name', label: 'Data Service Name'},
             {id: 'nodes', label: 'Nodes'},
-            {id: 'wsdlUrl', label: 'WSDL 1.1'}],
+            {id: 'wsdlUrl', label: 'WSDL 1.1'},
+            {id: 'dsStatus', label: 'Status'}],
         tableOrderBy: 'name'
     });
 

--- a/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/HTTPClient.js
+++ b/components/org.wso2.micro.integrator.dashboard.web/web-app/src/utils/HTTPClient.js
@@ -274,6 +274,11 @@ export default class HTTPClient {
         return this.getResource(resourcePath)
     }
 
+    static getDataServiceFaultDetails(groupId, nodeId, serviceName) {
+        const resourcePath = `${groupId}/${Constants.PREFIX_NODES}/${nodeId}/data-services/${encodeURIComponent(serviceName)}/faultDetails`
+        return this.getResource(resourcePath)
+    }
+
     static updateArtifact(groupId, pageId, payload) {
         const path = `/${Constants.PREFIX_GROUPS}/${groupId}/${pageId}`
         return this.patch(path, payload)


### PR DESCRIPTION
## Purpose

Sync the public `1.2.x` branch with the customer-patch branch `support-1.2.0.x-full` in the internal repo. Everything up to `6e1a79e6b` (Merge PR #29, secondary user stores) was already present on `1.2.x`; this brings across the two features merged to the support branch after that point.

## Goals

Bring `1.2.x` up to date with the following support-branch features:

| Feature | Support PR | Author |
|---|---|---|
| Faulty data services support in ICP | #30 | @DedunuKarunarathne |
| Fix ICP startup login URL hostname configuration | #33 | @chiranSachintha |

Release-plugin version-bump commits between them were intentionally not carried over.

## Approach

Two commits, one per feature, with `(cherry picked from ...)` provenance trailers pointing at the support-branch SHAs. Original authorship is preserved on both.

**1. Add faulty data services support to ICP** — squash of support commits `97a747cea` and `ab0e39926` (the latter is a review fixup on the former). Adds a `data-services/{service-name}/faultDetails` endpoint, a `DataServiceFaultDetails` model, faulty-list merging in `DelegatesUtil`, and a Status column plus fault-details panel in the Data Services UI.

**2. Fix ICP startup login URL hostname configuration** — support commit `c1526c838`, applied cleanly with no modification.

### One deliberate deviation

On the support branch, the faulty-**CApp** fault-details feature (`6bbf7d9ba`, "Show faulty capp error stack trace in ICP") sits immediately adjacent to this code in `GroupsApi.java` and `HTTPClient.js`. That feature is **not** present on `1.2.x`, so the `CAppFaultDetails` endpoint and its client method were left out of the conflict resolutions here; only the data-services parts were taken. This follows existing practice on this branch (cf. "Remove delete-logger endpoints not yet available on 1.2.x").

Worth noting separately: the faulty-CApp feature predates the sync cutoff yet never landed on `1.2.x`, so it remains out of sync and may warrant a follow-up PR.

## User stories

N/A — direct port of already-reviewed support-branch features.

## Release note

- Faulty data services are now listed in the ICP dashboard with a status indicator and their fault details.
- Fixed the hostname used in the ICP startup login URL.

## Documentation

N/A — these changes were already reviewed and merged on the internal support branch; no new doc impact beyond what those PRs covered.

## Training

N/A

## Certification

N/A — no certification impact; this is a branch sync of existing reviewed features.

## Marketing

N/A

## Automation tests

- Unit tests
  > No new tests added; this is a port of already-reviewed commits. No test changes were present in the source PRs.
- Integration tests
  > None added, as above.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? no — port of previously reviewed code, no new security surface beyond a read-only GET endpoint
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

- `wso2-enterprise/integration-control-plane` PR #30 — Add faulty data services support to ICP
- `wso2-enterprise/integration-control-plane` PR #33 — Fix ICP startup login URL hostname configuration

## Migrations (if applicable)

N/A — no schema or config migration required.

## Test environment

Verified that the affected Java modules compile against `1.2.x`:

```
mvn -o -pl components/org.wso2.ei.dashboard.core,components/org.wso2.ei.dashboard.bootstrap -am compile
=> BUILD SUCCESS
```

Frontend changes were not built locally (no `node_modules`; the web app targets Node 14 while the local toolchain is Node 24) — CI should be relied on for the web-app build. All symbols the changed frontend files reference were verified to exist on `1.2.x`: `StatusIcon` (handles the `enabled`/`disabled` states the new `dsStatus` column maps onto), `HeadingSection`, `SourceViewSection`, and `ExpansionPanel` (valid for the pinned `@material-ui/core` v4).

## Learning

N/A
