### PR TITLE
Confine workflow UI to Workflow integrations and flatten the workflow tabs

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -292,11 +292,12 @@ function fetchPendingTaskCount(componentId: string, environmentId: string, taskQ
   return wfRequest<{ count: number }>(componentId, environmentId, `human-tasks/pending-count${buildQuery({ taskQueue })}`).then((d) => d.count ?? 0);
 }
 
-export function usePendingTaskCount(s: Scope, taskQueue?: string) {
+/** `enabled` lets a caller skip the poll when the count is not being shown. */
+export function usePendingTaskCount(s: Scope, taskQueue?: string, enabled = true) {
   return useQuery({
     queryKey: ['wf', 'pending-count', s.componentId, s.environmentId, taskQueue],
     queryFn: () => fetchPendingTaskCount(s.componentId, s.environmentId, taskQueue),
-    enabled: enabledFor(s),
+    enabled: enabledFor(s) && enabled,
     refetchInterval: 30000,
   });
 }
@@ -356,6 +357,9 @@ export interface ReviewActivityFilters {
 // full set rather than only the first page.
 const REVIEW_ACTIVITY_MAX_PAGES = 20;
 
+// Page size the badge count reads; a full page is reported as capped rather than as an exact total.
+const PENDING_REVIEW_PAGE = 50;
+
 async function fetchReviewActivities(componentId: string, environmentId: string, filters: ReviewActivityFilters): Promise<Page<ReviewActivity>> {
   const items: ReviewActivity[] = [];
   let pageToken: string | undefined;
@@ -373,6 +377,31 @@ export function useReviewActivities(s: Scope, filters: ReviewActivityFilters) {
     queryKey: ['wf', 'review-activities', s.componentId, s.environmentId, filters],
     queryFn: () => fetchReviewActivities(s.componentId, s.environmentId, filters),
     enabled: enabledFor(s),
+  });
+}
+
+/** How many review activities are awaiting a decision, and whether that count hit the page cap. */
+export interface PendingReviewCount {
+  count: number;
+  capped: boolean;
+}
+
+/**
+ * Count of review activities awaiting a decision, for the tab badge. The runtime has no count
+ * endpoint, so this reads a single PENDING page — one request, unlike the listing, which walks up to
+ * REVIEW_ACTIVITY_MAX_PAGES so its client-side filters see everything. A full page reports `capped`
+ * so the badge can say "50+" rather than claim exactly 50.
+ */
+export function usePendingReviewActivityCount(s: Scope, taskQueue?: string, enabled = true) {
+  return useQuery({
+    queryKey: ['wf', 'pending-review-count', s.componentId, s.environmentId, taskQueue],
+    queryFn: (): Promise<PendingReviewCount> =>
+      wfRequest<Page<ReviewActivity>>(s.componentId, s.environmentId, `review-activities${buildQuery({ status: 'PENDING', taskQueue, limit: PENDING_REVIEW_PAGE })}`).then((p) => ({
+        count: p.items?.length ?? 0,
+        capped: p.hasMore === true,
+      })),
+    enabled: enabledFor(s) && enabled,
+    refetchInterval: 30000,
   });
 }
 
@@ -402,7 +431,7 @@ export function useReviewDecision(s: Scope) {
       else init = { method: 'POST' };
       return wfRequest<unknown>(s.componentId, s.environmentId, `review-activities/${encodeURIComponent(taskId)}/${decision}`, init);
     },
-    onSuccess: () => invalidateForEnvironment(qc, s.environmentId, 'review-activities'),
+    onSuccess: () => invalidateForEnvironment(qc, s.environmentId, 'review-activities', 'pending-review-count'),
   });
 }
 

