### PR TITLE
[devant-migration] Fix data-fetch waterfalls across integration detail pages

### DIFF
--- a/ipaas/src/pages/AutomationTest.tsx
+++ b/ipaas/src/pages/AutomationTest.tsx
@@ -58,17 +58,15 @@ export default function AutomationTest({ org, project, component }: ComponentSco
   const { projectId } = useProjectId(project);
   const { data: comp, isLoading } = useComponentByHandler(projectId, component);
 
+  // Derived rather than synced via an effect — an effect+render round trip here would delay
+  // useComponentDeployment/useRuntimeArguments/useTaskExecutions below from becoming enabled.
   const tracks = useMemo(() => comp?.deploymentTracks ?? [], [comp?.deploymentTracks]);
-  const [trackId, setTrackId] = useState('');
-  useEffect(() => {
-    if (tracks.length) setTrackId((prev) => (prev && tracks.some((t) => t.id === prev) ? prev : (tracks.find((t) => t.latest)?.id ?? tracks[0].id)));
-  }, [tracks]);
+  const [trackIdState, setTrackId] = useState('');
+  const trackId = tracks.some((t) => t.id === trackIdState) ? trackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: environments = [] } = useEnvironments(org, projectId);
-  const [envId, setEnvId] = useState('');
-  useEffect(() => {
-    if (environments.length) setEnvId((prev) => (prev && environments.some((e) => e.id === prev) ? prev : environments[0].id));
-  }, [environments]);
+  const [envIdState, setEnvId] = useState('');
+  const envId = environments.some((e) => e.id === envIdState) ? envIdState : (environments[0]?.id ?? '');
 
   const { data: deployment } = useComponentDeployment(org, orgUuid ?? '', comp?.id ?? '', trackId, envId);
   const releaseId = deployment?.releaseId ?? '';

--- a/ipaas/src/pages/Component.tsx
+++ b/ipaas/src/pages/Component.tsx
@@ -80,16 +80,12 @@ export default function Component(scope: ComponentScope): JSX.Element {
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
   const [selectedTrackId, setSelectedTrackId] = useState('');
 
-  // Initialise / sync selected track when component loads or tracks change
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => {
-      if (prev && tracks.some((t) => t.id === prev)) return prev;
-      return tracks.find((t) => t.latest)?.id ?? tracks[0].id;
-    });
-  }, [component?.id, tracks]);
-
-  const versionId = selectedTrackId;
+  // Derived rather than synced via an effect: the version-scoped queries below (endpoints,
+  // deployment status) key off this, and waiting for an effect + extra render to set it would
+  // add a full round trip to the waterfall before those queries could even become enabled.
+  // Falls back to the latest track whenever the current selection isn't valid for these tracks
+  // (initial mount, or a stale id left over from a previously viewed component).
+  const versionId = tracks.some((t) => t.id === selectedTrackId) ? selectedTrackId : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: endpoints = [] } = useComponentEndpoints(component?.id ?? '', versionId);
   const apimId = IS_WIP ? (endpoints.find((e) => e.apimId)?.apimId ?? null) : null;

--- a/ipaas/src/pages/ComponentApiInfo.tsx
+++ b/ipaas/src/pages/ComponentApiInfo.tsx
@@ -17,7 +17,7 @@
  */
 
 import { Alert, Box, CircularProgress, Divider, MenuItem, PageContent, Select, Tab, Tabs, Typography } from '@wso2/oxygen-ui';
-import { useEffect, useMemo, useState, type JSX } from 'react';
+import { useMemo, useState, type JSX } from 'react';
 import NotFound from '../components/NotFound';
 import DeploymentTrackBar from '../components/DeploymentTrackBar';
 import MarketplaceTab from '../components/ApiInfo/MarketplaceTab';
