### PR TITLE
[Devant migration] Build promotion refs from the environment handle

### DIFF
--- a/ipaas/src/api/cloud/_environmentShape.ts
+++ b/ipaas/src/api/cloud/_environmentShape.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The BFF environment wire shape, and the one mapper that normalizes it.
+ *
+ * Two domain modules need this: `environments.ts` for environment CRUD, and
+ * `deploymentPipelines.ts` to project environments into promotion-chain templates.
+ * It lives in its own module so neither of them has to depend on the other —
+ * `environments.ts` already imports `appendEnvironmentToDefaultPipeline` from
+ * `deploymentPipelines.ts`, so exporting the mapper from `environments.ts` instead
+ * would close an import cycle.
+ *
+ * Keeping a second, hand-rolled copy of this shape is what caused pipelines to be
+ * written with environment display names instead of slugs: the duplicate read `name`
+ * as the slug, so every promotion ref built from it pointed at a label
+ * ("Development") rather than an environment ("development"), and autoDeploy then
+ * failed for every component in the project. Add fields here, not in a local
+ * interface.
+ */
+
+import type { Environment } from '../../types/environment';
+
+// OpenChoreo Environments are K8s resources: `name` is an RFC 1123 slug and the
+// identity used in every path (`/environments/{name}`) and in a pipeline's
+// promotion refs, while the human label lives in `displayName`. The frontend
+// Environment carries `id` (slug) and `name` (label) and expresses "production"
+// as `critical`, so we translate between the two shapes at the boundary.
+export interface BffEnvironment {
+  // The BFF serves the RFC 1123 slug as `id` and the human label as `name`, and
+  // flags production via `critical` with the dataplane in `dpId`. The
+  // slug/displayName/isProduction/dataPlaneRef aliases are tolerated as fallbacks.
+  id?: string;
+  uid?: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  dataPlaneRef?: string;
+  dpId?: string;
+  isProduction?: boolean;
+  critical?: boolean;
+  createdAt?: string;
+}
+
+// `id` must be the slug used in every path (`/environments/{name}`), in a pipeline's
+// promotion refs, and in the immutable ReleaseBinding `spec.environment` — NOT the
+// display label, or deploys mismatch the binding (e.g. label "Development" vs slug
+// "development").
+export const toEnvironment = (e: BffEnvironment): Environment => ({
+  id: e.id || e.name,
+  name: e.displayName || e.name,
+  critical: e.critical ?? e.isProduction ?? false,
+  description: e.description,
+  createdAt: e.createdAt,
+  dpId: e.dpId ?? e.dataPlaneRef,
+});

--- a/ipaas/src/api/cloud/deploymentPipelines.ts
+++ b/ipaas/src/api/cloud/deploymentPipelines.ts
@@ -40,6 +40,11 @@
 import type { CreateDeploymentPipelineRequest, DeploymentPipeline, EnvTemplate, PipelineDeletionEligibility, PromotionTreeNode } from '../../types/deploymentPipeline';
 import { toHandler } from '../../utils/string';
 import { bff, items, seg, type ListResponse } from './_client';
+// environments.ts imports appendEnvironmentToDefaultPipeline from here, so this edge
+// closes an import cycle. It is safe because both sides are referenced only inside
+// function bodies, never at module scope — ESM live bindings are initialised by the
+// time either is called. Do not move these references to module scope.
+import { toEnvironment, type BffEnvironment } from './environments';
 
 // _orgUuid / _orgNumericId are kept for devant contract parity; cloud derives
 // the org from the access token instead of taking an id from the caller.
@@ -68,7 +73,14 @@ interface BffProject {
   deploymentPipeline?: string;
 }
 