--- a/frontend/src/components/EntryPoints.tsx
+++ b/frontend/src/components/EntryPoints.tsx
@@ -90,6 +90,41 @@ function EntryTypeChip({ cfg }: { cfg?: { label: string; color: string; bgColor:
 // needed when a user actually opens the API docs drawer for a BI service.
 const OpenApiDefinitionsDrawer = lazy(() => import('./OpenApiDefinitionsDrawer').then((m) => ({ default: m.OpenApiDefinitionsDrawer })));
 
+/**
+ * View Workflows / Start New Workflow, with the start dialog and its toast.
+ *
+ * Rendered beside the definition selector, which only a Workflow integration has - workflow
+ * definitions are not listed for any other integration type.
+ */
+function WorkflowActions({ componentId, envId, workflowType }: { componentId: string; envId: string; workflowType: string }) {
+  const [startOpen, setStartOpen] = useState(false);
+  const [toast, setToast] = useState<WorkflowToast>(null);
+  const navigate = useNavigate();
+  const scope = useScope();
+
+  return (
+    <>
+      <Button variant="contained" size="small" startIcon={<LayoutGrid size={14} />} onClick={() => navigate(`${resourceUrl(scope, 'workflows')}?tab=management&type=${encodeURIComponent(workflowType)}&env=${encodeURIComponent(envId)}`)}>
+        View Workflows
+      </Button>
+      <Authorized permissions={[Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
+        <Button variant="contained" size="small" startIcon={<Play size={14} />} onClick={() => setStartOpen(true)}>
+          Start New Workflow
+        </Button>
+      </Authorized>
+      {startOpen && (
+        <StartWorkflowDialog scope={{ targets: [{ componentId, componentName: '', handler: hasComponent(scope) ? scope.component : '' }], environmentId: envId }} initialWorkflowType={workflowType} onClose={() => setStartOpen(false)} onToast={setToast} />
+      )}
+      <Snackbar open={toast !== null} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        {/* Alert stays mounted so the Snackbar's exit transition can play after the toast clears. */}
+        <Alert severity={toast?.severity ?? 'success'} onClose={() => setToast(null)} sx={{ width: '100%' }}>
+          {toast?.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
 function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArtifact; onOpenDrawerTab: (tab: string) => void }) {
   const [tracingEnabled, setTracingEnabled] = useState(false);
   const [statisticsEnabled, setStatisticsEnabled] = useState(false);
@@ -103,8 +138,6 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   const [listenerToggleError, setListenerToggleError] = useState<string | null>(null);
   const [triggerConfirmDialogOpen, setTriggerConfirmDialogOpen] = useState(false);
   const [triggerSuccessMessage, setTriggerSuccessMessage] = useState<string | null>(null);
-  const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
-  const [workflowToast, setWorkflowToast] = useState<WorkflowToast>(null);
   const { artifact, artifactType, envId, componentId, projectId } = selected;
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -121,7 +154,6 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   const overviewFields = (config?.overviewFields ?? '').split(', ').filter(Boolean);
   const showTracingToggle = ['RestApi', 'ProxyService', 'InboundEndpoint'].includes(artifactType);
   const showParametersButton = artifactType === 'InboundEndpoint';
-  const showInstancesButton = artifactType === 'Workflow';
   const showWsdlButton = artifactType === 'ProxyService';
   const showStatisticsToggle = ['RestApi', 'ProxyService', 'InboundEndpoint'].includes(artifactType);
   const showStatusToggle = ['ProxyService', 'InboundEndpoint'].includes(artifactType);
@@ -141,18 +173,7 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
   // Track if any preceding controls are visible for proper divider placement
   const hasPrecedingControls = compositeApp || showStatusToggle || showStatusChip || showTracingToggle || showStatisticsToggle || showListenerToggle;
   const hasHeaderControls =
-    !!compositeApp ||
-    showStatusChip ||
-    showStatusToggle ||
-    showTracingToggle ||
-    showStatisticsToggle ||
-    showListenerToggle ||
-    showParametersButton ||
-    showWsdlButton ||
-    showInstancesButton ||
-    showTaskToggle ||
-    showTaskTrigger ||
-    (showApiDocsButton && !!apiDocsRuntimeId);
+    !!compositeApp || showStatusChip || showStatusToggle || showTracingToggle || showStatisticsToggle || showListenerToggle || showParametersButton || showWsdlButton || showTaskToggle || showTaskTrigger || (showApiDocsButton && !!apiDocsRuntimeId);
 
   const artifactName = artifactType === 'Automation' ? (artifact.packageName?.toString() ?? '') : (artifact.name?.toString() ?? '');
   const artifactKey = `${artifactType}-${artifactName}`;
@@ -438,23 +459,6 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
                 View WSDL
               </Button>
             )}
-            {showInstancesButton && (
-              <Button
-                variant="contained"
-                size="small"
-                startIcon={<LayoutGrid size={14} />}
-                onClick={() => navigate(`${resourceUrl(scope, 'workflows')}?tab=admin&type=${encodeURIComponent(artifactName)}&env=${encodeURIComponent(envId)}`)}
-                sx={{ ml: showParametersButton || showWsdlButton ? 0 : 'auto' }}>
-                View Instances
-              </Button>
-            )}
-            {showInstancesButton && (
-              <Authorized permissions={[Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
-                <Button variant="contained" size="small" startIcon={<Play size={14} />} onClick={() => setStartWorkflowOpen(true)}>
-                  Start Workflow
-                </Button>
-              </Authorized>
-            )}
             {showApiDocsButton && apiDocsRuntimeId && (
               <Stack direction="row" gap={1} sx={{ ml: 'auto' }}>
                 <Authorized permissions={[Permissions.INTEGRATION_EDIT, Permissions.INTEGRATION_MANAGE]}>
@@ -536,25 +540,11 @@ function EntryPointDetail({ selected, onOpenDrawerTab }: { selected: SelectedArt
           {listenerToggleError}
         </Alert>
       </Snackbar>
-      {startWorkflowOpen && (
-        <StartWorkflowDialog
-          scope={{ targets: [{ componentId, componentName: '', handler: hasComponent(scope) ? scope.component : '' }], environmentId: envId }}
-          initialWorkflowType={artifactName}
-          onClose={() => setStartWorkflowOpen(false)}
-          onToast={setWorkflowToast}
-        />
-      )}
       {viewingApiDocs && apiDocsRuntimeId && (
         <Suspense fallback={null}>
           <OpenApiDefinitionsDrawer runtimeId={apiDocsRuntimeId} onClose={() => setViewingApiDocs(false)} serviceBasePath={artifact.basePath?.toString()} />
         </Suspense>
       )}
-      <Snackbar open={workflowToast !== null} autoHideDuration={4000} onClose={() => setWorkflowToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-        {/* Alert stays mounted so the Snackbar's exit transition can play after the toast clears. */}
-        <Alert severity={workflowToast?.severity ?? 'success'} onClose={() => setWorkflowToast(null)} sx={{ width: '100%' }}>
-          {workflowToast?.message}
-        </Alert>
-      </Snackbar>
     </>
   );
 }
@@ -582,9 +572,10 @@ function EntryPointsList({
   const navigate = useNavigate();
   const scope = useScope();
   const isMI = componentType === 'MI';
-  // A Workflow integration is presented by its workflow definitions alone. Its BI runtime also
+  // Workflow definitions are shown for a Workflow integration and no other type. Its BI runtime also
   // reports the service and listener artifacts that host the workflow engine, but those are
-  // implementation detail rather than something the integration exposes.
+  // implementation detail rather than something the integration exposes - so the two sets do not mix
+  // in either direction.
   const workflowOnly = isWorkflowIntegration(displayType);
 
   const { data: apis = EMPTY_ARTIFACTS, isLoading: loadingApis } = useArtifacts('RestApi', envId, componentId, { enabled: isMI, active: isOnline });
@@ -593,9 +584,9 @@ function EntryPointsList({
   const { data: tasks = EMPTY_ARTIFACTS, isLoading: loadingTasks } = useArtifacts('Task', envId, componentId, { enabled: isMI, active: isOnline });
   const { data: services = EMPTY_ARTIFACTS, isLoading: loadingServices } = useArtifacts('Service', envId, componentId, { enabled: !isMI && !workflowOnly, active: isOnline });
   const { data: automations = EMPTY_ARTIFACTS, isLoading: loadingAutomations } = useArtifacts('Automation', envId, componentId, { enabled: !isMI && !workflowOnly, active: isOnline });
-  const { data: workflows = EMPTY_ARTIFACTS, isLoading: loadingWorkflows } = useArtifacts('Workflow', envId, componentId, { enabled: !isMI, active: isOnline });
+  const { data: workflows = EMPTY_ARTIFACTS, isLoading: loadingWorkflows } = useArtifacts('Workflow', envId, componentId, { enabled: !isMI && workflowOnly, active: isOnline });
 
-  const isLoading = isMI ? loadingApis || loadingProxies || loadingInbound || loadingTasks : workflowOnly ? loadingWorkflows : loadingServices || loadingAutomations || loadingWorkflows;
+  const isLoading = isMI ? loadingApis || loadingProxies || loadingInbound || loadingTasks : workflowOnly ? loadingWorkflows : loadingServices || loadingAutomations;
 
   const allEntryPoints = useMemo(
     () =>
@@ -603,7 +594,7 @@ function EntryPointsList({
         ? [...apis.map((a) => ({ artifact: a, type: 'RestApi' })), ...proxies.map((a) => ({ artifact: a, type: 'ProxyService' })), ...inboundEps.map((a) => ({ artifact: a, type: 'InboundEndpoint' })), ...tasks.map((a) => ({ artifact: a, type: 'Task' }))]
         : workflowOnly
           ? workflows.map((a) => ({ artifact: a, type: 'Workflow' }))
-          : [...services.map((a) => ({ artifact: a, type: 'Service' })), ...workflows.map((a) => ({ artifact: a, type: 'Workflow' })), ...automations.map((a) => ({ artifact: a, type: 'Automation' }))],
+          : [...services.map((a) => ({ artifact: a, type: 'Service' })), ...automations.map((a) => ({ artifact: a, type: 'Automation' }))],
     [isMI, workflowOnly, apis, proxies, inboundEps, tasks, services, workflows, automations],
   );
 
@@ -649,27 +640,40 @@ function EntryPointsList({
   const isProxy = selectedEntry?.type === 'ProxyService';
   const primaryLabel = isProxy ? '' : isTask ? 'Class' : isMI ? 'URL' : 'Package';
   const secondaryLabel = isProxy ? '' : isTask ? 'Group' : isMI ? 'Context' : 'API';
+  // A workflow integration lists workflow definitions, and the management API reports no package or
+  // API for them - Package read as an em dash and API only repeated the name in the selector - so
+  // the selector is named for what it holds and those two columns are dropped.
+  const selectorLabel = workflowOnly ? 'Workflow Definitions' : 'Endpoint';
 
   return (
     <>
-      {/* Endpoint / Package / API grid — mirrors devant's endpoint panel layout. MI components
-          don't have a package/API concept, so they show URL/Context instead (or group/class for Tasks). */}
-      <Box sx={{ display: 'grid', gridTemplateColumns: '220px 1fr 1fr', columnGap: 2, rowGap: 0.75, alignItems: 'start', mb: 2 }}>
+      {/* Selector / Package / API grid — mirrors devant's endpoint panel layout. MI components
+          don't have a package/API concept, so they show URL/Context instead (or group/class for Tasks);
+          workflow integrations have neither and show the selector alone. */}
+      <Box sx={{ display: 'grid', gridTemplateColumns: workflowOnly ? 'minmax(220px, 360px) 1fr' : '220px 1fr 1fr', columnGap: 2, rowGap: 0.75, alignItems: 'start', mb: 2 }}>
         <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
-          Endpoint
+          {selectorLabel}
         </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
-          {primaryLabel}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
-          {secondaryLabel}
-        </Typography>
+        {workflowOnly ? (
+          // Empty header cell above the actions, so grid auto-placement keeps the selector and the
+          // buttons on the same row.
+          <Box />
+        ) : (
+          <>
+            <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+              {primaryLabel}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
+              {secondaryLabel}
+            </Typography>
+          </>
+        )}
 
         <Select
           size="small"
           value={activeKey}
           onChange={(e) => setSelectedKey(e.target.value)}
-          inputProps={{ 'aria-label': 'Endpoint' }}
+          inputProps={{ 'aria-label': selectorLabel }}
           sx={{ fontSize: '13px', width: '100%' }}
           renderValue={(val) => {
             const entry = allEntryPoints.find(({ artifact: a, type }) => `${type}::${type === 'Automation' ? a.packageName : a.name}` === val);
@@ -700,39 +704,45 @@ function EntryPointsList({
           })}
         </Select>
 
-        {(() => {
-          if (isProxy)
+        {workflowOnly && selectedEntry && (
+          <Stack direction="row" gap={1} sx={{ alignSelf: 'center', justifyContent: 'flex-end' }}>
+            <WorkflowActions componentId={componentId} envId={envId} workflowType={selectedEntry.artifact.name?.toString() ?? ''} />
+          </Stack>
+        )}
+        {!workflowOnly &&
+          (() => {
+            if (isProxy)
+              return (
+                <>
+                  <Box />
+                  <Box />
+                </>
+              );
+            const primaryValue = (isTask ? selectedEntry?.artifact.class : isMI ? selectedEntry?.artifact.url : selectedEntry?.artifact.package)?.toString();
+            const secondaryValue = (isTask ? selectedEntry?.artifact.group : isMI ? selectedEntry?.artifact.context : selectedEntry?.artifact.name)?.toString();
             return (
               <>
-                <Box />
-                <Box />
+                <Stack direction="row" alignItems="center" gap={0.75} sx={{ minWidth: 0, alignSelf: 'center' }}>
+                  <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
+                    {isTask ? <Layers size={15} /> : isMI ? <LinkIcon size={15} /> : <Package size={15} />}
+                  </Box>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {primaryValue ?? '—'}
+                  </Typography>
+                  {primaryValue ? <CopyButton value={primaryValue} label={primaryLabel} /> : null}
+                </Stack>
+
+                <Stack direction="row" alignItems="center" gap={0.75} sx={{ alignSelf: 'center' }}>
+                  <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
+                    <Tag size={15} />
+                  </Box>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                    {secondaryValue ?? '—'}
+                  </Typography>
+                </Stack>
               </>
             );
-          const primaryValue = (isTask ? selectedEntry?.artifact.class : isMI ? selectedEntry?.artifact.url : selectedEntry?.artifact.package)?.toString();
-          const secondaryValue = (isTask ? selectedEntry?.artifact.group : isMI ? selectedEntry?.artifact.context : selectedEntry?.artifact.name)?.toString();
-          return (
-            <>
-              <Stack direction="row" alignItems="center" gap={0.75} sx={{ minWidth: 0, alignSelf: 'center' }}>
-                <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
-                  {isTask ? <Layers size={15} /> : isMI ? <LinkIcon size={15} /> : <Package size={15} />}
-                </Box>
-                <Typography variant="body2" sx={{ fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                  {primaryValue ?? '—'}
-                </Typography>
-                {primaryValue ? <CopyButton value={primaryValue} label={primaryLabel} /> : null}
-              </Stack>
-
-              <Stack direction="row" alignItems="center" gap={0.75} sx={{ alignSelf: 'center' }}>
-                <Box component="span" sx={{ display: 'flex', alignItems: 'center', color: 'primary.main' }}>
-                  <Tag size={15} />
-                </Box>
-                <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                  {secondaryValue ?? '—'}
-                </Typography>
-              </Stack>
-            </>
-          );
-        })()}
+          })()}
       </Box>
       {selectedEntry && <EntryPointDetail selected={{ artifact: selectedEntry.artifact, artifactType: selectedEntry.type, envId, componentId, projectId }} onOpenDrawerTab={(tab) => onOpenDrawer(selectedEntry.artifact, selectedEntry.type, envId, tab)} />}
     </>

--- a/frontend/src/components/workflow/AdminPortal.tsx
+++ b/frontend/src/components/workflow/AdminPortal.tsx
@@ -267,7 +267,7 @@ function WorkflowsAdmin({
         </Tooltip>
         <Authorized permissions={[Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
           <Button variant="contained" size="small" startIcon={<Play size={14} />} onClick={() => setStartOpen(true)}>
-            Start Workflow
+            Start New Workflow
           </Button>
         </Authorized>
       </Stack>
@@ -439,7 +439,7 @@ export function StartWorkflowDialog({ scope, initialWorkflowType, onClose, onToa
   const viewInstance = () => {
     if (!started) return;
     onClose();
-    navigate(`${resourceUrl(navScope, 'workflows')}?tab=admin&workflowId=${encodeURIComponent(started.workflowId)}&env=${encodeURIComponent(scope.environmentId)}`);
+    navigate(`${resourceUrl(navScope, 'workflows')}?tab=management&workflowId=${encodeURIComponent(started.workflowId)}&env=${encodeURIComponent(scope.environmentId)}`);
   };
 
   if (started) {

--- a/frontend/src/components/workflow/UserPortal.tsx
+++ b/frontend/src/components/workflow/UserPortal.tsx
@@ -25,7 +25,7 @@ import { DetailRow, StatusChip, SubmitError, WorkflowIdLink, type WorkflowScope 
 import { ReviewActivities, StatusFilter } from './AdminPortal';
 import Authorized from '../Authorized';
 import { Permissions } from '../../constants/permissions';
-import { useCompleteHumanTask, useFailHumanTask, useHumanTask, useHumanTasks, usePendingTaskCount, type HumanTask } from '../../api/workflows';
+import { useCompleteHumanTask, useFailHumanTask, useHumanTask, useHumanTasks, type HumanTask } from '../../api/workflows';
 
 const emptySx = { py: 4, textAlign: 'center', color: 'text.secondary' } as const;
 
@@ -55,30 +55,16 @@ function taskDisplayName(t?: HumanTask): string {
 
 type Toast = { severity: 'success' | 'error'; message: string } | null;
 
-export default function UserPortal({ targets, environmentId, taskQueue }: PortalScope) {
+/**
+ * Hosts the two user-facing workflow views. Which one shows is decided by the page's tabs, so this
+ * only dispatches and owns the toast both views report through.
+ */
+export default function UserPortal({ targets, environmentId, taskQueue, view }: PortalScope & { view: 'tasks' | 'reviews' }) {
   const scope: PortalScope = { targets, environmentId, taskQueue };
-  const [view, setView] = useState<'tasks' | 'reviews'>('tasks');
   const [toast, setToast] = useState<Toast>(null);
-  const { data: pendingCount } = usePendingTaskCount(gatewayScope(scope), taskQueue);
 
   return (
     <>
-      <Stack direction="row" alignItems="center" gap={1} sx={{ mb: 2 }}>
-        <Button variant={view === 'tasks' ? 'contained' : 'outlined'} size="small" onClick={() => setView('tasks')}>
-          My Tasks
-        </Button>
-        {/* The proxy authorizes /review-activities with the workflow permissions, not the human-task
-            ones that gate this tab, so the view is only offered to someone who can actually load it
-            — a Viewer holds view_human_tasks alone and would otherwise be shown a view that 403s. */}
-        <Authorized permissions={[Permissions.WORKFLOW_VIEW_WORKFLOWS, Permissions.WORKFLOW_MANAGE_WORKFLOWS]}>
-          <Button variant={view === 'reviews' ? 'contained' : 'outlined'} size="small" onClick={() => setView('reviews')}>
-            Review Activities
-          </Button>
-        </Authorized>
-        <Box sx={{ flex: 1 }} />
-        {pendingCount !== undefined && <Chip label={`${pendingCount} pending`} size="small" color={pendingCount > 0 ? 'info' : 'default'} />}
-      </Stack>
-
       {view === 'tasks' ? <MyTasks scope={scope} onToast={setToast} /> : <ReviewActivities scope={scope} onToast={setToast} />}
 
       <Snackbar open={toast !== null} autoHideDuration={4000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>

--- a/frontend/src/components/workflow/WorkflowInstancesPanel.tsx
+++ b/frontend/src/components/workflow/WorkflowInstancesPanel.tsx
@@ -69,28 +69,33 @@ export default function WorkflowInstancesPanel({ componentId, environmentId, wor
         <Typography sx={emptySx}>{search ? 'No running instances match that workflow ID.' : 'No running instances.'}</Typography>
       ) : (
         <>
-          <ListingTable>
-            <ListingTable.Head>
-              <ListingTable.Row>
-                <ListingTable.Cell>Workflow ID</ListingTable.Cell>
-                <ListingTable.Cell>Status</ListingTable.Cell>
-                <ListingTable.Cell>Started</ListingTable.Cell>
-              </ListingTable.Row>
-            </ListingTable.Head>
-            <ListingTable.Body>
-              {items.map((wf) => (
-                <ListingTable.Row key={`${wf.workflowId}:${wf.runId ?? ''}`}>
-                  <ListingTable.Cell>
-                    <WorkflowIdLink workflowId={wf.workflowId} environmentId={environmentId} />
-                  </ListingTable.Cell>
-                  <ListingTable.Cell>
-                    <StatusChip status={wf.status} />
-                  </ListingTable.Cell>
-                  <ListingTable.Cell>{formatTime(wf.startTime)}</ListingTable.Cell>
+          {/* Bounded and scrollable: this sits inside the integration overview card, and the query
+              returns up to 50 runs, which would otherwise stretch the card to whatever is in flight.
+              maxHeight rather than a fixed height so a couple of runs do not leave a mostly empty box. */}
+          <Box sx={{ maxHeight: 260, overflowY: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+            <ListingTable>
+              <ListingTable.Head>
+                <ListingTable.Row>
+                  <ListingTable.Cell>Workflow ID</ListingTable.Cell>
+                  <ListingTable.Cell>Status</ListingTable.Cell>
+                  <ListingTable.Cell>Started</ListingTable.Cell>
                 </ListingTable.Row>
-              ))}
-            </ListingTable.Body>
-          </ListingTable>
+              </ListingTable.Head>
+              <ListingTable.Body>
+                {items.map((wf) => (
+                  <ListingTable.Row key={`${wf.workflowId}:${wf.runId ?? ''}`}>
+                    <ListingTable.Cell>
+                      <WorkflowIdLink workflowId={wf.workflowId} environmentId={environmentId} />
+                    </ListingTable.Cell>
+                    <ListingTable.Cell>
+                      <StatusChip status={wf.status} />
+                    </ListingTable.Cell>
+                    <ListingTable.Cell>{formatTime(wf.startTime)}</ListingTable.Cell>
+                  </ListingTable.Row>
+                ))}
+              </ListingTable.Body>
+            </ListingTable>
+          </Box>
           {page?.hasMore && (
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1, textAlign: 'center' }}>
               Showing the first {items.length}. Open Workflows to narrow further.

--- a/frontend/src/components/workflow/shared.tsx
+++ b/frontend/src/components/workflow/shared.tsx
@@ -37,7 +37,7 @@ function useViewWorkflowById(environmentId: string): (workflowId: string) => voi
   const navigate = useNavigate();
   const scope = useScope();
   return (workflowId: string) => {
-    navigate(`${resourceUrl(scope, 'workflows')}?tab=admin&workflowId=${encodeURIComponent(workflowId)}&env=${encodeURIComponent(environmentId)}`);
+    navigate(`${resourceUrl(scope, 'workflows')}?tab=management&workflowId=${encodeURIComponent(workflowId)}&env=${encodeURIComponent(environmentId)}`);
   };
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,11 +1,19 @@
 :root {
-  color-scheme: light dark;
+  /* Native widgets - scrollbars above all - follow the console's own theme, which Oxygen marks on the
+     root as data-color-scheme. Declaring "light dark" instead makes the browser follow the OS, so a
+     dark-mode machine got black scrollbars while the UI stayed light; hardcoding either value gets it
+     wrong in the other theme. This is the light default, overridden for dark below. */
+  color-scheme: light;
   color: rgba(255, 255, 255, 0.87);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html[data-color-scheme='dark'] {
+  color-scheme: dark;
 }
 
 html,

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -167,14 +167,16 @@ export default function AppLayout(): JSX.Element {
     accessControlPerms.push(Permissions.INTEGRATION_EDIT, Permissions.INTEGRATION_MANAGE);
   }
   const canSeeAccessControl = hasAnyPermission(accessControlPerms, projectId || undefined, componentId);
-  // Workflows is an integration-level view only for workflow integrations. Project level is
-  // unaffected: a project's workflow data is namespace-wide, not tied to one integration. While the
-  // component list is still loading `currentComponent` is undefined, so the item stays hidden until
-  // its type is known rather than appearing and then disappearing.
+  // Two integration-level entries depend on the integration's type, and each stays hidden until
+  // `currentComponent` resolves — the same way access control waits on its permissions — so neither is
+  // offered and then withdrawn once the type is known.
+  //
+  // Workflows applies only to a workflow integration. Project level is unaffected: a project's
+  // workflow data is namespace-wide, not tied to one integration.
   const showWorkflows = !hasComponent(scope) || isWorkflowIntegration(currentComponent?.displayType);
-  // The Test Console drives a service's packed OpenAPI definition, and a workflow integration exposes
-  // workflows rather than services - so it has nothing to test there.
-  const showTest = !isWorkflowIntegration(currentComponent?.displayType);
+  // The Test Console drives a service's packed OpenAPI definition, so it applies to every type except
+  // workflow, which exposes workflows rather than services.
+  const showTest = !!currentComponent && !isWorkflowIntegration(currentComponent.displayType);
   const items = sidebarItems(scope, resource)
     .filter((item) => item.resource !== 'access-control' || canSeeAccessControl)
     .filter((item) => item.resource !== 'workflows' || showWorkflows)

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -138,7 +138,8 @@ export default function AppLayout(): JSX.Element {
         // Only workflow integrations have this view; at project level it always applies.
         return !hasComponent(targetScope) || isWorkflowIntegration(components.find((c) => c.id === targetComponentId)?.displayType) ? 'workflows' : 'overview';
       case 'test':
-        return 'test';
+        // Only integrations that expose a service have anything to test.
+        return isWorkflowIntegration(components.find((c) => c.id === targetComponentId)?.displayType) ? 'overview' : 'test';
       case 'access-control': {
         const perms: string[] = [...ALL_USER_MGT_PERMISSIONS];
         if (hasProject(targetScope)) perms.push(Permissions.PROJECT_EDIT, Permissions.PROJECT_MANAGE);
@@ -171,9 +172,13 @@ export default function AppLayout(): JSX.Element {
   // component list is still loading `currentComponent` is undefined, so the item stays hidden until
   // its type is known rather than appearing and then disappearing.
   const showWorkflows = !hasComponent(scope) || isWorkflowIntegration(currentComponent?.displayType);
+  // The Test Console drives a service's packed OpenAPI definition, and a workflow integration exposes
+  // workflows rather than services - so it has nothing to test there.
+  const showTest = !isWorkflowIntegration(currentComponent?.displayType);
   const items = sidebarItems(scope, resource)
     .filter((item) => item.resource !== 'access-control' || canSeeAccessControl)
-    .filter((item) => item.resource !== 'workflows' || showWorkflows);
+    .filter((item) => item.resource !== 'workflows' || showWorkflows)
+    .filter((item) => item.resource !== 'test' || showTest);
 
   return (
     <AppShell>

--- a/frontend/src/pages/OrgRuntimes.tsx
+++ b/frontend/src/pages/OrgRuntimes.tsx
@@ -31,13 +31,11 @@ import {
   DialogTitle,
   Divider,
   Drawer,
-  FormControlLabel,
   IconButton,
   ListingTable,
   PageContent,
   PageTitle,
   Stack,
-  Switch,
   Tab,
   TablePagination,
   Tabs,
@@ -59,7 +57,7 @@ import { Permissions } from '../constants/permissions';
 import { technologyLabel } from '../constants/technologies';
 import { useAccessControl } from '../contexts/AccessControlContext';
 import type { OrgScope } from '../nav';
-import { runtimeImports, workflowManagementToml } from '../utils/runtimeToml';
+import { runtimeImports } from '../utils/runtimeToml';
 
 const drawerSx = {
   '& .MuiDrawer-paper': { width: '45%', maxWidth: 560, minWidth: 360, position: 'fixed', top: 64, height: 'calc(100% - 64px)', borderLeft: '1px solid', borderColor: 'divider' },
@@ -160,18 +158,17 @@ secret = "${secret}"
 #icp_url = "https://<hostname>:9445"`;
 }
 
-function biToml(envName: string, secret: string, workflowMgt: boolean): string {
-  const base = `[wso2.icp.runtime.bridge]
+// No workflow configuration here: this dialog is org-scoped, with the project and integration left
+// as fill-in placeholders, so it cannot tell whether the runtime belongs to a Workflow integration.
+// Register a workflow runtime from that integration's own Runtime page, which knows its type.
+function biToml(envName: string, secret: string): string {
+  return `[wso2.icp.runtime.bridge]
 environment = "${envName}"
 project = "<project name>"
 integration = "<integration name>"
 runtime = "<unique id for the runtime>"
 secret = "${secret}"
 #serverUrl="https://<hostname>:9445"`;
-  if (!workflowMgt) return base;
-  return `${base}
-
-${workflowManagementToml('<integration name>', secret)}`;
 }
 
 function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () => void }) {
@@ -179,7 +176,6 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
   const [secret, setSecret] = useState<string | null>(null);
   const [tab, setTab] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [workflowMgt, setWorkflowMgt] = useState(false);
 
   const handleGenerate = () => {
     setError(null);
@@ -192,7 +188,7 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
     );
   };
 
-  const config = secret ? (tab === 0 ? biToml(env.handler, secret, workflowMgt) : miToml(env.handler, secret)) : null;
+  const config = secret ? (tab === 0 ? biToml(env.handler, secret) : miToml(env.handler, secret)) : null;
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
@@ -211,7 +207,6 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
             <Alert severity="warning" sx={{ mb: 2 }}>
               <strong>The secret will be shown once — copy it before closing.</strong>
             </Alert>
-            <FormControlLabel control={<Switch checked={workflowMgt} onChange={(e) => setWorkflowMgt(e.target.checked)} />} label="Enable Workflow Management" sx={{ display: 'flex' }} />
             <DialogContentText variant="caption" sx={{ mb: 2, display: 'block' }}>
               Applies to Default (BI) runtimes only — the MI configuration is not affected.
             </DialogContentText>
@@ -240,17 +235,11 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
                 </DialogContentText>
                 <CodeBoxWithCopy code={`[build-options]\nremoteManagement = true`} />
                 <DialogContentText sx={{ mb: 1 }}>
-                  {workflowMgt ? (
-                    <>
-                      Add the following imports to your runtime's <strong>main.bal</strong> file:
-                    </>
-                  ) : (
-                    <>
-                      Import wso2/icp.runtime.bridge to your runtime's <strong>main.bal</strong> file:
-                    </>
-                  )}
+                  Import wso2/icp.runtime.bridge to your runtime's <strong>main.bal</strong> file:
                 </DialogContentText>
-                <CodeBoxWithCopy code={runtimeImports(workflowMgt)} />
+                {/* Bridge import only: this dialog emits no workflow configuration, so the workflow
+                    management module is not needed here. */}
+                <CodeBoxWithCopy code={runtimeImports(false)} />
                 <Alert severity="info" sx={{ mt: 2 }}>
                   The above configuration is for runtimes using the <strong>Default</strong> integration. If you're using the <strong>MI</strong> integration, switch to the MI tab to see the correct configuration.
                 </Alert>

--- a/frontend/src/pages/Runtime.tsx
+++ b/frontend/src/pages/Runtime.tsx
@@ -38,7 +38,6 @@ import {
   PageContent,
   PageTitle,
   Stack,
-  Switch,
   TablePagination,
   Typography,
 } from '@wso2/oxygen-ui';
@@ -86,14 +85,15 @@ secret = "${secret}"
 }
 
 function biToml(envName: string, secret: string, projectHandle: string, integrationHandle: string, workflowMgt: boolean): string {
+  // The bridge's workflow keys belong to a Workflow integration only, like the [ballerina.workflow]
+  // blocks appended below — no other integration type's snippet mentions workflows at all.
+  const workflowKeys = workflowMgt ? '\nenableWorkflowManagement = true\n# workflowManagementApiPort = 8234' : '';
   const base = `[wso2.icp.runtime.bridge]
 environment = "${envName}"
 project = "${projectHandle}"
 integration = "${integrationHandle}"
 runtime = "<unique id for the runtime>"
-secret = "${secret}"
-enableWorkflowManagement = true
-# workflowManagementApiPort = 8234
+secret = "${secret}"${workflowKeys}
 # serverUrl = "https://<hostname>:9445"
 # runtimeBaseUrl = "http://<hostname>"`;
   if (!workflowMgt) return base;
@@ -125,13 +125,12 @@ function AddRuntimeModal({
   const queryClient = useQueryClient();
   const [secret, setSecret] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [workflowMgtChoice, setWorkflowMgtChoice] = useState(false);
+
   const isBI = componentType === 'BI';
-  // A Workflow integration exists to host workflows, so its runtime always registers with workflow
-  // management enabled and the toggle is not offered. Derived rather than seeded into state so a
-  // late-arriving integration type still takes effect.
-  const alwaysWorkflowMgt = isWorkflowIntegration(displayType);
-  const workflowMgt = alwaysWorkflowMgt || workflowMgtChoice;
+  // Only a Workflow integration gets workflow configuration; no other type carries anything workflow
+  // related, so this follows the integration's type with nothing to choose. Derived rather than held
+  // in state so a late-arriving type still takes effect.
+  const workflowMgt = isWorkflowIntegration(displayType);
 
   const handleGenerate = () => {
     setError(null);
@@ -173,7 +172,6 @@ function AddRuntimeModal({
             <Alert severity="warning" sx={{ mb: 2 }}>
               <strong>The secret will be shown once — copy it before closing.</strong>
             </Alert>
-            {isBI && !alwaysWorkflowMgt && <FormControlLabel control={<Switch checked={workflowMgtChoice} onChange={(e) => setWorkflowMgtChoice(e.target.checked)} />} label="Enable Workflow Management" sx={{ display: 'flex', mb: 2 }} />}
             <Button variant="contained" onClick={handleGenerate} disabled={createMutation.isPending}>
               {createMutation.isPending ? 'Generating...' : 'Generate Secret'}
             </Button>

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Autocomplete, Box, CircularProgress, PageContent, Stack, Tab, Tabs, TextField, Typography } from '@wso2/oxygen-ui';
+import { Autocomplete, Box, Chip, CircularProgress, PageContent, Stack, Tab, Tabs, TextField, Typography } from '@wso2/oxygen-ui';
 import { useEffect, useState, type JSX } from 'react';
 import { useSearchParams } from 'react-router';
 import { useProjectByHandler, useComponentByHandler, useComponents, useEnvironments } from '../api/queries';
@@ -27,8 +27,26 @@ import { useAccessControl } from '../contexts/AccessControlContext';
 import { useLoadComponentPermissions, useLoadProjectPermissions } from '../hooks/usePermissionLoader';
 import { Permissions } from '../constants/permissions';
 import { resourceUrl, broaden, hasComponent, type ComponentScope, type ProjectScope } from '../nav';
-import type { WorkflowTarget } from '../api/workflows';
+import { usePendingReviewActivityCount, usePendingTaskCount, type WorkflowTarget } from '../api/workflows';
+import { gatewayScope } from '../components/workflow/helpers';
 import { isWorkflowIntegration } from '../constants/integrationTypes';
+
+/**
+ * Tab title with the amount of work waiting behind it. Omitted at zero, and while the count is still
+ * loading, so a tab only grows a badge when there is something to act on.
+ */
+function TabLabel({ title, count, capped }: { title: string; count?: number; capped?: boolean }): JSX.Element {
+  return (
+    <Stack direction="row" alignItems="center" gap={0.75}>
+      <span>{title}</span>
+      {count !== undefined && count > 0 && <Chip label={capped ? `${count}+` : count} size="small" color="primary" sx={{ height: 18, fontSize: 11, fontWeight: 600, '& .MuiChip-label': { px: 0.75 } }} />}
+    </Stack>
+  );
+}
+
+type TabKey = 'tasks' | 'reviews' | 'management';
+// Tab order, and the order a permitted fallback is picked in.
+const TAB_ORDER: TabKey[] = ['tasks', 'reviews', 'management'];
 
 export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Element {
   const componentLevel = hasComponent(scope);
@@ -70,8 +88,8 @@ export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Ele
   // project scope.
   const taskQueue = componentLevel ? component?.handler : undefined;
 
-  // Optional deep-link params (e.g. from the Overview page's "View Instances" action or the
-  // start-workflow success dialog): ?tab=admin&type=<workflowType>&workflowId=<id>&env=<environmentId>
+  // Optional deep-link params (e.g. from the Overview page's "View Workflows" action or the
+  // start-workflow success dialog): ?tab=management&type=<workflowType>&workflowId=<id>&env=<environmentId>
   const [searchParams, setSearchParams] = useSearchParams();
   // Held in state rather than read from the URL on every render. The admin view unmounts on a tab
   // switch and re-seeds its filters from these on mount, so leaving them in the URL would reapply a
@@ -89,9 +107,11 @@ export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Ele
     setDeepLink({ workflowType: urlWorkflowType ?? undefined, workflowId: urlWorkflowId ?? undefined });
   }, [urlWorkflowType, urlWorkflowId]);
   // The active tab is driven by the URL, so navigating here from elsewhere (e.g. clicking a
-  // workflow ID in User Actions or Review Activities) switches tabs deterministically.
-  const tabKey: 'user' | 'admin' = searchParams.get('tab') === 'admin' ? 'admin' : 'user';
-  const setTabKey = (v: 'user' | 'admin') => {
+  // workflow ID in a task or review) switches tabs deterministically. `admin` is still accepted so
+  // links made before the tabs were flattened keep working.
+  const requestedTab = searchParams.get('tab');
+  const tabKey: TabKey = requestedTab === 'management' || requestedTab === 'admin' ? 'management' : requestedTab === 'reviews' ? 'reviews' : 'tasks';
+  const setTabKey = (v: TabKey) => {
     // Leaving the admin view discards its deep link, in state and in the URL alike: it has already
     // been applied, and re-applying it on the way back would resurrect a cleared filter.
     setDeepLink({});
@@ -111,6 +131,26 @@ export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Ele
   // Remounts the admin portal when the deep link changes, so a new one re-seeds the filters.
   const deepLinkKey = `${deepLink.workflowType ?? ''}:${deepLink.workflowId ?? ''}`;
 
+  const activeEnvId = environments.some((e) => e.id === selectedEnvId) ? selectedEnvId : (environments[0]?.id ?? '');
+  const selectedEnv = environments.find((e) => e.id === activeEnvId) ?? null;
+  // Each tab is gated by its dedicated workflow permission.
+  const permScope = componentLevel ? componentId : undefined;
+  const canViewHumanTasks = hasAnyPermission([Permissions.WORKFLOW_VIEW_HUMAN_TASKS, Permissions.WORKFLOW_MANAGE_HUMAN_TASKS], projectId, permScope);
+  const canViewWorkflows = hasAnyPermission([Permissions.WORKFLOW_VIEW_WORKFLOWS, Permissions.WORKFLOW_MANAGE_WORKFLOWS], projectId, permScope);
+  // Review Activities is gated on the workflow permissions, not the human-task ones: the proxy
+  // authorizes /review-activities on that branch, so a Viewer holding only view_human_tasks would
+  // otherwise be offered a tab that 403s on load.
+  const allowedTabs: Record<TabKey, boolean> = { tasks: canViewHumanTasks, reviews: canViewWorkflows, management: canViewWorkflows };
+  // Resolve the requested tab to one the user may see, else the first they may (null = none).
+  const activeTab: TabKey | null = allowedTabs[tabKey] ? tabKey : (TAB_ORDER.find((t) => allowedTabs[t]) ?? null);
+
+  // Counts for the tab badges. Both poll, so each is skipped when its tab is not on offer — and both
+  // read through the same gateway runtime the views themselves use.
+  const gateway = gatewayScope({ targets, environmentId: activeEnvId, taskQueue });
+  // Declared above the early returns below, so these hooks run in the same order on every render.
+  const { data: pendingTasks } = usePendingTaskCount(gateway, taskQueue, allowedTabs.tasks);
+  const { data: pendingReviews } = usePendingReviewActivityCount(gateway, taskQueue, allowedTabs.reviews);
+
   if (loadingProject || loadingComponent || loadingEnvs || loadingComponents)
     return (
       <PageContent sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
@@ -118,15 +158,6 @@ export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Ele
       </PageContent>
     );
   if (componentLevel && !component) return <NotFound message="Component not found" backTo={resourceUrl(broaden(scope)!, 'overview')} backLabel="Back to Project" />;
-
-  const activeEnvId = environments.some((e) => e.id === selectedEnvId) ? selectedEnvId : (environments[0]?.id ?? '');
-  const selectedEnv = environments.find((e) => e.id === activeEnvId) ?? null;
-  // Each tab is gated by its dedicated workflow permission.
-  const permScope = componentLevel ? componentId : undefined;
-  const canViewHumanTasks = hasAnyPermission([Permissions.WORKFLOW_VIEW_HUMAN_TASKS, Permissions.WORKFLOW_MANAGE_HUMAN_TASKS], projectId, permScope);
-  const canViewWorkflows = hasAnyPermission([Permissions.WORKFLOW_VIEW_WORKFLOWS, Permissions.WORKFLOW_MANAGE_WORKFLOWS], projectId, permScope);
-  // Resolve the requested tab to one the user is allowed to see (null = neither).
-  const activeTab: 'user' | 'admin' | null = tabKey === 'admin' && canViewWorkflows ? 'admin' : tabKey === 'user' && canViewHumanTasks ? 'user' : canViewHumanTasks ? 'user' : canViewWorkflows ? 'admin' : null;
 
   return (
     <PageContent>
@@ -166,19 +197,20 @@ export default function Workflows(scope: ComponentScope | ProjectScope): JSX.Ele
       ) : (
         <>
           <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
-            <Tabs value={activeTab} onChange={(_, v) => setTabKey(v as 'user' | 'admin')}>
-              {canViewHumanTasks && <Tab label="User Actions" value="user" />}
-              {canViewWorkflows && <Tab label="Admin Actions" value="admin" />}
+            <Tabs value={activeTab} onChange={(_, v) => setTabKey(v as TabKey)}>
+              {allowedTabs.tasks && <Tab label={<TabLabel title="My Tasks" count={pendingTasks} />} value="tasks" />}
+              {allowedTabs.reviews && <Tab label={<TabLabel title="Review Activities" count={pendingReviews?.count} capped={pendingReviews?.capped} />} value="reviews" />}
+              {allowedTabs.management && <Tab label="Workflow Executions" value="management" />}
             </Tabs>
           </Box>
           {!activeEnvId ? (
             <Typography color="text.secondary" sx={{ py: 6, textAlign: 'center' }}>
               Select an environment to continue.
             </Typography>
-          ) : activeTab === 'user' ? (
-            <UserPortal targets={targets} environmentId={activeEnvId} taskQueue={taskQueue} />
-          ) : (
+          ) : activeTab === 'management' ? (
             <AdminPortal key={deepLinkKey} targets={targets} environmentId={activeEnvId} taskQueue={taskQueue} initialWorkflowType={deepLink.workflowType} initialWorkflowId={deepLink.workflowId} />
+          ) : (
+            <UserPortal targets={targets} environmentId={activeEnvId} taskQueue={taskQueue} view={activeTab === 'reviews' ? 'reviews' : 'tasks'} />
           )}
         </>
       )}


### PR DESCRIPTION
Follow-up to #765. Frontend only — 11 files, no backend or schema changes.

Two themes: workflow surfaces now appear **only** for integrations of the Workflow type, and the workflow tabs are flattened so the work waiting on a user is reachable in one click.

## Workflow UI is confined to Workflow integrations

Previously any BI integration surfaced workflow UI, because workflow artifacts are read for every BI runtime. An *Integration as API* therefore listed workflows next to its services, and its runtime snippet mentioned workflow settings.

- **Overview** lists workflow definitions only for a Workflow integration. The `Workflow` artifact query is now *enabled* only for that type, so no other type requests them, let alone shows them.
- **Test Console** is hidden for a Workflow integration — it drives a service's packed OpenAPI definition, and a workflow integration exposes workflows rather than services. `canAccessResource` falls back to Overview too, so switching integrations while on Test can't land on a page whose nav entry is hidden.
- **Enable Workflow Management toggle removed.** There is nothing to choose: workflow configuration follows the integration's type. `enableWorkflowManagement` and the commented `workflowManagementApiPort` also move out of the bridge block's fixed text and behind that same condition — they were printed for every BI integration regardless of type (and, before this, regardless of the toggle).

## Workflow tabs flattened

`My Tasks` | `Review Activities` | `Workflow Management`

`My Tasks` and `Review Activities` were buttons inside a `User Actions` tab; they are now tabs in their own right, and `Admin Actions` moves to the end as `Workflow Management`. Each of the first two carries the work waiting behind it as a badge after the title, omitted at zero and while loading so a tab is only decorated when there's something to act on.

## Overview polish for Workflow integrations

- Selector renamed **Workflow Definitions**; the `Package` and `API` columns are dropped — the management API reports neither, so one read as an em dash and the other only repeated the name in the selector.
- `View Instances` → **View Workflows**, `Start Workflow` → **Start New Workflow**, both now on the selector's own row rather than a row of their own beneath it.
- The running-instances list is bounded and scrollable (it returns up to 50 runs, which otherwise stretched the card to whatever happened to be in flight).

## Fix: scrollbars followed the OS, not the console

`:root` declared `color-scheme: light dark`, which tells the browser to paint native widgets from the **OS** preference. On a dark-mode machine showing the light theme, scrollbars came out black. It now tracks `data-color-scheme` — the attribute Oxygen marks the active scheme with and styles its own components from — so scrollbars match whichever theme is actually showing. Hardcoding either value would have been wrong in the other theme.

## Decisions worth a reviewer's attention

- **Review Activities is gated on the workflow permissions, not the human-task ones.** That's what the proxy enforces for `/review-activities` (anything that isn't `human-tasks` takes the workflow branch), so gating it on human-task permissions would offer a Viewer — who holds `view_human_tasks` alone — a tab that 403s on load. Deciding a review still requires `manage_workflows`, unchanged.
- **Legacy integrations.** An integration created before the Workflow type existed carries `ballerinaService`. If it genuinely hosts workflows, they no longer appear on its *overview*; they remain reachable from the Workflows page, whose project-level view still fans definitions out across every integration. Changing such an integration's type to Workflow restores the overview listing.
- **The org-level Add Runtime dialog no longer emits workflow configuration at all.** It is org-scoped, with the project and integration left as fill-in placeholders, so it cannot tell whether a runtime belongs to a Workflow integration. Registering a workflow runtime is done from that integration's own Runtime page, which knows its type. This is a deliberate loss of a previously reachable option.
- **Deep links** are retargeted to `?tab=management`, with `?tab=admin` still accepted so links already shared or bookmarked keep working.
- **The review-activity badge count reads a single page.** There is no count endpoint, and reusing the listing fetch would walk up to 20 pages per poll; a full page is reported as capped so the badge reads `50+` rather than claiming exactly 50. Both counts poll, so each is skipped when its tab isn't on offer, and deciding a review invalidates its badge as well as the list.
- **Type-dependent nav entries stay hidden until the type is known.** Both Workflows and Test Console wait for the component to resolve, matching the access control entry, which already waits on its permissions. Neither is offered and then withdrawn — which mattered for Test, since its route still resolves, so a click in that window would have landed on the Test Console for an integration with no services.

## Testing

The frontend has no test harness (no runner, no `*.test.*` files), so no automated tests are added here. Each change was checked during development against the real modules — the entry-point/fetch gating across all 14 integration-type × technology combinations, tab resolution and permission gating per seeded role, deep-link handling including the legacy alias, badge rendering and cache invalidation against a real `QueryClient`, and the generated runtime snippets for every type.

`tsc`, `eslint` and `prettier` are clean for every file touched. Three pre-existing `tsc` errors remain elsewhere in the tree and are untouched: `RegistryFileViewer`, `EditEnvironment`, and `SyncSwitch`'s type-only import of the undeclared `@mui/system`.

Not covered: no path was exercised in a browser as part of this, so the visual result of the tab badges, the bounded instances list and the scrollbar fix is worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

