### PR TITLE
[WSO2 Cloud] Implement Component Runtime Page

### DIFF
--- a/ipaas/src/api/cloud/runtime.ts
+++ b/ipaas/src/api/cloud/runtime.ts
@@ -16,16 +16,92 @@
  * under the License.
  */
 
-// Component runtime (pods/metrics/redeploy) is a wip-only surface for now. Signatures mirror Contracts.RuntimeApi.
-import type { ClusterPod, PodEvent, PodLogOptions, PodMetrics, RuntimeReleaseDetails } from '../../types/runtime';
+// Component runtime (release detail, pods, metrics, redeploy) backed by the ipaas-service
+// runtime endpoints. Releases are addressed by componentName (handler) + releaseId — there's
+// no cluster/namespace concept in this API, unlike the wip devops proxy. Signatures mirror
+// Contracts.RuntimeApi; the clusterId/namespace params exist only for that parity and are unused.
+import { BffError, bff, q, seg } from './_client';
+import type { ClusterPod, PodEvent, PodLogOptions, RuntimeMetrics, RuntimeReleaseDetails } from '../../types/runtime';
 
-const ni = (name: string): never => {
-  throw new Error(`[cloud] runtime.${name}: not implemented`);
+// A failed log read answers `{ error, message }` with the real, user-facing reason (e.g.
+// "previous container logs are not supported") — unwrap it so callers see that, not the raw
+// `HTTP 400: {"error":...}` envelope text.
+function podLogsError(error: unknown): Error {
+  if (error instanceof BffError) {
+    try {
+      const body = JSON.parse(error.body) as { message?: string };
+      if (body.message) return new Error(body.message);
+    } catch {
+      // Not JSON — fall through to the raw error below.
+    }
+  }
+  return error instanceof Error ? error : new Error('Failed to fetch container logs');
+}
+
+const releasePath = (componentName: string, releaseId: string): string => `/components/${seg(componentName)}/releases/${seg(releaseId)}`;
+
+/** Only replicas/undeployed are guaranteed by the backend — every other key may be omitted. */
+interface CloudReleaseRuntime {
+  componentId?: string;
+  releaseId?: string;
+  namespace?: string;
+  replicas: number;
+  undeployed: boolean;
+  image?: string;
+  lastDeployedMessage?: string;
+}
+
+// Prefer the response's own componentId/releaseId over the request params — they're the
+// OpenChoreo-side identifiers, which is what the Runtime page displays for cloud.
+function toReleaseDetails(raw: CloudReleaseRuntime, releaseId: string): RuntimeReleaseDetails {
+  return {
+    ID: raw.releaseId ?? releaseId,
+    componentId: raw.componentId,
+    namespace: raw.namespace ?? '',
+    replicas: raw.replicas,
+    undeployed: raw.undeployed,
+    image: raw.image,
+    latest_deployment: raw.lastDeployedMessage ? { deployment_history: { change_message: raw.lastDeployedMessage } } : undefined,
+    environment: { environment_clusters: [], namespace: raw.namespace },
+  };
+}
+
+/** Full runtime detail for a deployed release (replicas, namespace, last-deployed message). */
+export const fetchReleaseDetails = (_projectId: string, _componentId: string, componentName: string, releaseId: string): Promise<RuntimeReleaseDetails> =>
+  bff.get<CloudReleaseRuntime>(`${releasePath(componentName, releaseId)}/runtime`).then((raw) => toReleaseDetails(raw, releaseId));
+
+/** Pods for a release. An empty array is normal (scaled to zero, or no current binding). */
+export const fetchComponentPods = (_projectId: string, componentName: string, _clusterId: string, releaseId: string, _namespace: string): Promise<ClusterPod[]> =>
+  bff.get<ClusterPod[]>(`${releasePath(componentName, releaseId)}/pods`);
+
+/**
+ * OpenChoreo has no pod-level metrics source — `podLevelMetrics` is always `[]`.
+ * `componentLevelMetrics` is the real aggregate and is absent (not zeroed) whenever it
+ * can't be resolved (no binding, Observer unreachable). Passed straight through.
+ */
+export const fetchComponentPodMetrics = (_projectId: string, componentName: string, _clusterId: string, releaseId: string, _namespace: string): Promise<RuntimeMetrics> =>
+  bff.get<RuntimeMetrics>(`${releasePath(componentName, releaseId)}/metrics`);
+
+/** Redeploy the currently deployed release ("Redeploy Release" button). No request body. */
+export const redeployRelease = (_projectId: string, _componentId: string, componentName: string, releaseId: string, _message?: string): Promise<void> =>
+  bff.post<{ message: string }>(`${releasePath(componentName, releaseId)}/redeploy`).then(() => undefined);
+
+/** Recent lifecycle events for one pod (~1hr retention) — an empty array is normal. */
+export const fetchPodEvents = (_projectId: string, componentName: string, releaseId: string, _clusterId: string, _namespace: string, podName: string): Promise<PodEvent[]> =>
+  bff.get<PodEvent[]>(`${releasePath(componentName, releaseId)}/pods/${seg(podName)}/events`);
+
+/**
+ * Container logs for one pod. `previous` isn't supported by OpenChoreo's log API — a request
+ * for it fails with a 400 (the real reason lands in the thrown error's message) rather than
+ * silently returning current logs, which would misreport which instance the logs are from.
+ */
+export const fetchPodLogs = async (_projectId: string, componentName: string, releaseId: string, _clusterId: string, _namespace: string, podName: string, options: PodLogOptions): Promise<string> => {
+  try {
+    const res = await bff.get<{ logs: string }>(
+      `${releasePath(componentName, releaseId)}/pods/${seg(podName)}/logs${q({ containerName: options.containerName, sinceSeconds: options.sinceSeconds, maxTailLines: options.maxTailLines, previous: options.previous })}`,
+    );
+    return res.logs ?? '';
+  } catch (e) {
+    throw podLogsError(e);
+  }
 };
-
-export const fetchReleaseDetails = (_projectId: string, _componentId: string, _releaseId: string): Promise<RuntimeReleaseDetails> => ni('fetchReleaseDetails');
-export const fetchComponentPods = (_projectId: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<ClusterPod[]> => ni('fetchComponentPods');
-export const fetchComponentPodMetrics = (_projectId: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<PodMetrics[]> => ni('fetchComponentPodMetrics');
-export const redeployRelease = (_projectId: string, _componentId: string, _releaseId: string, _message?: string): Promise<void> => ni('redeployRelease');
-export const fetchPodEvents = (_projectId: string, _clusterId: string, _namespace: string, _podName: string): Promise<PodEvent[]> => ni('fetchPodEvents');
-export const fetchPodLogs = (_projectId: string, _clusterId: string, _namespace: string, _podName: string, _options: PodLogOptions): Promise<string> => ni('fetchPodLogs');

--- a/ipaas/src/api/contracts.ts
+++ b/ipaas/src/api/contracts.ts
@@ -113,7 +113,7 @@ import type { CreateUrlMappingInput, CustomDomain, CustomDomainType, CustomUrlMa
 import type { OrgWorkflowConfig, ReviewerDecisionRequest, WorkflowConfigRequest, WorkflowDefinition, WorkflowInstanceResponse, WorkflowReviewData } from '../types/workflow';
 import type { Dataplane, IdentityProvider, IdentityProviderRequest, RoleGroupMappingResponse } from '../types/appSecurity';
 import type { Cluster, PdpManagerPdp } from '../types/dataPlanes';
-import type { ClusterPod as RuntimeClusterPod, PodEvent as RuntimePodEvent, PodLogOptions as RuntimePodLogOptions, PodMetrics as RuntimePodMetrics, RuntimeReleaseDetails } from '../types/runtime';
+import type { ClusterPod as RuntimeClusterPod, PodEvent as RuntimePodEvent, PodLogOptions as RuntimePodLogOptions, RuntimeMetrics, RuntimeReleaseDetails } from '../types/runtime';
 import type { CreateGitCredentialInput, CredentialDeleteEligibility, GitCredential } from '../types/credentials';
 import type { Environment, CloudDataPlane, EnvironmentInput, EnvironmentTemplate, CreateEnvironmentData, EnvDeletionEligibility } from '../types/environment';
 import type { ExecutionConfigs, TaskExecution, ExecutionLogEntry, ExecutionArgument, UpdateJobConfigsInput, TriggerComponentInput, TriggerRunResult, RuntimeArgument } from '../types/executions';
@@ -912,12 +912,14 @@ export interface DataPlanesApi {
 // ---------------------------------------------------------------------------
 
 export interface RuntimeApi {
-  fetchReleaseDetails(projectId: string, componentId: string, releaseId: string): Promise<RuntimeReleaseDetails>;
-  fetchComponentPods(projectId: string, clusterId: string, releaseId: string, namespace: string): Promise<RuntimeClusterPod[]>;
-  fetchComponentPodMetrics(projectId: string, clusterId: string, releaseId: string, namespace: string): Promise<RuntimePodMetrics[]>;
-  redeployRelease(projectId: string, componentId: string, releaseId: string, message?: string): Promise<void>;
-  fetchPodEvents(projectId: string, clusterId: string, namespace: string, podName: string): Promise<RuntimePodEvent[]>;
-  fetchPodLogs(projectId: string, clusterId: string, namespace: string, podName: string, options: RuntimePodLogOptions): Promise<string>;
+  // componentId is a UUID (wip); componentName is the handler slug (cloud) — each
+  // product's implementation uses whichever one its backend addresses releases by.
+  fetchReleaseDetails(projectId: string, componentId: string, componentName: string, releaseId: string): Promise<RuntimeReleaseDetails>;
+  fetchComponentPods(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string): Promise<RuntimeClusterPod[]>;
+  fetchComponentPodMetrics(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string): Promise<RuntimeMetrics>;
+  redeployRelease(projectId: string, componentId: string, componentName: string, releaseId: string, message?: string): Promise<void>;
+  fetchPodEvents(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string): Promise<RuntimePodEvent[]>;
+  fetchPodLogs(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string, options: RuntimePodLogOptions): Promise<string>;
 }
 
 export interface AppApi {

--- a/ipaas/src/api/icp/runtime.ts
+++ b/ipaas/src/api/icp/runtime.ts
@@ -16,16 +16,16 @@
  * under the License.
  */
 
-// Component runtime (pods/metrics/redeploy) is a wip-only surface for now. Signatures mirror Contracts.RuntimeApi.
-import type { ClusterPod, PodEvent, PodLogOptions, PodMetrics, RuntimeReleaseDetails } from '../../types/runtime';
+// Component runtime (pods/metrics/redeploy) has no icp backend yet. Signatures mirror Contracts.RuntimeApi.
+import type { ClusterPod, PodEvent, PodLogOptions, RuntimeMetrics, RuntimeReleaseDetails } from '../../types/runtime';
 
 const ni = (name: string): never => {
   throw new Error(`[icp] runtime.${name}: not implemented`);
 };
 
-export const fetchReleaseDetails = (_projectId: string, _componentId: string, _releaseId: string): Promise<RuntimeReleaseDetails> => ni('fetchReleaseDetails');
-export const fetchComponentPods = (_projectId: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<ClusterPod[]> => ni('fetchComponentPods');
-export const fetchComponentPodMetrics = (_projectId: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<PodMetrics[]> => ni('fetchComponentPodMetrics');
-export const redeployRelease = (_projectId: string, _componentId: string, _releaseId: string, _message?: string): Promise<void> => ni('redeployRelease');
-export const fetchPodEvents = (_projectId: string, _clusterId: string, _namespace: string, _podName: string): Promise<PodEvent[]> => ni('fetchPodEvents');
-export const fetchPodLogs = (_projectId: string, _clusterId: string, _namespace: string, _podName: string, _options: PodLogOptions): Promise<string> => ni('fetchPodLogs');
+export const fetchReleaseDetails = (_projectId: string, _componentId: string, _componentName: string, _releaseId: string): Promise<RuntimeReleaseDetails> => ni('fetchReleaseDetails');
+export const fetchComponentPods = (_projectId: string, _componentName: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<ClusterPod[]> => ni('fetchComponentPods');
+export const fetchComponentPodMetrics = (_projectId: string, _componentName: string, _clusterId: string, _releaseId: string, _namespace: string): Promise<RuntimeMetrics> => ni('fetchComponentPodMetrics');
+export const redeployRelease = (_projectId: string, _componentId: string, _componentName: string, _releaseId: string, _message?: string): Promise<void> => ni('redeployRelease');
+export const fetchPodEvents = (_projectId: string, _componentName: string, _releaseId: string, _clusterId: string, _namespace: string, _podName: string): Promise<PodEvent[]> => ni('fetchPodEvents');
+export const fetchPodLogs = (_projectId: string, _componentName: string, _releaseId: string, _clusterId: string, _namespace: string, _podName: string, _options: PodLogOptions): Promise<string> => ni('fetchPodLogs');

--- a/ipaas/src/api/wip/runtime.ts
+++ b/ipaas/src/api/wip/runtime.ts
@@ -18,7 +18,7 @@
 
 import { getOrgUuidFromToken } from '../../auth/tokenManager';
 import { choreoClient, withScopeRetry } from './httpClients';
-import type { ClusterPod, PodEvent, PodLogOptions, PodMetrics, RuntimeReleaseDetails } from '../../types/runtime';
+import type { ClusterPod, PodEvent, PodLogOptions, PodMetrics, RuntimeMetrics, RuntimeReleaseDetails } from '../../types/runtime';
 
 // Component runtime data lives on the choreo gateway devops service; REST calls
 // carry organization_id + project_id query params (org UUID comes from the token).
@@ -29,7 +29,7 @@ function commonParams(projectId: string): URLSearchParams {
 }
 
 /** Full runtime detail for a deployed release (replicas, namespace, cluster, last-deployed). */
-export function fetchReleaseDetails(projectId: string, componentId: string, releaseId: string): Promise<RuntimeReleaseDetails> {
+export function fetchReleaseDetails(projectId: string, componentId: string, _componentName: string, releaseId: string): Promise<RuntimeReleaseDetails> {
   return withScopeRetry(async () => {
     const res = await choreoClient.get<{ data: RuntimeReleaseDetails }>(`${BASE}/components/${encodeURIComponent(componentId)}/release/${encodeURIComponent(releaseId)}?${commonParams(projectId).toString()}`);
     return res.data;
@@ -49,13 +49,15 @@ async function queryDpResources<T>(projectId: string, clusterId: string, apiVers
 }
 
 /** Pods for a release (labelSelector release_id=…). */
-export function fetchComponentPods(projectId: string, clusterId: string, releaseId: string, namespace: string): Promise<ClusterPod[]> {
+export function fetchComponentPods(projectId: string, _componentName: string, clusterId: string, releaseId: string, namespace: string): Promise<ClusterPod[]> {
   return withScopeRetry(() => queryDpResources<ClusterPod>(projectId, clusterId, 'v1', 'Pod', { namespace, labelSelector: `release_id=${releaseId}` }));
 }
 
-/** Live cpu/memory metrics for a release's pods. */
-export function fetchComponentPodMetrics(projectId: string, clusterId: string, releaseId: string, namespace: string): Promise<PodMetrics[]> {
-  return withScopeRetry(() => queryDpResources<PodMetrics>(projectId, clusterId, encodeURIComponent('metrics.k8s.io/v1beta1'), 'PodMetrics', { namespace, labelSelector: `release_id=${releaseId}` }));
+/** Live cpu/memory metrics for a release's pods. There's no component-level aggregate on this backend — the caller computes it from pods + podLevelMetrics. */
+export function fetchComponentPodMetrics(projectId: string, _componentName: string, clusterId: string, releaseId: string, namespace: string): Promise<RuntimeMetrics> {
+  return withScopeRetry(async () => ({
+    podLevelMetrics: await queryDpResources<PodMetrics>(projectId, clusterId, encodeURIComponent('metrics.k8s.io/v1beta1'), 'PodMetrics', { namespace, labelSelector: `release_id=${releaseId}` }),
+  }));
 }
 
 interface RawPodEvent {
@@ -83,7 +85,7 @@ function toPodEvent(raw: RawPodEvent): PodEvent {
 }
 
 /** Events the cluster published about one pod. */
-export async function fetchPodEvents(projectId: string, clusterId: string, namespace: string, podName: string): Promise<PodEvent[]> {
+export async function fetchPodEvents(projectId: string, _componentName: string, _releaseId: string, clusterId: string, namespace: string, podName: string): Promise<PodEvent[]> {
   const raw = await withScopeRetry(() => queryDpResources<RawPodEvent>(projectId, clusterId, 'v1', 'Event', { namespace, fieldSelector: `involvedObject.name=${podName}` }));
   return raw.map(toPodEvent);
 }
@@ -110,7 +112,7 @@ function podLogsError(error: unknown): Error {
  * Container logs for one pod. The devops proxy answers with the whole log as a single
  * string; `stream: false` keeps it a plain request rather than a live tail.
  */
-export function fetchPodLogs(projectId: string, clusterId: string, namespace: string, podName: string, options: PodLogOptions): Promise<string> {
+export function fetchPodLogs(projectId: string, _componentName: string, _releaseId: string, clusterId: string, namespace: string, podName: string, options: PodLogOptions): Promise<string> {
   const body = { stream: false, namespace, podName, containerName: options.containerName, previous: options.previous, sinceSeconds: options.sinceSeconds, maxTailLines: options.maxTailLines };
   return withScopeRetry(async () => {
     try {
@@ -123,6 +125,6 @@ export function fetchPodLogs(projectId: string, clusterId: string, namespace: st
 }
 
 /** Redeploy the currently deployed release ("Redeploy Release" button). */
-export function redeployRelease(projectId: string, componentId: string, releaseId: string, message = 'Manually redeployed'): Promise<void> {
+export function redeployRelease(projectId: string, componentId: string, _componentName: string, releaseId: string, message = 'Manually redeployed'): Promise<void> {
   return withScopeRetry(() => choreoClient.post<void>(`${BASE}/components/${encodeURIComponent(componentId)}/release/${encodeURIComponent(releaseId)}/deploy-deployment?${commonParams(projectId).toString()}`, { message }));
 }

--- a/ipaas/src/components/Runtime/CopyField.tsx
+++ b/ipaas/src/components/Runtime/CopyField.tsx
@@ -22,7 +22,7 @@ import { useState, type JSX } from 'react';
 import { copyValueBox, fieldLabel } from './CopyField.styles';
 
 /** A labelled, read-only monospace value with a copy-to-clipboard button. */
-export default function CopyField({ label, value }: { label: string; value: string }): JSX.Element {
+export default function CopyField({ label, value, emptyText = '—' }: { label: string; value: string; emptyText?: string }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const [failed, setFailed] = useState(false);
   const onCopy = () => {
@@ -47,8 +47,8 @@ export default function CopyField({ label, value }: { label: string; value: stri
       </Grid>
       <Grid size={{ xs: 12, sm: 9 }}>
         <Stack direction="row" alignItems="center" gap={0.5}>
-          <Box sx={copyValueBox} title={value}>
-            {value || '—'}
+          <Box sx={copyValueBox} title={value || undefined}>
+            {value || emptyText}
           </Box>
           <Tooltip title={copied ? 'Copied' : failed ? 'Copy failed' : 'Copy'}>
             <span>

--- a/ipaas/src/components/Runtime/CopyField.tsx
+++ b/ipaas/src/components/Runtime/CopyField.tsx
@@ -22,7 +22,7 @@ import { useState, type JSX } from 'react';
 import { copyValueBox, fieldLabel } from './CopyField.styles';
 
 /** A labelled, read-only monospace value with a copy-to-clipboard button. */
-export default function CopyField({ label, value, emptyText = '—' }: { label: string; value: string; emptyText?: string }): JSX.Element {
+export default function CopyField({ label, value }: { label: string; value: string }): JSX.Element {
   const [copied, setCopied] = useState(false);
   const [failed, setFailed] = useState(false);
   const onCopy = () => {
@@ -48,7 +48,7 @@ export default function CopyField({ label, value, emptyText = '—' }: { label: 
       <Grid size={{ xs: 12, sm: 9 }}>
         <Stack direction="row" alignItems="center" gap={0.5}>
           <Box sx={copyValueBox} title={value || undefined}>
-            {value || emptyText}
+            {value || 'N/A'}
           </Box>
           <Tooltip title={copied ? 'Copied' : failed ? 'Copy failed' : 'Copy'}>
             <span>

--- a/ipaas/src/components/Runtime/PodEventsDrawer.tsx
+++ b/ipaas/src/components/Runtime/PodEventsDrawer.tsx
@@ -34,7 +34,7 @@ interface PodEventsDrawerProps {
 /** Conditions come from the pod the runtime page already holds, so only events are fetched. */
 export default function PodEventsDrawer({ open, onClose, onExited, pod, scope }: PodEventsDrawerProps): JSX.Element {
   const podName = pod?.metadata.name ?? '';
-  const { data: events, isLoading, isError } = usePodEvents(scope.projectId, scope.clusterId, pod?.metadata.namespace ?? scope.namespace, podName, open);
+  const { data: events, isLoading, isError } = usePodEvents(scope.projectId, scope.componentHandler, scope.releaseId, scope.clusterId, pod?.metadata.namespace ?? scope.namespace, podName, open);
 
   return (
     <PodDrawerShell open={open} onClose={onClose} onExited={onExited} title={`Pod Conditions and Events for ${podName}`}>

--- a/ipaas/src/components/Runtime/PodInsightsTable.tsx
+++ b/ipaas/src/components/Runtime/PodInsightsTable.tsx
@@ -24,10 +24,15 @@ import PodEventsDrawer from './PodEventsDrawer';
 import PodLogsDrawer from './PodLogsDrawer';
 import PodUsageCell from './PodUsageCell';
 import { DATA_PLANE_LABEL, POD_ACTION_LABELS } from '../../constants/runtime';
+import { IS_CLOUD } from '../../features';
 import { calculatePodUsage, formatBytes, formatVcpu, podLastActivity, podRestartCount } from '../../utils/podMetrics';
 import { getPodStatus, podStatusPalette, runningPodCount } from '../../utils/pods';
 import { formatDistanceToNow } from '../../utils/time';
 import type { ClusterPod, PodMetrics, PodScope } from '../../types/runtime';
+
+// OpenChoreo has no pod-level metrics source, so these columns would always read empty on cloud.
+const SHOW_POD_USAGE = !IS_CLOUD;
+const COLUMN_COUNT = SHOW_POD_USAGE ? 8 : 6;
 
 interface PodInsightsTableProps {
   pods: ClusterPod[] | undefined;
@@ -107,8 +112,12 @@ export default function PodInsightsTable({ pods, metrics, isLoading, isError, is
             <ListingTable.Head>
               <ListingTable.Row>
                 <ListingTable.Cell>Pod Details</ListingTable.Cell>
-                <ListingTable.Cell>CPU Usage</ListingTable.Cell>
-                <ListingTable.Cell>Memory Usage</ListingTable.Cell>
+                {SHOW_POD_USAGE && (
+                  <>
+                    <ListingTable.Cell>CPU Usage</ListingTable.Cell>
+                    <ListingTable.Cell>Memory Usage</ListingTable.Cell>
+                  </>
+                )}
                 <ListingTable.Cell>Status</ListingTable.Cell>
                 <ListingTable.Cell>Available</ListingTable.Cell>
                 <ListingTable.Cell>Restarts</ListingTable.Cell>
@@ -119,7 +128,7 @@ export default function PodInsightsTable({ pods, metrics, isLoading, isError, is
             <ListingTable.Body>
               {rows.length === 0 ? (
                 <ListingTable.Row>
-                  <ListingTable.Cell colSpan={8} align="center" sx={styles.emptyRow}>
+                  <ListingTable.Cell colSpan={COLUMN_COUNT} align="center" sx={styles.emptyRow}>
                     All pods are currently scaled down.
                   </ListingTable.Cell>
                 </ListingTable.Row>
@@ -139,16 +148,22 @@ export default function PodInsightsTable({ pods, metrics, isLoading, isError, is
                             {pod.metadata.name}
                           </Typography>
                         </Tooltip>
-                        <Typography variant="caption" color="text.secondary" sx={styles.dataPlane}>
-                          {DATA_PLANE_LABEL}
-                        </Typography>
+                        {!IS_CLOUD && (
+                          <Typography variant="caption" color="text.secondary" sx={styles.dataPlane}>
+                            {DATA_PLANE_LABEL}
+                          </Typography>
+                        )}
                       </ListingTable.Cell>
-                      <ListingTable.Cell>
-                        <PodUsageCell used={usage.cpu.used} limit={usage.cpu.limits} display={`${formatVcpu(usage.cpu.used)} / ${formatVcpu(usage.cpu.limits)} vCPU`} />
-                      </ListingTable.Cell>
-                      <ListingTable.Cell>
-                        <PodUsageCell used={usage.memory.used} limit={usage.memory.limits} display={`${formatBytes(usage.memory.used)} / ${formatBytes(usage.memory.limits)}`} />
-                      </ListingTable.Cell>
+                      {SHOW_POD_USAGE && (
+                        <>
+                          <ListingTable.Cell>
+                            <PodUsageCell used={usage.cpu.used} limit={usage.cpu.limits} display={`${formatVcpu(usage.cpu.used)} / ${formatVcpu(usage.cpu.limits)} vCPU`} />
+                          </ListingTable.Cell>
+                          <ListingTable.Cell>
+                            <PodUsageCell used={usage.memory.used} limit={usage.memory.limits} display={`${formatBytes(usage.memory.used)} / ${formatBytes(usage.memory.limits)}`} />
+                          </ListingTable.Cell>
+                        </>
+                      )}
                       <ListingTable.Cell>
                         <Chip size="small" variant="outlined" color={palette.chip} icon={isRunning ? <Check size={13} /> : <Info size={13} />} label={status} sx={styles.statusChip(palette.text)} />
                       </ListingTable.Cell>

--- a/ipaas/src/components/Runtime/PodLogsDrawer.tsx
+++ b/ipaas/src/components/Runtime/PodLogsDrawer.tsx
@@ -61,7 +61,7 @@ export default function PodLogsDrawer({ open, onClose, onExited, pod, scope }: P
   }, [sinceInput]);
 
   const options = useMemo<PodLogOptions>(() => ({ previous, sinceSeconds, containerName }), [previous, sinceSeconds, containerName]);
-  const { data: logs = '', isLoading, isFetching, isError, error, refetch } = usePodLogs(scope.projectId, scope.clusterId, pod?.metadata.namespace ?? scope.namespace, podName, options, open);
+  const { data: logs = '', isLoading, isFetching, isError, error, refetch } = usePodLogs(scope.projectId, scope.componentHandler, scope.releaseId, scope.clusterId, pod?.metadata.namespace ?? scope.namespace, podName, options, open);
 
   const lines = useMemo(() => filterLogLines(logs, search, filterMode), [logs, search, filterMode]);
   // `previous` reads the prior instance of a container, which only exists after a restart.

--- a/ipaas/src/components/Runtime/ResourceUsageCards.tsx
+++ b/ipaas/src/components/Runtime/ResourceUsageCards.tsx
@@ -16,8 +16,8 @@
  * under the License.
  */
 
-import { Card, CardContent, Grid, Stack, Typography } from '@wso2/oxygen-ui';
-import { type JSX } from 'react';
+import { Card, CardContent, Chip, Grid, Stack, Tooltip, Typography } from '@wso2/oxygen-ui';
+import { type JSX, type ReactNode } from 'react';
 import { formatBytes, formatVcpu } from '../../utils/podMetrics';
 import type { CalculatedUsage } from '../../types/runtime';
 import UsageBar from './UsageBar';
@@ -28,34 +28,62 @@ const cardSx = {
   borderRadius: 1,
 } as const;
 
-export default function ResourceUsageCards({ usage }: { usage: CalculatedUsage }): JSX.Element {
+const UNAVAILABLE_TOOLTIP = "Usage metrics couldn't be retrieved for this release.";
+
+interface UsageCardProps {
+  title: string;
+  detail: ReactNode;
+  usagePercent: number;
+  unavailable?: boolean;
+}
+
+function UsageCard({ title, detail, usagePercent, unavailable }: UsageCardProps): JSX.Element {
+  return (
+    <Card elevation={0} sx={cardSx}>
+      <CardContent>
+        <Stack gap={1.5}>
+          <Stack direction="row" alignItems="center" justifyContent="space-between">
+            <Typography variant="h6">{title}</Typography>
+            {unavailable && (
+              <Tooltip title={UNAVAILABLE_TOOLTIP}>
+                <Chip size="small" variant="outlined" label="Unavailable" sx={{ height: 20, fontSize: '0.68rem', fontWeight: 500 }} />
+              </Tooltip>
+            )}
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            {detail}
+          </Typography>
+          {!unavailable && <UsageBar percent={usagePercent} />}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface ResourceUsageCardsProps {
+  usage: CalculatedUsage;
+  /** True when there's no usage source at all (cloud, componentLevelMetrics absent) — "0 used" would misreport an unknown as a confirmed zero. */
+  usageUnavailable?: boolean;
+}
+
+export default function ResourceUsageCards({ usage, usageUnavailable }: ResourceUsageCardsProps): JSX.Element {
   return (
     <Grid container spacing={3}>
       <Grid size={{ xs: 12, md: 6 }}>
-        <Card elevation={0} sx={cardSx}>
-          <CardContent>
-            <Stack gap={1.5}>
-              <Typography variant="h6">CPU Usage</Typography>
-              <Typography variant="body2" color="text.secondary">
-                {formatVcpu(usage.cpu.used)} of {formatVcpu(usage.cpu.limits)} total allocated vCPU used
-              </Typography>
-              <UsageBar percent={usage.cpu.usagePercent} />
-            </Stack>
-          </CardContent>
-        </Card>
+        <UsageCard
+          title="CPU Usage"
+          detail={usageUnavailable ? `${formatVcpu(usage.cpu.limits)} vCPU allocated` : `${formatVcpu(usage.cpu.used)} of ${formatVcpu(usage.cpu.limits)} total allocated vCPU used`}
+          usagePercent={usage.cpu.usagePercent}
+          unavailable={usageUnavailable}
+        />
       </Grid>
       <Grid size={{ xs: 12, md: 6 }}>
-        <Card elevation={0} sx={cardSx}>
-          <CardContent>
-            <Stack gap={1.5}>
-              <Typography variant="h6">Memory Usage</Typography>
-              <Typography variant="body2" color="text.secondary">
-                {formatBytes(usage.memory.used)} of {formatBytes(usage.memory.limits)} total allocated memory used
-              </Typography>
-              <UsageBar percent={usage.memory.usagePercent} />
-            </Stack>
-          </CardContent>
-        </Card>
+        <UsageCard
+          title="Memory Usage"
+          detail={usageUnavailable ? `${formatBytes(usage.memory.limits)} allocated` : `${formatBytes(usage.memory.used)} of ${formatBytes(usage.memory.limits)} total allocated memory used`}
+          usagePercent={usage.memory.usagePercent}
+          unavailable={usageUnavailable}
+        />
       </Grid>
     </Grid>
   );

--- a/ipaas/src/components/Runtime/RuntimeOverview.tsx
+++ b/ipaas/src/components/Runtime/RuntimeOverview.tsx
@@ -92,7 +92,7 @@ export default function RuntimeOverview({ componentName, status, lastDeployedAt,
         <CopyField label="Component ID" value={componentId} />
         <CopyField label="Release ID" value={releaseId} />
         <CopyField label="Namespace" value={namespace ?? ''} />
-        <CopyField label="Image" value={imageUrl ?? ''} emptyText={isDeployed ? 'Not available' : 'Not deployed yet'} />
+        <CopyField label="Image" value={imageUrl ?? ''} />
       </Grid>
     </Grid>
   );

--- a/ipaas/src/components/Runtime/RuntimeOverview.tsx
+++ b/ipaas/src/components/Runtime/RuntimeOverview.tsx
@@ -92,7 +92,7 @@ export default function RuntimeOverview({ componentName, status, lastDeployedAt,
         <CopyField label="Component ID" value={componentId} />
         <CopyField label="Release ID" value={releaseId} />
         <CopyField label="Namespace" value={namespace ?? ''} />
-        <CopyField label="Image" value={imageUrl ?? ''} />
+        <CopyField label="Image" value={imageUrl ?? ''} emptyText={isDeployed ? 'Not available' : 'Not deployed yet'} />
       </Grid>
     </Grid>
   );

--- a/ipaas/src/hooks/useRuntime.ts
+++ b/ipaas/src/hooks/useRuntime.ts
@@ -26,25 +26,29 @@ const POLL_MS = 30_000;
 /** Pod logs refresh faster than the pod list — the drawer is a near-live view. */
 const LOGS_POLL_MS = 10_000;
 
-/** Component runtime (pods/metrics/redeploy) is wip-only for now (cloud/icp API stubs throw). */
-export function isRuntimeEnabled(): boolean {
-  return IS_WIP;
+/**
+ * wip addresses releases by clusterId+namespace (a devops proxy over raw k8s); cloud
+ * addresses them by componentName alone. Each backend needs its own identifying params
+ * before it's worth firing the query.
+ */
+function hasReleaseScope(componentName: string, clusterId: string, namespace: string): boolean {
+  return IS_WIP ? !!clusterId && !!namespace : !!componentName;
 }
 
-export function useReleaseDetails(projectId: string, componentId: string, releaseId: string) {
+export function useReleaseDetails(projectId: string, componentId: string, componentName: string, releaseId: string) {
   return useQuery({
     queryKey: [ROOT_KEY, 'release', releaseId],
-    queryFn: () => fetchReleaseDetails(projectId, componentId, releaseId),
-    enabled: isRuntimeEnabled() && !!projectId && !!componentId && !!releaseId,
+    queryFn: () => fetchReleaseDetails(projectId, componentId, componentName, releaseId),
+    enabled: !!projectId && !!releaseId && (IS_WIP ? !!componentId : !!componentName),
     retry: false,
   });
 }
 
-export function useComponentPods(projectId: string, clusterId: string, releaseId: string, namespace: string, pollMs: number = POLL_MS) {
+export function useComponentPods(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string, pollMs: number = POLL_MS) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'pods', clusterId, releaseId, namespace],
-    queryFn: () => fetchComponentPods(projectId, clusterId, releaseId, namespace),
-    enabled: isRuntimeEnabled() && !!projectId && !!clusterId && !!releaseId && !!namespace,
+    queryKey: [ROOT_KEY, 'pods', componentName, clusterId, releaseId, namespace],
+    queryFn: () => fetchComponentPods(projectId, componentName, clusterId, releaseId, namespace),
+    enabled: !!projectId && !!releaseId && hasReleaseScope(componentName, clusterId, namespace),
     retry: false,
     staleTime: pollMs,
     refetchInterval: pollMs,
@@ -52,11 +56,11 @@ export function useComponentPods(projectId: string, clusterId: string, releaseId
   });
 }
 
-export function useComponentPodMetrics(projectId: string, clusterId: string, releaseId: string, namespace: string) {
+export function useComponentPodMetrics(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'podMetrics', clusterId, releaseId, namespace],
-    queryFn: () => fetchComponentPodMetrics(projectId, clusterId, releaseId, namespace),
-    enabled: isRuntimeEnabled() && !!projectId && !!clusterId && !!releaseId && !!namespace,
+    queryKey: [ROOT_KEY, 'podMetrics', componentName, clusterId, releaseId, namespace],
+    queryFn: () => fetchComponentPodMetrics(projectId, componentName, clusterId, releaseId, namespace),
+    enabled: !!projectId && !!releaseId && hasReleaseScope(componentName, clusterId, namespace),
     retry: false,
     staleTime: POLL_MS,
     refetchInterval: POLL_MS,
@@ -64,23 +68,23 @@ export function useComponentPodMetrics(projectId: string, clusterId: string, rel
   });
 }
 
-export function usePodEvents(projectId: string, clusterId: string, namespace: string, podName: string, enabled: boolean) {
+export function usePodEvents(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string, enabled: boolean) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'podEvents', clusterId, namespace, podName],
-    queryFn: () => fetchPodEvents(projectId, clusterId, namespace, podName),
-    enabled: enabled && isRuntimeEnabled() && !!projectId && !!clusterId && !!namespace && !!podName,
+    queryKey: [ROOT_KEY, 'podEvents', componentName, releaseId, clusterId, namespace, podName],
+    queryFn: () => fetchPodEvents(projectId, componentName, releaseId, clusterId, namespace, podName),
+    enabled: enabled && !!projectId && !!podName && (IS_WIP ? !!clusterId && !!namespace : !!componentName && !!releaseId),
     retry: false,
-    // The cluster returns events in no particular order.
+    // The backend returns events in no particular order.
     select: (events) => [...events].sort((a, b) => new Date(b.timestamp ?? 0).getTime() - new Date(a.timestamp ?? 0).getTime()),
   });
 }
 
-export function usePodLogs(projectId: string, clusterId: string, namespace: string, podName: string, options: PodLogOptions, enabled: boolean) {
+export function usePodLogs(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string, options: PodLogOptions, enabled: boolean) {
   return useQuery({
     // `previous` and `sinceSeconds` change what the server returns, so they belong in the key.
-    queryKey: [ROOT_KEY, 'podLogs', clusterId, namespace, podName, options.containerName, options.previous, options.sinceSeconds],
-    queryFn: () => fetchPodLogs(projectId, clusterId, namespace, podName, options),
-    enabled: enabled && isRuntimeEnabled() && !!projectId && !!clusterId && !!namespace && !!podName,
+    queryKey: [ROOT_KEY, 'podLogs', componentName, releaseId, clusterId, namespace, podName, options.containerName, options.previous, options.sinceSeconds],
+    queryFn: () => fetchPodLogs(projectId, componentName, releaseId, clusterId, namespace, podName, options),
+    enabled: enabled && !!projectId && !!podName && (IS_WIP ? !!clusterId && !!namespace : !!componentName && !!releaseId),
     retry: false,
     refetchInterval: LOGS_POLL_MS,
     staleTime: LOGS_POLL_MS,
@@ -90,7 +94,8 @@ export function usePodLogs(projectId: string, clusterId: string, namespace: stri
 export function useRedeployRelease() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (input: { projectId: string; componentId: string; releaseId: string }) => redeployRelease(input.projectId, input.componentId, input.releaseId),
+    mutationFn: (input: { projectId: string; componentId: string; componentName: string; releaseId: string }) =>
+      redeployRelease(input.projectId, input.componentId, input.componentName, input.releaseId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: [ROOT_KEY] });
       qc.invalidateQueries({ queryKey: ['componentDeployment'] });

--- a/ipaas/src/hooks/useRuntime.ts
+++ b/ipaas/src/hooks/useRuntime.ts
@@ -37,7 +37,7 @@ function hasReleaseScope(componentName: string, clusterId: string, namespace: st
 
 export function useReleaseDetails(projectId: string, componentId: string, componentName: string, releaseId: string) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'release', releaseId],
+    queryKey: [ROOT_KEY, 'release', projectId, releaseId],
     queryFn: () => fetchReleaseDetails(projectId, componentId, componentName, releaseId),
     enabled: !!projectId && !!releaseId && (IS_WIP ? !!componentId : !!componentName),
     retry: false,
@@ -46,7 +46,7 @@ export function useReleaseDetails(projectId: string, componentId: string, compon
 
 export function useComponentPods(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string, pollMs: number = POLL_MS) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'pods', componentName, clusterId, releaseId, namespace],
+    queryKey: [ROOT_KEY, 'pods', projectId, componentName, clusterId, releaseId, namespace],
     queryFn: () => fetchComponentPods(projectId, componentName, clusterId, releaseId, namespace),
     enabled: !!projectId && !!releaseId && hasReleaseScope(componentName, clusterId, namespace),
     retry: false,
@@ -58,7 +58,7 @@ export function useComponentPods(projectId: string, componentName: string, clust
 
 export function useComponentPodMetrics(projectId: string, componentName: string, clusterId: string, releaseId: string, namespace: string) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'podMetrics', componentName, clusterId, releaseId, namespace],
+    queryKey: [ROOT_KEY, 'podMetrics', projectId, componentName, clusterId, releaseId, namespace],
     queryFn: () => fetchComponentPodMetrics(projectId, componentName, clusterId, releaseId, namespace),
     enabled: !!projectId && !!releaseId && hasReleaseScope(componentName, clusterId, namespace),
     retry: false,
@@ -70,7 +70,7 @@ export function useComponentPodMetrics(projectId: string, componentName: string,
 
 export function usePodEvents(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string, enabled: boolean) {
   return useQuery({
-    queryKey: [ROOT_KEY, 'podEvents', componentName, releaseId, clusterId, namespace, podName],
+    queryKey: [ROOT_KEY, 'podEvents', projectId, componentName, releaseId, clusterId, namespace, podName],
     queryFn: () => fetchPodEvents(projectId, componentName, releaseId, clusterId, namespace, podName),
     enabled: enabled && !!projectId && !!podName && (IS_WIP ? !!clusterId && !!namespace : !!componentName && !!releaseId),
     retry: false,
@@ -82,7 +82,7 @@ export function usePodEvents(projectId: string, componentName: string, releaseId
 export function usePodLogs(projectId: string, componentName: string, releaseId: string, clusterId: string, namespace: string, podName: string, options: PodLogOptions, enabled: boolean) {
   return useQuery({
     // `previous` and `sinceSeconds` change what the server returns, so they belong in the key.
-    queryKey: [ROOT_KEY, 'podLogs', componentName, releaseId, clusterId, namespace, podName, options.containerName, options.previous, options.sinceSeconds],
+    queryKey: [ROOT_KEY, 'podLogs', projectId, componentName, releaseId, clusterId, namespace, podName, options.containerName, options.previous, options.sinceSeconds],
     queryFn: () => fetchPodLogs(projectId, componentName, releaseId, clusterId, namespace, podName, options),
     enabled: enabled && !!projectId && !!podName && (IS_WIP ? !!clusterId && !!namespace : !!componentName && !!releaseId),
     retry: false,

--- a/ipaas/src/pages/CloudEditorDeployment.tsx
+++ b/ipaas/src/pages/CloudEditorDeployment.tsx
@@ -129,7 +129,10 @@ export default function CloudEditorDeployment(): JSX.Element {
     deploy();
   }, [params, createCodeServerMutation, getOrCreateRegistryMutation]);
 
-  const podsQuery = useComponentPods(params.projectId, instance?.clusterId ?? '', instance?.releaseId ?? '', instance?.namespace ?? '', CLOUD_EDITOR_POLL_MS);
+  // This page has no component handler/name available (only params.componentId, a UUID) —
+  // harmless since cloud's clusterId/namespace are already absent here (see the redirect
+  // above), so the query stays disabled on cloud regardless of componentName.
+  const podsQuery = useComponentPods(params.projectId, '', instance?.clusterId ?? '', instance?.releaseId ?? '', instance?.namespace ?? '', CLOUD_EDITOR_POLL_MS);
   const pods = useMemo(() => podsQuery.data ?? [], [podsQuery.data]);
   const isAnyPodRunning = pods.some((p) => p.status?.phase === 'Running');
   const isPolling = !!instance?.clusterId && !isAnyPodRunning;

--- a/ipaas/src/pages/ComponentRuntime.tsx
+++ b/ipaas/src/pages/ComponentRuntime.tsx
@@ -18,7 +18,6 @@
 
 import { Alert, Box, CircularProgress, MenuItem, PageContent, Select, Snackbar, Typography } from '@wso2/oxygen-ui';
 import { useEffect, useMemo, useState, type JSX } from 'react';
-import ComingSoon from './ComingSoon';
 import DeploymentTrackBar from '../components/DeploymentTrackBar';
 import PodInsightsTable from '../components/Runtime/PodInsightsTable';
 import ReplicaRangeControl from '../components/Runtime/ReplicaRangeControl';
@@ -32,10 +31,11 @@ import { useLoadComponentPermissions } from '../hooks/usePermissionLoader';
 import { useOrgUuid } from '../hooks/useOrgUuid';
 import { useProjectId } from '../hooks/useProjects';
 import { Permissions } from '../constants/permissions';
-import { isRuntimeEnabled, useComponentPodMetrics, useComponentPods, useReleaseDetails, useRedeployRelease } from '../hooks/useRuntime';
+import { IS_CLOUD } from '../features';
+import { useComponentPodMetrics, useComponentPods, useReleaseDetails, useRedeployRelease } from '../hooks/useRuntime';
 import { useHpa, useScalingState } from '../hooks/useScaling';
 import { DeploymentStatus } from '../types/deployment';
-import { calculateAggregateUsage } from '../utils/podMetrics';
+import { calculateAggregateUsage, usageFromComponentLevelMetrics } from '../utils/podMetrics';
 import type { ComponentScope } from '../nav';
 
 export default function ComponentRuntime({ org, project, component }: ComponentScope): JSX.Element {
@@ -60,22 +60,41 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
   const releaseId = deployment?.releaseId ?? '';
   const status = deployment?.deploymentStatusV2 ?? DeploymentStatus.NotDeployed;
 
-  const { data: release } = useReleaseDetails(projectId, componentId, releaseId);
+  const { data: release } = useReleaseDetails(projectId, componentId, component, releaseId);
   const clusterId = release?.environment?.environment_clusters?.[0]?.cluster_id ?? '';
   const namespace = release?.environment?.namespace ?? '';
   const isDeployed = status !== DeploymentStatus.NotDeployed && !!releaseId && release?.undeployed !== true;
 
-  const pods = useComponentPods(projectId, clusterId, releaseId, namespace);
-  const metrics = useComponentPodMetrics(projectId, clusterId, releaseId, namespace);
-  const usage = useMemo(() => calculateAggregateUsage(pods.data ?? [], metrics.data ?? []), [pods.data, metrics.data]);
+  // Cloud's runtime-details response is the authoritative source for these (OpenChoreo IDs,
+  // deployed image) — wip keeps using its existing component/deployment-derived values.
+  const displayComponentId = IS_CLOUD ? release?.componentId ?? componentId : componentId;
+  const displayReleaseId = IS_CLOUD ? release?.ID ?? releaseId : releaseId;
+  const displayImageUrl = IS_CLOUD ? release?.image : deployment?.imageUrl ?? undefined;
+
+  const pods = useComponentPods(projectId, component, clusterId, releaseId, namespace);
+  const metrics = useComponentPodMetrics(projectId, component, clusterId, releaseId, namespace);
+
+  // release.replicas is a one-shot fetch (invalidated once right when Redeploy is clicked,
+  // before the rollout settles) and then never refreshed, so it goes stale — e.g. it can get
+  // stuck at 2 after a redeploy's old pod terminates. The live, polled pod count self-corrects.
+  const replicaCount = IS_CLOUD ? pods.data?.length ?? release?.replicas ?? 0 : release?.replicas ?? 0;
+  // cloud has no pod-level metrics source and instead sends a pre-aggregated total; wip's
+  // backend only ever gives per-pod metrics, so it's summed against pod resource limits.
+  const usage = useMemo(
+    () => (metrics.data?.componentLevelMetrics ? usageFromComponentLevelMetrics(metrics.data.componentLevelMetrics) : calculateAggregateUsage(pods.data ?? [], metrics.data?.podLevelMetrics ?? [])),
+    [pods.data, metrics.data],
+  );
+  // cloud sends componentLevelMetrics only when it can resolve one (Observer reachable) —
+  // when it's absent but pods are actually running, "0 used" would misreport unknown as zero.
+  const usageUnavailable = IS_CLOUD && !metrics.data?.componentLevelMetrics && (pods.data?.length ?? 0) > 0;
 
   // Min/max replicas above the pod table edit the same HPA the Scaling page owns.
   const { data: hpa, isLoading: loadingHpa, isError: hpaError, refetch: refetchHpa } = useHpa(projectId, componentId, releaseId);
   const { data: scalingState } = useScalingState(projectId, componentId, releaseId);
   const scalingPath = useMemo(() => ({ componentId, releaseId }), [componentId, releaseId]);
   const podScope = useMemo(
-    () => ({ projectId, clusterId, namespace, orgHandler: org, projectHandler: project, componentHandler: component }),
-    [projectId, clusterId, namespace, org, project, component],
+    () => ({ projectId, clusterId, namespace, releaseId, orgHandler: org, projectHandler: project, componentHandler: component }),
+    [projectId, clusterId, namespace, releaseId, org, project, component],
   );
   const [alert, setAlert] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
@@ -86,13 +105,9 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
   const canManage = hasPermission(Permissions.INTEGRATION_MANAGE, projectId, componentId);
 
   const redeploy = useRedeployRelease();
-  const onRedeploy = () => redeploy.mutate({ projectId, componentId, releaseId });
+  const onRedeploy = () => redeploy.mutate({ projectId, componentId, componentName: component, releaseId });
 
   const isLoading = loadingProject || loadingComponent || loadingEnvironments;
-
-  if (!isRuntimeEnabled()) {
-    return <ComingSoon title="Coming Soon" description="Runtime management is currently under development." />;
-  }
 
   if (isLoading) {
     return (
@@ -147,10 +162,10 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
           status={status}
           lastDeployedAt={release?.latest_deployment?.deployment_history?.CreatedAt ?? deployment?.build?.deployedAt}
           lastDeployedMessage={release?.latest_deployment?.deployment_history?.change_message}
-          componentId={componentId}
-          releaseId={releaseId}
+          componentId={displayComponentId}
+          releaseId={displayReleaseId}
           namespace={namespace}
-          imageUrl={deployment?.imageUrl ?? undefined}
+          imageUrl={displayImageUrl}
           isDeployed={isDeployed}
           redeploying={redeploy.isPending}
           canRedeploy={!!releaseId}
@@ -161,7 +176,7 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
           <>
             <PodInsightsTable
               pods={pods.data}
-              metrics={metrics.data}
+              metrics={metrics.data?.podLevelMetrics}
               isLoading={pods.isLoading}
               isError={pods.isError}
               isFetching={pods.isFetching || metrics.isFetching}
@@ -177,7 +192,7 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
                   isLoading={loadingHpa}
                   isError={hpaError}
                   onRetry={() => refetchHpa()}
-                  replicas={release?.replicas ?? 0}
+                  replicas={replicaCount}
                   orgUuid={orgUuid ?? ''}
                   projectId={projectId}
                   path={scalingPath}
@@ -189,7 +204,7 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
               }
             />
             <Box sx={{ mt: 4 }}>
-              <ResourceUsageCards usage={usage} />
+              <ResourceUsageCards usage={usage} usageUnavailable={usageUnavailable} />
             </Box>
           </>
         )}

--- a/ipaas/src/pages/ComponentRuntime.tsx
+++ b/ipaas/src/pages/ComponentRuntime.tsx
@@ -67,8 +67,11 @@ export default function ComponentRuntime({ org, project, component }: ComponentS
 
   // Cloud's runtime-details response is the authoritative source for these (OpenChoreo IDs,
   // deployed image) — wip keeps using its existing component/deployment-derived values.
-  const displayComponentId = IS_CLOUD ? release?.componentId ?? componentId : componentId;
-  const displayReleaseId = IS_CLOUD ? release?.ID ?? releaseId : releaseId;
+  // Falling back to componentId/releaseId while `release` is still loading would flash a
+  // handler-shaped value that then flips to the real OpenChoreo UUID once it arrives —
+  // show nothing until the authoritative value is in, rather than a mismatched one first.
+  const displayComponentId = IS_CLOUD ? release?.componentId ?? '' : componentId;
+  const displayReleaseId = IS_CLOUD ? release?.ID ?? '' : releaseId;
   const displayImageUrl = IS_CLOUD ? release?.image : deployment?.imageUrl ?? undefined;
 
   const pods = useComponentPods(projectId, component, clusterId, releaseId, namespace);

--- a/ipaas/src/pages/RegisterOrganization.tsx
+++ b/ipaas/src/pages/RegisterOrganization.tsx
@@ -224,7 +224,7 @@ export default function RegisterOrganization(): JSX.Element {
             {isCreating ? 'Creating...' : 'Create Organization'}
           </Button>
 
-          <Button variant="text" color="secondary" size="small" onClick={() => logout().then(() => navigate(loginUrl()))} disabled={isCreating}>
+          <Button variant="outlined" color="secondary" size="small" onClick={() => logout().then(() => navigate(loginUrl()))} disabled={isCreating}>
             Sign out and use a different account
           </Button>
         </Stack>

--- a/ipaas/src/types/runtime.ts
+++ b/ipaas/src/types/runtime.ts
@@ -43,6 +43,9 @@ export interface RuntimeReleaseDetails {
     namespace?: string;
   };
   containers?: ReleaseContainerSpec[];
+  /** OpenChoreo component UUID and deployed image ref (cloud only — not on the wip devops shape). */
+  componentId?: string;
+  image?: string;
 }
 
 export interface PodResourceQuantities {
@@ -95,6 +98,25 @@ export interface PodMetrics {
 }
 
 /**
+ * Server-computed cpu/memory aggregate for a release (cloud only). cpu in whole
+ * cores (0.5 = 500m), memory in bytes — unlike PodMetrics, no quantity-string parsing needed.
+ */
+export interface ComponentLevelMetrics {
+  cpu: { usedCores: number; limitCores: number };
+  memory: { usedBytes: number; limitBytes: number };
+}
+
+/**
+ * Pod-level metrics plus an optional pre-aggregated total. OpenChoreo has no
+ * pod-level metrics source, so cloud always sends `podLevelMetrics: []` and
+ * relies on `componentLevelMetrics` instead; WIP only ever fills podLevelMetrics.
+ */
+export interface RuntimeMetrics {
+  podLevelMetrics: PodMetrics[];
+  componentLevelMetrics?: ComponentLevelMetrics;
+}
+
+/**
  * An event the cluster published about a pod. The cluster keeps these for roughly an
  * hour, so an empty list is normal.
  */
@@ -120,6 +142,7 @@ export interface PodScope {
   projectId: string;
   clusterId: string;
   namespace: string;
+  releaseId: string;
   orgHandler: string;
   projectHandler: string;
   componentHandler: string;

--- a/ipaas/src/utils/podMetrics.ts
+++ b/ipaas/src/utils/podMetrics.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import type { CalculatedUsage, ClusterPod, PodMetrics } from '../types/runtime';
+import type { CalculatedUsage, ClusterPod, ComponentLevelMetrics, PodMetrics } from '../types/runtime';
 
 /**
  * Parse a Kubernetes CPU quantity into millicores.
@@ -98,6 +98,16 @@ function sumMetricsUsage(metrics: PodMetrics[]): { cpu: number; memory: number }
 function percent(used: number, limits: number): number {
   if (limits <= 0) return 0;
   return Math.min(100, Math.round((used / limits) * 100));
+}
+
+/** Cloud's server-computed aggregate (whole cores/bytes) in the same shape as calculateAggregateUsage. */
+export function usageFromComponentLevelMetrics(agg: ComponentLevelMetrics): CalculatedUsage {
+  const cpuUsed = agg.cpu.usedCores * 1000;
+  const cpuLimits = agg.cpu.limitCores * 1000;
+  return {
+    cpu: { limits: cpuLimits, used: cpuUsed, usagePercent: percent(cpuUsed, cpuLimits) },
+    memory: { limits: agg.memory.limitBytes, used: agg.memory.usedBytes, usagePercent: percent(agg.memory.usedBytes, agg.memory.limitBytes) },
+  };
 }
 
 /** Aggregate CPU/memory used vs. allocated across all pods of a release. */


### PR DESCRIPTION
## Summary

- Removed the isRuntimeEnabled()/IS_WIP flag that gated the Runtime page behind a "Coming Soon" placeholder — the page (and its nav entry) is now live for cloud as well as wip.
- Implemented all 6 RuntimeApi methods for cloud against the new ipaas-service endpoints, addressed by componentName + releaseId (vs. wip's clusterId/namespace devops-proxy addressing):
  - fetchReleaseDetails → GET .../runtime
  - fetchComponentPods → GET .../pods
  - fetchComponentPodMetrics → GET .../metrics
  - redeployRelease → POST .../redeploy
  - fetchPodEvents → GET .../pods/{podName}/events
  - fetchPodLogs → GET .../pods/{podName}/logs
- Extended the shared RuntimeApi contract and all three product implementations (wip/cloud/icp) to thread componentName through consistently; wip's existing devops-proxy calls are unchanged (only gained unused params for signature parity).
- Added RuntimeMetrics/ComponentLevelMetrics types to carry cloud's pre-aggregated CPU/memory total, since OpenChoreo has no pod-level metrics source (podLevelMetrics is always [] there).
- Resource usage cards now prefer the server-side aggregate on cloud, falling back to the existing client-side pod+metrics computation on wip; when cloud has running pods but no aggregate available , the cards show an explicit "Unavailable" state instead of misreporting an unknown as a confirmed zero.
- Hid the CPU/Memory columns in the pod table on cloud only; wip/icp keep them.
- Fixed the replica count going stale after a redeploy on cloud (it was a one-shot fetch that could get stuck mid-rollout) — now derived from the live, polled pod count on cloud.
- Replaced the "Image —" empty state with a meaningful message ("lable" depending on deploy status); 