@@ -66,31 +66,17 @@ export default function ComponentApiInfo(scope: ComponentScope): JSX.Element {
 
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
   const aggregatedTracks = useMemo(() => aggregateByMajorVersion(tracks), [tracks]);
-  const [selectedTrackId, setSelectedTrackId] = useState('');
-
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => {
-      if (prev && tracks.some((t) => t.id === prev)) return prev;
-      return tracks.find((t) => t.latest)?.id ?? tracks[0].id;
-    });
-  }, [component?.id, tracks]);
+  // Derived rather than synced via an effect — an effect+render round trip here would delay
+  // useComponentEndpoints/useApimApi below from becoming enabled. Falls back to the latest
+  // track/first endpoint whenever the current selection isn't valid for the current list.
+  const [selectedTrackIdState, setSelectedTrackId] = useState('');
+  const selectedTrackId = tracks.some((t) => t.id === selectedTrackIdState) ? selectedTrackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: endpoints = [] } = useComponentEndpoints(component?.id ?? '', selectedTrackId);
   const apimEndpoints = useMemo(() => Array.from(new Map(endpoints.filter((e) => e.apimId).map((e) => [e.apimId, e])).values()), [endpoints]);
 
-  const [selectedApimId, setSelectedApimId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!apimEndpoints.length) {
-      setSelectedApimId(null);
-      return;
-    }
-    setSelectedApimId((prev) => {
-      if (prev && apimEndpoints.some((e) => e.apimId === prev)) return prev;
-      return apimEndpoints[0].apimId ?? null;
-    });
-  }, [apimEndpoints]);
+  const [selectedApimIdState, setSelectedApimId] = useState<string | null>(null);
+  const selectedApimId = apimEndpoints.some((e) => e.apimId === selectedApimIdState) ? selectedApimIdState : (apimEndpoints[0]?.apimId ?? null);
 
   const selectedEndpoint = apimEndpoints.find((e) => e.apimId === selectedApimId) ?? null;
   const selectedTrack = tracks.find((t) => t.id === selectedTrackId) ?? null;

--- a/ipaas/src/pages/ComponentPlans.tsx
+++ b/ipaas/src/pages/ComponentPlans.tsx
@@ -91,31 +91,17 @@ export default function ComponentPlans(scope: ComponentScope): JSX.Element {
 
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
   const aggregatedTracks = useMemo(() => aggregateByMajorVersion(tracks), [tracks]);
-  const [selectedTrackId, setSelectedTrackId] = useState('');
-
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => {
-      if (prev && tracks.some((t) => t.id === prev)) return prev;
-      return tracks.find((t) => t.latest)?.id ?? tracks[0].id;
-    });
-  }, [component?.id, tracks]);
+  // Derived rather than synced via an effect — an effect+render round trip here would delay
+  // useComponentEndpoints/useApimApi below from becoming enabled. Falls back to the latest
+  // track/first endpoint whenever the current selection isn't valid for the current list.
+  const [selectedTrackIdState, setSelectedTrackId] = useState('');
+  const selectedTrackId = tracks.some((t) => t.id === selectedTrackIdState) ? selectedTrackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: endpoints = [] } = useComponentEndpoints(component?.id ?? '', selectedTrackId);
   const apimEndpoints = useMemo(() => Array.from(new Map(endpoints.filter((e) => e.apimId).map((e) => [e.apimId, e])).values()), [endpoints]);
 
-  const [selectedApimId, setSelectedApimId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!apimEndpoints.length) {
-      setSelectedApimId(null);
-      return;
-    }
-    setSelectedApimId((prev) => {
-      if (prev && apimEndpoints.some((e) => e.apimId === prev)) return prev;
-      return apimEndpoints[0].apimId ?? null;
-    });
-  }, [apimEndpoints]);
+  const [selectedApimIdState, setSelectedApimId] = useState<string | null>(null);
+  const selectedApimId = apimEndpoints.some((e) => e.apimId === selectedApimIdState) ? selectedApimIdState : (apimEndpoints[0]?.apimId ?? null);
 
   const { data: policies = [], isLoading: loadingPolicies } = useThrottlingPolicies();
   const { data: apimInfo, isLoading: loadingApim } = useApimApi(selectedApimId);

