### PR TITLE
Add missing VITE_TRYIT_URL and VITE_WORKFLOW_URL to frontend config

### DIFF
--- a/icp_server/config.bal
+++ b/icp_server/config.bal
@@ -90,6 +90,8 @@ configurable string[] tlsCiphers = [
 configurable string backendGraphqlEndpoint = publicBaseUrl + "/graphql";
 configurable string backendAuthBaseUrl = publicBaseUrl + "/auth";
 configurable string backendObservabilityEndpoint = publicBaseUrl + "/icp/observability";
+configurable string backendWorkflowEndpoint = publicBaseUrl + "/icp/workflow";
+configurable string backendTryitEndpoint = publicBaseUrl + "/icp/tryit";
 
 // WebSocket endpoint — shares the main HTTPS port so no separate cert trust is needed
 configurable string backendWsUrl = toWsScheme(publicBaseUrl) + "/runtime-status";

--- a/icp_server/webserver.bal
+++ b/icp_server/webserver.bal
@@ -173,6 +173,8 @@ function updateFrontendConfig() returns error? {
         "VITE_GRAPHQL_URL": backendGraphqlEndpoint,
         "VITE_AUTH_BASE_URL": backendAuthBaseUrl,
         "VITE_OBSERVABILITY_URL": backendObservabilityEndpoint,
+        "VITE_WORKFLOW_URL": backendWorkflowEndpoint,
+        "VITE_TRYIT_URL": backendTryitEndpoint,
         "VITE_WS_URL": backendWsUrl,
         "VITE_SSO_ENABLED": ssoEnabled,
         "VITE_ICP_VERSION": icpVersion


### PR DESCRIPTION
## Summary
- `updateFrontendConfig()` in `icp_server/webserver.bal` writes `www/config.json` with only `VITE_GRAPHQL_URL`, `VITE_AUTH_BASE_URL`, `VITE_OBSERVABILITY_URL`, and `VITE_WS_URL`.
- The frontend's Test Console (`TestConsoleSwaggerPanel`/`TestConsole.tsx` → `tryitApiUrl`) and workflow management features read `VITE_TRYIT_URL`/`VITE_WORKFLOW_URL` from that file via `window.API_CONFIG`, and silently fall back to a hardcoded `https://localhost:9446/...` default when the keys are missing.
- In any deployment not accessed through `localhost` (e.g. behind a Gateway/ingress at a real hostname), that fallback URL is unreachable from the browser — "Try it out" in the Test Console fails outright.
- Adds `backendTryitEndpoint` and `backendWorkflowEndpoint` configurables in `icp_server/config.bal`, following the existing `backendGraphqlEndpoint`/`backendAuthBaseUrl`/`backendObservabilityEndpoint` pattern (derived from `publicBaseUrl`), and includes both in the generated `config.json`.

## Test plan
- [x] Rebuilt the distribution and redeployed to a local Kubernetes cluster with `publicBaseUrl` overridden to a non-localhost hostname.
- [x] Verified `/config.json` now serves `VITE_TRYIT_URL` and `VITE_WORKFLOW_URL` pointing at the configured public hostname instead of falling back to `https://localhost:9446`.
- [ ] Existing `bal test` suite (blocked locally by an unrelated pre-existing compile error: `Mutation.updateProject` uses `ProjectUpdateInput` as both an input and output GraphQL type — not touched by this change).