### PR TITLE
Fix admin-only authorization bypass on admin resource sub-paths

### DIFF
--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/audit/AuditLogger.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/audit/AuditLogger.java
@@ -35,6 +35,9 @@ public final class AuditLogger {
     private static final String NA = "N/A";
     private static final String SUCCESS = "Success";
     private static final String FAILURE = "Failure";
+    private static final int MAX_FIELD_LENGTH = 256;
+    private static final int MAX_DATA_LENGTH = 2048;
+    private static final String TRUNCATION_SUFFIX = "...";
 
     private AuditLogger() {}
 
@@ -52,6 +55,24 @@ public final class AuditLogger {
         write(actor(username), "Logout", NA,
                 "\"username\" : \"" + actor(username) + "\"",
                 SUCCESS);
+    }
+
+    // -------------------------------------------------------------------------
+    // Authorization
+    // -------------------------------------------------------------------------
+
+    /**
+     * Records an authenticated user being refused access to a resource. Invalid or expired
+     * sessions (401) are deliberately not recorded here: they are routine on session expiry and
+     * would drown the genuine denials, and failed logins are already covered by
+     * {@link #logLogin(String, boolean)}.
+     */
+    public static void logAccessDenied(String performedBy, String method, String resource, String reason) {
+        write(actor(performedBy), "Access Denied", resource,
+                "\"method\" : \"" + method + "\""
+                        + ", \"resource\" : \"" + resource + "\""
+                        + ", \"reason\" : \"" + reason + "\"",
+                FAILURE);
     }
 
     // -------------------------------------------------------------------------
@@ -142,11 +163,31 @@ public final class AuditLogger {
     // -------------------------------------------------------------------------
 
     private static void write(String initiator, String action, String target, String data, String result) {
-        AUDIT_LOG.info("Initiator : " + initiator
-                + " | Action : " + action
-                + " | Target : " + target
-                + " | Data : { " + data + " }"
+        AUDIT_LOG.info("Initiator : " + clean(initiator, MAX_FIELD_LENGTH)
+                + " | Action : " + clean(action, MAX_FIELD_LENGTH)
+                + " | Target : " + clean(target, MAX_FIELD_LENGTH)
+                + " | Data : { " + clean(data, MAX_DATA_LENGTH) + " }"
                 + " | Result : " + result);
+    }
+
+    /**
+     * Keeps a single event on a single line. Values such as a denied request path are supplied by
+     * the caller of the REST API, so a raw line break would let one request forge additional audit
+     * entries. Over-long values are truncated to bound the damage of a padded field, with the
+     * ellipsis counted inside the limit so the emitted value never exceeds it.
+     */
+    private static String clean(String value, int maxLength) {
+        if (value == null) {
+            return NA;
+        }
+        String sanitized = value.replaceAll("[\\r\\n]", " ");
+        if (sanitized.length() <= maxLength) {
+            return sanitized;
+        }
+        // max() keeps the length non-negative: this runs while writing an audit entry, where an
+        // exception would both lose the record and surface as a 500 to the caller.
+        int keep = Math.max(0, maxLength - TRUNCATION_SUFFIX.length());
+        return sanitized.substring(0, keep) + TRUNCATION_SUFFIX;
     }
 
     private static String actor(String performedBy) {

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthenticationFilter.java
@@ -27,8 +27,10 @@ import org.wso2.micro.integrator.dashboard.utils.SSOConstants;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static org.wso2.ei.dashboard.core.commons.Constants.TOKEN_CACHE_TIMEOUT;
@@ -41,6 +43,7 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
@@ -59,7 +62,11 @@ import static org.wso2.ei.dashboard.core.commons.auth.JwtUtil.isJWTToken;
 @Priority(Priorities.AUTHENTICATION)
 public class AuthenticationFilter implements ContainerRequestFilter {
     private static final String AUTHENTICATION_SCHEME = "Bearer";
-    private static final List<String> ADMIN_ONLY_PATHS = Arrays.asList("/log-configs", "/users", "/roles");
+    // Resource types under /groups/{group-id}/ that only an admin may reach, in any form: the
+    // collection itself and every sub-path below it.
+    private static final Set<String> ADMIN_ONLY_RESOURCES = new HashSet<>(
+            Arrays.asList("log-configs", "users", "roles", "all-roles"));
+    private static final String GROUPS_RESOURCE = "groups";
     // Root resources reachable without a dashboard session. Anything not listed here requires authentication.
     //   login     - credential submission and the CSRF token used to submit it
     //   logout    - session teardown, which cannot require the session it is tearing down
@@ -68,7 +75,8 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     private static final List<String> UNAUTHENTICATED_PATHS =
             Arrays.asList("login", "logout", "heartbeat", "healthz");
     private static final String MAKE_NON_ADMIN_USERS_READ_ONLY = "make_non_admin_users_read_only";
-    private static final String ACTION_PERFORMED_BY = "performedBy";
+    private static final String ADMIN_ONLY_DENIAL = "Admin only resource";
+    private static final String READ_ONLY_DENIAL = "Read only mode is enabled for non-admin users";
     // Tracks SSO Bearer tokens that have already produced a login audit entry.
     // expireAfterAccess: an active session keeps the entry alive; eviction only happens on inactivity,
     // so a long-lived token does not generate repeated Login entries while it is in continuous use.
@@ -105,21 +113,36 @@ public class AuthenticationFilter implements ContainerRequestFilter {
             return;
         }
 
-        boolean makeNonAdminUsersReadOnly = Boolean.parseBoolean(System.getProperty(MAKE_NON_ADMIN_USERS_READ_ONLY));
-        if (isAdminResource(requestContext) && !securityHandler.isAuthorized(config, token)) {
-            // The user is authenticated but not permitted to access this resource.
-            abortWithForbidden(requestContext);
-            return;
-        }
-        if (!"GET".equalsIgnoreCase(httpMethod) && makeNonAdminUsersReadOnly
-                && !securityHandler.isAuthorized(config, token)) {
-            // For non-admin resources, request except GET are blocked
-            // if the 'makeNonAdminUsersReadOnly' is set to 'true'
-            abortWithForbidden(requestContext);
-            return;
-        }
+        // Resolved before the authorization checks so a denial can be attributed to a user in the
+        // audit log. Every SecurityHandler reads the subject from the token itself or from a cache
+        // populated during authentication, so this costs no additional remote call.
         String performedBy = securityHandler.getSubject(config, token);
-        requestContext.setProperty(ACTION_PERFORMED_BY, performedBy);
+        requestContext.setProperty(AuthorizationUtils.ACTION_PERFORMED_BY, performedBy);
+
+        // Evaluated lazily and at most once: for opaque SSO tokens isAuthorized() calls the
+        // userInfo endpoint whenever the caller is not a cached admin, so it must stay off the
+        // path of requests that do not need it.
+        Boolean isAdmin = null;
+        if (isAdminResource(requestContext)) {
+            isAdmin = resolveIsAdmin(requestContext, securityHandler, config, token);
+            if (!isAdmin) {
+                // The user is authenticated but not permitted to access this resource.
+                abortWithForbidden(requestContext, performedBy, ADMIN_ONLY_DENIAL);
+                return;
+            }
+        }
+        boolean makeNonAdminUsersReadOnly = Boolean.parseBoolean(System.getProperty(MAKE_NON_ADMIN_USERS_READ_ONLY));
+        if (!"GET".equalsIgnoreCase(httpMethod) && makeNonAdminUsersReadOnly) {
+            if (isAdmin == null) {
+                isAdmin = resolveIsAdmin(requestContext, securityHandler, config, token);
+            }
+            if (!isAdmin) {
+                // For non-admin resources, request except GET are blocked
+                // if the 'makeNonAdminUsersReadOnly' is set to 'true'
+                abortWithForbidden(requestContext, performedBy, READ_ONLY_DENIAL);
+                return;
+            }
+        }
 
         // Log SSO logins on first use of each Bearer token (cookie-based = local login, already audited in LoginDelegate)
         if (isTokenBasedAuthentication(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
@@ -153,20 +176,41 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         return separator < 0 ? path : path.substring(0, separator);
     }
 
+    /**
+     * Resolves whether the caller is an admin and records the verdict on the request, so that
+     * resource methods can assert on it without recomputing it.
+     */
+    private static boolean resolveIsAdmin(ContainerRequestContext requestContext, SecurityHandler securityHandler,
+                                          SSOConfig config, String token) {
+        boolean isAdmin = securityHandler.isAuthorized(config, token);
+        requestContext.setProperty(AuthorizationUtils.CALLER_IS_ADMIN, isAdmin);
+        return isAdmin;
+    }
+
+    /**
+     * Decides whether a request targets an admin-only resource.
+     *
+     * The resource type is the segment following the group id in
+     * {@code groups/{group-id}/<resource-type>/...}, so sub-paths such as
+     * {@code users/{user-id}} are covered along with the collection itself. Matching the last
+     * segment instead would leave every sub-path of an admin-only resource unprotected.
+     * Segments are compared decoded, so percent-encoded spellings cannot slip past.
+     */
     private static boolean isAdminResource(ContainerRequestContext requestContext) {
-        String path = ((ContainerRequest) requestContext).getPath(false);
-        int lastSeparator = path.lastIndexOf("/");
-        // A single segment path carries no separator to split on, so qualify it to match how ADMIN_ONLY_PATHS
-        // is written. Without this the substring below is called with -1 on such paths.
-        String resource = lastSeparator < 0 ? "/" + path : path.substring(lastSeparator);
-        return ADMIN_ONLY_PATHS.contains(resource);
+        List<PathSegment> segments = requestContext.getUriInfo().getPathSegments();
+        if (segments.size() < 3 || !GROUPS_RESOURCE.equals(segments.get(0).getPath())) {
+            return false;
+        }
+        return ADMIN_ONLY_RESOURCES.contains(segments.get(2).getPath());
     }
 
     private void abortWithUnauthorized(ContainerRequestContext requestContext) {
         abortWith(requestContext, Response.Status.UNAUTHORIZED, "Unauthorized");
     }
 
-    private void abortWithForbidden(ContainerRequestContext requestContext) {
+    private void abortWithForbidden(ContainerRequestContext requestContext, String performedBy, String reason) {
+        AuditLogger.logAccessDenied(performedBy, requestContext.getMethod(),
+                requestContext.getUriInfo().getPath(), reason);
         abortWith(requestContext, Response.Status.FORBIDDEN, "Forbidden");
     }
 

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthorizationUtils.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/auth/AuthorizationUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ei.dashboard.core.commons.auth;
+
+import org.wso2.ei.dashboard.core.commons.audit.AuditLogger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+/**
+ * Resource level authorization checks.
+ *
+ * These back up the admin-only path check in {@link AuthenticationFilter}. That check derives the
+ * verdict from the request URI, so a change to the API layout that stops it matching would fail
+ * open silently. Asserting here on the verdict the filter recorded keeps the destructive
+ * operations failing closed instead.
+ */
+public final class AuthorizationUtils {
+
+    /**
+     * Request property holding the username the request was authenticated as.
+     */
+    public static final String ACTION_PERFORMED_BY = "performedBy";
+
+    /**
+     * Request property holding the admin verdict computed by {@link AuthenticationFilter}. Absent
+     * when the filter did not need to evaluate authorization for the request.
+     */
+    public static final String CALLER_IS_ADMIN = "isAdmin";
+
+    private AuthorizationUtils() {
+    }
+
+    /**
+     * Rejects the request with a 403 unless the caller was confirmed to be an admin.
+     *
+     * @param requestContext context of the request being served
+     * @param action         description of the operation, recorded in the audit log on denial
+     */
+    public static void requireAdmin(ContainerRequestContext requestContext, String action) {
+        if (Boolean.TRUE.equals(requestContext.getProperty(CALLER_IS_ADMIN))) {
+            return;
+        }
+        // An absent property lands here too: it means authorization was never evaluated for this
+        // route, so the caller is unverified rather than known to be non-admin. Deny either way.
+        AuditLogger.logAccessDenied((String) requestContext.getProperty(ACTION_PERFORMED_BY),
+                requestContext.getMethod(), requestContext.getUriInfo().getPath(),
+                "Admin only operation: " + action);
+        Map<String, String> responseBody = new HashMap<>();
+        responseBody.put("message", "Forbidden");
+        throw new ForbiddenException(Response.status(Response.Status.FORBIDDEN).entity(responseBody)
+                .header("content-type", "application/json").build());
+    }
+}

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/GroupsApi.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/api/GroupsApi.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.dashboard.security.user.core.common.DashboardUserStoreException;
 import org.wso2.ei.dashboard.core.commons.audit.AuditLogger;
+import org.wso2.ei.dashboard.core.commons.auth.AuthorizationUtils;
 import org.wso2.ei.dashboard.core.commons.Constants;
 import org.wso2.ei.dashboard.core.commons.utils.HttpUtils;
 import org.wso2.ei.dashboard.core.exception.ManagementApiException;
@@ -297,6 +298,7 @@ public class GroupsApi {
             @PathParam("user-id") @Parameter(description = "User ID") String userId,
             @QueryParam("domain") @Parameter(description = "domain name") String domain,
             @Context ContainerRequestContext requestContext) {
+        AuthorizationUtils.requireAdmin(requestContext, "Delete User");
         String performedBy = (String) requestContext.getProperty("performedBy");
         try {
             Ack ack = UsersDelegate.getDelegate(groupId).deleteUser(userId, domain, performedBy);
@@ -1064,6 +1066,7 @@ public class GroupsApi {
             @PathParam("node-id") @Parameter(description = "NodeId") String nodeId,
             @Valid LogConfigUpdateRequest request,
             @Context ContainerRequestContext requestContext) throws ManagementApiException {
+        AuthorizationUtils.requireAdmin(requestContext, "Update Log Config");
         LogConfigDelegate logConfigDelegate = new LogConfigDelegate();
         Ack ack = logConfigDelegate.updateLogLevelByNodeId(groupId, nodeId, request);
         if (Constants.SUCCESS_STATUS.equals(ack.getStatus())) {
@@ -1543,6 +1546,7 @@ public class GroupsApi {
             @PathParam("role-name") @Parameter(description = "Role Name") String roleName,
             @QueryParam("domain") @Parameter(description = "domain name") String domain,
             @Context ContainerRequestContext requestContext) {
+        AuthorizationUtils.requireAdmin(requestContext, "Delete Role");
         try {
             Ack ack = RolesDelegate.getDelegate(groupId).deleteRole(roleName, domain);
             String performedBy = (String) requestContext.getProperty("performedBy");


### PR DESCRIPTION
The admin-only check in AuthenticationFilter compared only the last path segment against the admin-only list, so any endpoint whose template ends in a path parameter escaped the gate. A non-admin dashboard user could delete users and roles on the managed nodes and change a node's log level, while the plain collection paths were still correctly blocked with 403.

## Related Issues

Fixes: https://github.com/wso2-enterprise/wso2-integration-internal/issues/5223