--- a/ipaas/src/pages/Lifecycle.tsx
+++ b/ipaas/src/pages/Lifecycle.tsx
@@ -35,24 +35,15 @@ export default function Lifecycle(scope: ComponentScope): JSX.Element {
   const { data: component, isLoading: loadingComponent } = useComponentByHandler(projectId, scope.component);
 
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
-  const [selectedTrackId, setSelectedTrackId] = useState('');
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => {
-      if (prev && tracks.some((t) => t.id === prev)) return prev;
-      return tracks.find((t) => t.latest)?.id ?? tracks[0].id;
-    });
-  }, [component?.id, tracks]);
+  // Derived rather than synced via an effect — an effect+render round trip here would delay
+  // useComponentEndpoints and the four hooks gated on selectedApimId below from becoming enabled.
+  const [selectedTrackIdState, setSelectedTrackId] = useState('');
+  const selectedTrackId = tracks.some((t) => t.id === selectedTrackIdState) ? selectedTrackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: endpoints = [], isLoading: loadingEndpoints } = useComponentEndpoints(component?.id ?? '', selectedTrackId);
 
-  const [selectedApimId, setSelectedApimId] = useState<string | null>(null);
-  useEffect(() => {
-    setSelectedApimId((prev) => {
-      if (prev && endpoints.some((e) => e.apimId === prev)) return prev;
-      return endpoints.find((e) => e.apimId)?.apimId ?? null;
-    });
-  }, [endpoints]);
+  const [selectedApimIdState, setSelectedApimId] = useState<string | null>(null);
+  const selectedApimId = endpoints.some((e) => e.apimId === selectedApimIdState) ? selectedApimIdState : (endpoints.find((e) => e.apimId)?.apimId ?? null);
 
   const endpointsWithApim = useMemo(() => {
     const seen = new Set<string>();

--- a/ipaas/src/pages/McpPolicies.tsx
+++ b/ipaas/src/pages/McpPolicies.tsx
@@ -48,13 +48,12 @@ export default function McpPolicies(scope: ComponentScope): JSX.Element {
   const { projectId, isLoading: loadingProject } = useProjectId(scope.project);
   const { data: component, isLoading: loadingComponent } = useComponentByHandler(projectId, scope.component);
 
-  // Track → endpoint → APIM id (same resolution as the overview/lifecycle pages).
+  // Track → endpoint → APIM id (same resolution as the overview/lifecycle pages). Derived
+  // rather than synced via an effect — an effect+render round trip here would delay
+  // useComponentEndpoints below from becoming enabled.
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
-  const [selectedTrackId, setSelectedTrackId] = useState('');
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => (prev && tracks.some((t) => t.id === prev) ? prev : (tracks.find((t) => t.latest)?.id ?? tracks[0].id)));
-  }, [component?.id, tracks]);
+  const [selectedTrackIdState, setSelectedTrackId] = useState('');
+  const selectedTrackId = tracks.some((t) => t.id === selectedTrackIdState) ? selectedTrackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
   const { data: endpoints = [], isLoading: loadingEndpoints } = useComponentEndpoints(component?.id ?? '', selectedTrackId);
   const apimId = useMemo(() => endpoints.find((e) => e.apimId)?.apimId ?? null, [endpoints]);