-/** Walk the promotion tree, emitting a path per node that has children. */
+/**
+ * Walk the promotion tree, emitting a path per node that has children.
+ *
+ * Refs come from `env_template_id`, which carries the environment slug. The
+ * `?? env_name` fallback exists only for trees that predate the id — `env_name`
+ * holds a *display label*, so anything resolved through the fallback is written to
+ * the CR as-is and will not match an Environment.
+ */
 const treeToPromotionPaths = (tree: PromotionTreeNode | null | undefined): BffPromotionPath[] => {
   const paths: BffPromotionPath[] = [];
   const walk = (nodes: PromotionTreeNode[] | undefined): void => {
@@ -152,23 +164,19 @@ export const appendEnvironmentToDefaultPipeline = async (envSlug: string): Promi
 
 // OpenChoreo models no environment templates — the promotion chain is built over
 // environments directly, so each environment is projected into an EnvTemplate.
-interface BffEnvironmentTemplateSource {
-  name: string;
-  displayName?: string;
-  isProduction?: boolean;
-}
-
 export const fetchEnvTemplates = (_orgNumericId: number): Promise<EnvTemplate[]> =>
-  bff.get<ListResponse<BffEnvironmentTemplateSource>>('/environments').then((r) =>
-    items(r).map((e) => ({
-      id: e.name,
-      env_name: e.displayName || e.name,
-      critical: e.isProduction ?? false,
-      region: '',
-      choreo_env: '',
-      cluster_id: '',
-      dns_prefix: '',
-    })),
+  bff.get<ListResponse<BffEnvironment>>('/environments').then((r) =>
+    items(r)
+      .map(toEnvironment)
+      .map((e) => ({
+        id: e.id,
+        env_name: e.name,
+        critical: e.critical,
+        region: '',
+        choreo_env: '',
+        cluster_id: '',
+        dns_prefix: '',
+      })),
   );
 
 export const fetchOrgDeploymentPipelines = (_orgUuid: string): Promise<DeploymentPipeline[]> => bff.get<ListResponse<BffDeploymentPipeline>>('/deploymentpipelines').then((r) => items(r).map(toDeploymentPipeline));

--- a/ipaas/src/api/cloud/deploymentPipelines.ts
+++ b/ipaas/src/api/cloud/deploymentPipelines.ts
@@ -40,11 +40,7 @@
 import type { CreateDeploymentPipelineRequest, DeploymentPipeline, EnvTemplate, PipelineDeletionEligibility, PromotionTreeNode } from '../../types/deploymentPipeline';
 import { toHandler } from '../../utils/string';
 import { bff, items, seg, type ListResponse } from './_client';
-// environments.ts imports appendEnvironmentToDefaultPipeline from here, so this edge
-// closes an import cycle. It is safe because both sides are referenced only inside
-// function bodies, never at module scope — ESM live bindings are initialised by the
-// time either is called. Do not move these references to module scope.
-import { toEnvironment, type BffEnvironment } from './environments';
+import { toEnvironment, type BffEnvironment } from './_environmentShape';
 
 // _orgUuid / _orgNumericId are kept for devant contract parity; cloud derives
 // the org from the access token instead of taking an id from the caller.

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -30,7 +30,14 @@ import { bff, items, q, seg, type ListResponse, type MessageResponse } from './_
 // promotion refs, while the human label lives in `displayName`. The frontend
 // Environment carries `id` (slug) and `name` (label) and expresses "production"
 // as `critical`, so we translate between the two shapes at the boundary.
-interface BffEnvironment {
+//
+// Exported because deploymentPipelines.ts projects environments into promotion-chain
+// templates and must use this same mapping. Keeping a second, hand-rolled copy there
+// is what caused pipelines to be written with display names instead of slugs: the
+// duplicate read `name` as the slug, so every promotion ref pointed at a label
+// ("Development") rather than an environment ("development"). Add fields here, not in
+// a local interface.
+export interface BffEnvironment {
   // The BFF serves the RFC 1123 slug as `id` and the human label as `name`, and
   // flags production via `critical` with the dataplane in `dpId`. The
   // slug/displayName/isProduction/dataPlaneRef aliases are tolerated as fallbacks.
@@ -46,10 +53,11 @@ interface BffEnvironment {
   createdAt?: string;
 }
 
-// `id` must be the slug used in every path (`/environments/{name}`) and in the
-// immutable ReleaseBinding `spec.environment` — NOT the display label, or deploys
-// mismatch the binding (e.g. label "Development" vs slug "development").
-const toEnvironment = (e: BffEnvironment): Environment => ({
+// `id` must be the slug used in every path (`/environments/{name}`), in a pipeline's
+// promotion refs, and in the immutable ReleaseBinding `spec.environment` — NOT the
+// display label, or deploys mismatch the binding (e.g. label "Development" vs slug
+// "development").
+export const toEnvironment = (e: BffEnvironment): Environment => ({
   id: e.id || e.name,
   name: e.displayName || e.name,
   critical: e.critical ?? e.isProduction ?? false,

--- a/ipaas/src/api/cloud/environments.ts
+++ b/ipaas/src/api/cloud/environments.ts
@@ -22,49 +22,11 @@ import type { CloudDataPlane, CreateEnvironmentData, EnvDeletionEligibility, Env
 import { toHandler } from '../../utils/string';
 import { appendEnvironmentToDefaultPipeline } from './deploymentPipelines';
 import { bff, items, q, seg, type ListResponse, type MessageResponse } from './_client';
+// The wire shape and its mapper live in their own module so this file and
+// deploymentPipelines.ts can share one definition without importing each other.
+import { toEnvironment, type BffEnvironment } from './_environmentShape';
 
 // _orgUuid is kept for devant contract parity; cloud derives the org from the token.
-
-// OpenChoreo Environments are K8s resources: `name` is an RFC 1123 slug and the
-// identity used in every path (`/environments/{name}`) and in a pipeline's
-// promotion refs, while the human label lives in `displayName`. The frontend
-// Environment carries `id` (slug) and `name` (label) and expresses "production"
-// as `critical`, so we translate between the two shapes at the boundary.
-//
-// Exported because deploymentPipelines.ts projects environments into promotion-chain
-// templates and must use this same mapping. Keeping a second, hand-rolled copy there
-// is what caused pipelines to be written with display names instead of slugs: the
-// duplicate read `name` as the slug, so every promotion ref pointed at a label
-// ("Development") rather than an environment ("development"). Add fields here, not in
-// a local interface.
-export interface BffEnvironment {
-  // The BFF serves the RFC 1123 slug as `id` and the human label as `name`, and
-  // flags production via `critical` with the dataplane in `dpId`. The
-  // slug/displayName/isProduction/dataPlaneRef aliases are tolerated as fallbacks.
-  id?: string;
-  uid?: string;
-  name: string;
-  displayName?: string;
-  description?: string;
-  dataPlaneRef?: string;
-  dpId?: string;
-  isProduction?: boolean;
-  critical?: boolean;
-  createdAt?: string;
-}
-
-// `id` must be the slug used in every path (`/environments/{name}`), in a pipeline's
-// promotion refs, and in the immutable ReleaseBinding `spec.environment` — NOT the
-// display label, or deploys mismatch the binding (e.g. label "Development" vs slug
-// "development").
-export const toEnvironment = (e: BffEnvironment): Environment => ({
-  id: e.id || e.name,
-  name: e.displayName || e.name,
-  critical: e.critical ?? e.isProduction ?? false,
-  description: e.description,
-  createdAt: e.createdAt,
-  dpId: e.dpId ?? e.dataPlaneRef,
-});
 
 export const fetchEnvironments = (_orgUuid: string, projectId: string): Promise<Environment[]> => bff.get<ListResponse<BffEnvironment>>(`/environments${q({ project: projectId })}`).then((r) => items(r).map(toEnvironment));
 


### PR DESCRIPTION
Saving a CD pipeline wrote environment display names into the promotion paths, which broke autoDeploy for every component in the project:

  Failed to handle autoDeploy: failed to create ReleaseBinding:
  ReleaseBinding.openchoreo.dev "<component>-Development" is invalid:
  metadata.name: ... must be a lowercase RFC 1123 subdomain

fetchEnvTemplates read the slug from `e.name`, but ipaas-service serves the slug as `id` and the human label as `name` (see its responses.ToEnvironment) and sends no `displayName` at all. So EnvTemplate.id held "Development", and since the editor builds promotion refs from those ids -- buildPromotionTree sets env_template_id from EnvTemplate.id, and treeToPromotionPaths puts it on the wire -- every saved ref pointed at a label rather than an environment. Nothing downstream validates the ref: PromotionPath has no CRD pattern, there is no DeploymentPipeline webhook, and openchoreo-api only checks existence/conflict, so the bad value reached the CR unchallenged. The same mapping also read `isProduction`, which the BFF does not send either, so production flags silently read as false.

The cause was a second, hand-rolled copy of the environment wire shape: environments.ts already normalised it correctly and even carried a comment warning about this exact failure, while deploymentPipelines.ts had its own narrower interface that drifted. Delete the duplicate and export the one mapper instead, so there is a single place to keep correct.

That makes deploymentPipelines.ts import from environments.ts, which imports appendEnvironmentToDefaultPipeline back -- a cycle. It is safe because both sides are only referenced inside function bodies, so ESM live bindings are initialised before either runs; verified in both load orders and in a production build, which emits no circular-dependency warning. Noted at the import so it is not later "fixed" into a module-scope reference.


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.