--- a/ipaas/src/pages/McpProxyFromApi.tsx
+++ b/ipaas/src/pages/McpProxyFromApi.tsx
@@ -55,15 +55,12 @@ export default function McpProxyFromApi(scope: ProjectScope): JSX.Element {
   const { data: sourceDetail, isLoading: loadingSource } = useComponentByHandler(projectId, sourceHandler ?? undefined);
   const versions = useMemo(() => sourceDetail?.apiVersions ?? [], [sourceDetail]);
 
-  // Which version of the source API to convert → its APIM API id. Defaults to
-  // the latest version, falling back to the one the flow was launched from.
-  const [selectedApiId, setSelectedApiId] = useState('');
-  useEffect(() => {
-    if (selectedApiId) return;
-    const pick = versions.find((v) => v.latest) ?? versions.find((v) => v.id === apimIdParam) ?? versions[0];
-    if (pick) setSelectedApiId(pick.id);
-    else if (apimIdParam) setSelectedApiId(apimIdParam);
-  }, [versions, apimIdParam, selectedApiId]);
+  // Which version of the source API to convert → its APIM API id. Defaults to the latest
+  // version, falling back to the one the flow was launched from. Derived rather than synced
+  // via an effect — an effect+render round trip here would delay useApimApi below.
+  const [selectedApiIdState, setSelectedApiId] = useState('');
+  const defaultApiId = (versions.find((v) => v.latest) ?? versions.find((v) => v.id === apimIdParam) ?? versions[0])?.id ?? apimIdParam ?? '';
+  const selectedApiId = selectedApiIdState || defaultApiId;
 
   const apimId = selectedApiId || apimIdParam || sourceDetail?.apiId || null;
   const { data: apiInfo, isLoading: loadingApi } = useApimApi(apimId);

--- a/ipaas/src/pages/TestConsole.tsx
+++ b/ipaas/src/pages/TestConsole.tsx
@@ -102,23 +102,15 @@ export default function TestConsole(scope: ComponentScope): JSX.Element {
   const { data: component, isLoading: loadingComponent } = useComponentByHandler(projectId, scope.component);
   const { data: environments = [] } = useEnvironments(scope.org, projectId);
 
-  // Deployment track selection (default to latest)
+  // Deployment track selection (default to latest) — derived rather than synced via an effect,
+  // since an effect+render round trip here would delay useComponentDeployment/useEnvEndpoints below.
   const tracks = useMemo(() => component?.deploymentTracks ?? [], [component?.deploymentTracks]);
-  const [selectedTrackId, setSelectedTrackId] = useState('');
-  useEffect(() => {
-    if (!tracks.length) return;
-    setSelectedTrackId((prev) => {
-      if (prev && tracks.some((t) => t.id === prev)) return prev;
-      return tracks.find((t) => t.latest)?.id ?? tracks[0].id;
-    });
-  }, [component?.id, tracks]);
+  const [selectedTrackIdState, setSelectedTrackId] = useState('');
+  const selectedTrackId = tracks.some((t) => t.id === selectedTrackIdState) ? selectedTrackIdState : (tracks.find((t) => t.latest)?.id ?? tracks[0]?.id ?? '');
 
-  // Environment selection (by ID for stability across refetches)
-  const [selectedEnvId, setSelectedEnvId] = useState('');
-  useEffect(() => {
-    if (!environments.length) return;
-    setSelectedEnvId((prev) => (prev && environments.some((e) => e.id === prev) ? prev : environments[0].id));
-  }, [environments]);
+  // Environment selection (by ID for stability across refetches) — same reasoning.
+  const [selectedEnvIdState, setSelectedEnvId] = useState('');
+  const selectedEnvId = environments.some((e) => e.id === selectedEnvIdState) ? selectedEnvIdState : (environments[0]?.id ?? '');
   const selectedEnv = environments.find((e) => e.id === selectedEnvId) ?? null;
 
   // Deployment for selected env (provides releaseId)
@@ -128,13 +120,10 @@ export default function TestConsole(scope: ComponentScope): JSX.Element {
   // Endpoints for the selected env + track
   const { data: endpoints = [], isLoading: loadingEndpoints } = useEnvEndpoints(component?.id ?? '', selectedTrackId, releaseId);
 
-  // Selected endpoint
-  const [selectedEndpointId, setSelectedEndpointId] = useState('');
-  useEffect(() => {
-    if (endpoints.length > 0 && (!selectedEndpointId || !endpoints.find((e) => e.id === selectedEndpointId))) {
-      setSelectedEndpointId(endpoints[0].id);
-    }
-  }, [endpoints, selectedEndpointId]);
+  // Selected endpoint — derived rather than synced via an effect, since useApimSwagger below
+  // keys off selectedEndpoint and an effect+render round trip would delay it becoming enabled.
+  const [selectedEndpointIdState, setSelectedEndpointId] = useState('');
+  const selectedEndpointId = endpoints.some((e) => e.id === selectedEndpointIdState) ? selectedEndpointIdState : (endpoints[0]?.id ?? '');
   const selectedEndpoint = endpoints.find((e) => e.id === selectedEndpointId) ?? null;
 
   // Visibility options for selected endpoint


### PR DESCRIPTION
## Purpose
> $subject

Several pages synced a "selected track/environment/endpoint" id via
  useState + useEffect once its parent list loaded, then used that id
  to gate downstream queries (endpoints, deployment status, APIM info,
  lifecycle, swagger, runtime arguments). The effect added a guaranteed
  extra render round-trip before those queries could even become
  enabled, compounding with the rest of each page's natural data
  dependency chain into an inconsistent, sometimes-slow page load.

  Replaced each with a pure derived value computed directly during
  render (falls back to the default/latest item whenever the current
  selection isn't valid for the current list), so dependent queries can
  enable on the same render the parent data arrives. Manual picker
  onChange handlers are unchanged — only the automatic-default plumbing
  was simplified.

  ## Summary

  **Root cause:** navigating into an integration/component detail page appeared to hang or lag intermittently. It wasn't the Suspense boundary — the lazy-loaded route chunk resolves fine. The actual issue was a data-fetching waterfall: a "selected track/env/endpoint"
  `useState` started empty and was only populated by a `useEffect` after the parent list (tracks, environments, endpoints) finished loading. Because several other queries (endpoints, deployment status, APIM info, lifecycle state/history, swagger spec, runtime
  arguments) were keyed off that state, they couldn't even become `enabled` until the effect fired and triggered an extra render — adding one unavoidable round trip to every navigation, on top of the pages' already-sequential data dependencies.

  **Fix:** replaced the `useState` + `useEffect` sync in each spot with a plain derived value computed inline every render — no effect, no extra round trip. The value resolves to the latest/default item the moment the parent list is available, on the very same render
  pass.

  ### Files changed
  | File | Selections fixed | Downstream queries unblocked |
  |---|---|---|
  | `src/pages/Component.tsx` | deployment track | `useComponentEndpoints`, `useDeploymentStatus` |
  | `src/pages/ComponentApiInfo.tsx` | track, APIM endpoint | `useComponentEndpoints`, `useApimApi` |
  | `src/pages/ComponentPlans.tsx` | track, APIM endpoint | `useComponentEndpoints`, `useApimApi` |
  | `src/pages/Lifecycle.tsx` | track, APIM endpoint | `useComponentEndpoints`, `useLifecycleState`, `useLifecycleHistory`, `useChangeLifecycleState`, `useApimApi` |
  | `src/pages/TestConsole.tsx` | track, environment, endpoint | `useComponentDeployment`, `useEnvEndpoints`, `useApimSwagger` |
  | `src/pages/AutomationTest.tsx` | track, environment | `useComponentDeployment`, `useRuntimeArguments`, `useTaskExecutionCount`/`useTaskExecutions` |
  | `src/pages/McpProxyFromApi.tsx` | source API version | `useApimApi` |
  | `src/pages/McpPolicies.tsx` | track | `useComponentEndpoints` |

  ### Validation
  - `tsc --noEmit`: clean
  - `eslint`: clean
  - `prettier --check`: clean
  - Unit tests: 803/803 passing (no test updates needed — none of the touched files fall under this repo's tested paths)


Resolves - https://github.com/wso2-enterprise/integration-engineering/issues/2168

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.