### PR TITLE
Harden node registration heartbeat handshake

### DIFF
--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/Constants.java
@@ -60,6 +60,11 @@ public final class Constants {
 
     public static final String SUCCESS_STATUS = "success";
     public static final String FAIL_STATUS = "fail";
+    // Returned in place of a SUCCESS/FAIL Ack when a node registers for the first time: the caller must sign the
+    // returned challenge with the shared mi_super_admin password and resend the heartbeat before ICP will forward
+    // that password to the caller-supplied mgtApiUrl.
+    public static final String CHALLENGE_STATUS = "challenge";
+    public static final int NODE_CHALLENGE_TIMEOUT_SECONDS = 60;
 
     public static final String UTF_8_ENCODING = "UTF-8";
 

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/ManagementApiUtils.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/commons/utils/ManagementApiUtils.java
@@ -48,8 +48,16 @@ public class ManagementApiUtils {
 
     public static String getAccessToken(String mgtApiUrl) throws ManagementApiException {
         String username = System.getProperty("mi_username");
-        String password = System.getProperty("mi_password");
+        String password = getConfiguredPassword();
         return getToken(mgtApiUrl, username, password);
+    }
+
+    /**
+     * The shared mi_super_admin password ICP uses both to log in to managed MI nodes and, before that, to verify
+     * a new node's registration challenge. Never sent anywhere until the caller has proven it already holds it.
+     */
+    public static String getConfiguredPassword() {
+        return System.getProperty("mi_password");
     }
 
     public static String getToken(String mgtApiUrl, String username, String password) throws ManagementApiException {

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/HeartBeatDelegate.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/HeartBeatDelegate.java
@@ -59,12 +59,27 @@ public class HeartBeatDelegate {
                 logger.debug("Management API URL received is: " + heartbeat.getMgtApiUrl());
             }
             boolean isSuccess;
-            String productName = heartbeat.getProduct();
-            ArtifactsManager artifactsManager = getArtifactManager(productName, heartbeat);
 
             if (isNodeRegistered(heartbeat)) {
                 isSuccess = updateHeartbeat(heartbeat);
             } else {
+                // heartbeat is unauthenticated, so mgtApiUrl and the mi_super_admin password must never be sent
+                // out on the caller's say-so alone - the caller must first prove it already holds that password.
+                String signedChallenge = heartbeatRequest.getSignedChallenge();
+                if (signedChallenge == null || signedChallenge.isEmpty()) {
+                    String challenge = NodeRegistrationChallengeManager.issueChallenge(
+                            heartbeat.getGroupId(), heartbeat.getNodeId());
+                    return new Ack(Constants.CHALLENGE_STATUS, "Sign the challenge with the mi_super_admin " +
+                            "password and resend the heartbeat with signedChallenge set.").challenge(challenge);
+                }
+                if (!NodeRegistrationChallengeManager.verify(
+                        heartbeat.getGroupId(), heartbeat.getNodeId(), heartbeat.getMgtApiUrl(), signedChallenge)) {
+                    logger.warn("Rejected node registration for node " + heartbeat.getNodeId() + " in group " +
+                            heartbeat.getGroupId() + ": challenge verification failed.");
+                    return new Ack(Constants.FAIL_STATUS, "Challenge verification failed.");
+                }
+                String productName = heartbeat.getProduct();
+                ArtifactsManager artifactsManager = getArtifactManager(productName, heartbeat);
                 isSuccess = registerNode(heartbeat, artifactsManager);
                 if (isSuccess) {
                     artifactsManager.runFetchAllExecutorService();

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/NodeRegistrationChallengeManager.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/NodeRegistrationChallengeManager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ei.dashboard.core.rest.delegates.heartbeat;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.wso2.ei.dashboard.core.commons.Constants;
+import org.wso2.ei.dashboard.core.commons.utils.ManagementApiUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Gates first-time node registration behind proof that the caller already holds the shared mi_super_admin
+ * password, so that {@code mgtApiUrl} from an unauthenticated heartbeat is never trusted with that password
+ * unless the caller demonstrates it independently.
+ * <p>
+ * Flow: the first heartbeat for an unknown (groupId, nodeId) gets back a random challenge instead of being
+ * registered. The node signs the challenge together with (groupId, nodeId, mgtApiUrl) using its own copy of
+ * the shared password and resends the heartbeat with that signature attached; only a signature that matches
+ * what ICP computes from its own stored password, over that same tuple, causes registration (and the outbound
+ * call to mgtApiUrl) to proceed. Binding mgtApiUrl into the signed payload matters: without it, a signature
+ * observed on the wire for a legitimate node could be replayed verbatim against the same (groupId, nodeId)
+ * with a different, attacker-chosen mgtApiUrl.
+ */
+public class NodeRegistrationChallengeManager {
+
+    private static final Logger logger = LogManager.getLogger(NodeRegistrationChallengeManager.class);
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    // Keyed by groupId/nodeId, single-use, and short-lived: a challenge is only ever meant to be answered by
+    // the very next request in the same registration handshake.
+    private static final Cache<String, String> PENDING_CHALLENGES = CacheBuilder.newBuilder()
+            .expireAfterWrite(Constants.NODE_CHALLENGE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build();
+
+    private NodeRegistrationChallengeManager() {
+    }
+
+    /**
+     * Issues a fresh challenge for this (groupId, nodeId) pair, replacing any earlier unanswered one.
+     */
+    public static String issueChallenge(String groupId, String nodeId) {
+        byte[] nonce = new byte[32];
+        SECURE_RANDOM.nextBytes(nonce);
+        String challenge = Base64.getEncoder().encodeToString(nonce);
+        PENDING_CHALLENGES.put(cacheKey(groupId, nodeId), challenge);
+        return challenge;
+    }
+
+    /**
+     * Verifies a claimed signature against the challenge previously issued for this node, over the exact
+     * (groupId, nodeId, mgtApiUrl) tuple of the current request, using ICP's own stored copy of the shared
+     * password. The pending challenge is atomically consumed on lookup, so a given challenge can only ever be
+     * checked once - a second concurrent attempt with the same or a different signature both find nothing
+     * pending and fail closed.
+     */
+    public static boolean verify(String groupId, String nodeId, String mgtApiUrl, String signedChallenge) {
+        if (signedChallenge == null || signedChallenge.isEmpty()) {
+            return false;
+        }
+        String challenge = PENDING_CHALLENGES.asMap().remove(cacheKey(groupId, nodeId));
+        if (challenge == null) {
+            // Expired, never issued, or already consumed by a previous concurrent attempt.
+            return false;
+        }
+        String password = ManagementApiUtils.getConfiguredPassword();
+        if (password == null || password.isEmpty()) {
+            logger.error("mi_super_admin password is not configured; rejecting node registration challenge.");
+            return false;
+        }
+        String expectedSignature = sign(canonicalMessage(challenge, groupId, nodeId, mgtApiUrl), password);
+        if (expectedSignature == null) {
+            return false;
+        }
+        return constantTimeEquals(expectedSignature, signedChallenge);
+    }
+
+    private static String sign(String message, String password) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(password.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+            byte[] signature = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(signature);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            logger.error("Error occurred while signing node registration challenge.", e);
+            return null;
+        }
+    }
+
+    private static boolean constantTimeEquals(String a, String b) {
+        return MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Length-prefixed so that (groupId="a:b", nodeId="c") and (groupId="a", nodeId="b:c") cannot collide on a
+    // shared delimiter - both groupId and nodeId are attacker-controlled request fields.
+    private static String cacheKey(String groupId, String nodeId) {
+        return lengthPrefixed(groupId) + lengthPrefixed(nodeId);
+    }
+
+    // Binds the signature to the full registration attempt, not just the nonce: same length-prefixing
+    // discipline as cacheKey() so no combination of these attacker-controlled fields can be rearranged to
+    // produce the same signed bytes as a different, legitimately-signed combination.
+    private static String canonicalMessage(String challenge, String groupId, String nodeId, String mgtApiUrl) {
+        return lengthPrefixed(challenge) + lengthPrefixed(groupId) + lengthPrefixed(nodeId)
+                + lengthPrefixed(mgtApiUrl == null ? "" : mgtApiUrl);
+    }
+
+    private static String lengthPrefixed(String value) {
+        return value.length() + ":" + value;
+    }
+}

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/NodeRegistrationChallengeManager.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/delegates/heartbeat/NodeRegistrationChallengeManager.java
@@ -54,10 +54,14 @@ public class NodeRegistrationChallengeManager {
     private static final Logger logger = LogManager.getLogger(NodeRegistrationChallengeManager.class);
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    // groupId/nodeId are unauthenticated and attacker-controlled, so without a cap a flood of distinct pairs
+    // could grow this cache unboundedly for up to the full expiry window; this caps memory use under load.
+    private static final long MAX_PENDING_CHALLENGES = 10_000L;
 
     // Keyed by groupId/nodeId, single-use, and short-lived: a challenge is only ever meant to be answered by
     // the very next request in the same registration handshake.
     private static final Cache<String, String> PENDING_CHALLENGES = CacheBuilder.newBuilder()
+            .maximumSize(MAX_PENDING_CHALLENGES)
             .expireAfterWrite(Constants.NODE_CHALLENGE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .build();
 

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/Ack.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/Ack.java
@@ -32,9 +32,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Ack   {
   private @Valid String status = null;
   private @Valid String message = null;
+  private @Valid String challenge = null;
 
   public Ack(String status) {
     this.status = status;
+  }
+
+  public Ack(String status, String message) {
+    this.status = status;
+    this.message = message;
   }
 
   /**
@@ -73,6 +79,26 @@ public class Ack   {
     this.message = message;
   }
 
+  /**
+   * Set only when status is "challenge": a nonce the caller must sign with the shared mi_super_admin
+   * password and echo back (as signedChallenge) on the follow-up heartbeat.
+   **/
+  public Ack challenge(String challenge) {
+    this.challenge = challenge;
+    return this;
+  }
+
+
+  @ApiModelProperty(value = "")
+  @JsonProperty("challenge")
+
+  public String getChallenge() {
+    return challenge;
+  }
+  public void setChallenge(String challenge) {
+    this.challenge = challenge;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -84,21 +110,23 @@ public class Ack   {
     }
     Ack ack = (Ack) o;
     return Objects.equals(status, ack.status) &&
-        Objects.equals(message, ack.message);
+        Objects.equals(message, ack.message) &&
+        Objects.equals(challenge, ack.challenge);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, message);
+    return Objects.hash(status, message, challenge);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class Ack {\n");
-    
+
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("    challenge: ").append(toIndentedString(challenge)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/HeartbeatRequest.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/HeartbeatRequest.java
@@ -32,6 +32,7 @@ public class HeartbeatRequest   {
   private @Valid String nodeId = null;
   private @Valid Integer interval = null;
   private @Valid String mgtApiUrl = null;
+  private @Valid String signedChallenge = null;
 
   /**
    **/
@@ -123,6 +124,26 @@ public class HeartbeatRequest   {
     this.mgtApiUrl = mgtApiUrl;
   }
 
+  /**
+   * HMAC-SHA256(challenge, mi_super_admin password), base64-encoded. Absent on the first heartbeat for a new
+   * node; present on the follow-up heartbeat that answers the challenge ICP returned for that first attempt.
+   **/
+  public HeartbeatRequest signedChallenge(String signedChallenge) {
+    this.signedChallenge = signedChallenge;
+    return this;
+  }
+
+
+  @ApiModelProperty(value = "")
+  @JsonProperty("signedChallenge")
+
+  public String getSignedChallenge() {
+    return signedChallenge;
+  }
+  public void setSignedChallenge(String signedChallenge) {
+    this.signedChallenge = signedChallenge;
+  }
+
   @Override
   public boolean equals(java.lang.Object o) {
     if (this == o) {
@@ -136,12 +157,13 @@ public class HeartbeatRequest   {
            Objects.equals(groupId, heartbeatRequest.groupId) &&
            Objects.equals(nodeId, heartbeatRequest.nodeId) &&
            Objects.equals(interval, heartbeatRequest.interval) &&
-           Objects.equals(mgtApiUrl, heartbeatRequest.mgtApiUrl);
+           Objects.equals(mgtApiUrl, heartbeatRequest.mgtApiUrl) &&
+           Objects.equals(signedChallenge, heartbeatRequest.signedChallenge);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(product, groupId, nodeId, interval, mgtApiUrl);
+    return Objects.hash(product, groupId, nodeId, interval, mgtApiUrl, signedChallenge);
   }
 
   @Override
@@ -154,6 +176,7 @@ public class HeartbeatRequest   {
     sb.append("    nodeId: ").append(toIndentedString(nodeId)).append("\n");
     sb.append("    interval: ").append(toIndentedString(interval)).append("\n");
     sb.append("    mgtApiUrl: ").append(toIndentedString(mgtApiUrl)).append("\n");
+    sb.append("    signedChallenge: ").append(toIndentedString(signedChallenge)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/HeartbeatRequest.java
+++ b/components/org.wso2.ei.dashboard.core/src/main/java/org/wso2/ei/dashboard/core/rest/model/HeartbeatRequest.java
@@ -125,8 +125,9 @@ public class HeartbeatRequest   {
   }
 
   /**
-   * HMAC-SHA256(challenge, mi_super_admin password), base64-encoded. Absent on the first heartbeat for a new
-   * node; present on the follow-up heartbeat that answers the challenge ICP returned for that first attempt.
+   * HMAC-SHA256 over the challenge together with groupId, nodeId and mgtApiUrl, keyed with the mi_super_admin
+   * password, base64-encoded. Absent on the first heartbeat for a new node; present on the follow-up heartbeat
+   * that answers the challenge ICP returned for that first attempt.
    **/
   public HeartbeatRequest signedChallenge(String signedChallenge) {
     this.signedChallenge = signedChallenge;

--- a/components/org.wso2.ei.dashboard.core/swagger.json
+++ b/components/org.wso2.ei.dashboard.core/swagger.json
@@ -3827,6 +3827,10 @@
           },
           "mgtApiUrl" : {
             "type" : "string"
+          },
+          "signedChallenge" : {
+            "type" : "string",
+            "description" : "HMAC-SHA256 of the challenge together with groupId, nodeId and mgtApiUrl, keyed with the mi_super_admin password, base64-encoded. Omit on the first heartbeat for a new node; set on the follow-up heartbeat that answers the challenge returned for that attempt."
           }
         },
         "example" : {
@@ -3849,10 +3853,15 @@
         "type" : "object",
         "properties" : {
           "status" : {
-            "type" : "string"
+            "type" : "string",
+            "description" : "success, fail, or challenge. challenge is returned only for a heartbeat's first attempt to register a new node."
           },
           "message" : {
             "type" : "string"
+          },
+          "challenge" : {
+            "type" : "string",
+            "description" : "Present only when status is challenge: a nonce to sign with the mi_super_admin password and echo back as signedChallenge on the next heartbeat."
           }
         },
         "example" : {


### PR DESCRIPTION
## Summary
Strengthens the node-registration handshake on `POST /heartbeat`. First
contact for a new `(groupId, nodeId)` now requires the caller to answer a
random challenge - signed with the shared admin password already
configured on the dashboard - before registration completes. The
signature is scoped to the specific `(challenge, groupId, nodeId,
mgtApiUrl)` combination and each challenge is single-use and short-lived
(60s).

Already-registered nodes are unaffected; this only changes first-contact
registration behavior.

This is a breaking change for node clients: they must be updated to
answer the new challenge (`signedChallenge` field) before they can
register against a dashboard running this change.

## Test plan
- [x] `mvn -o compile` on `org.wso2.ei.dashboard.core`
- [x] End-to-end test driving the registration handshake directly against
      a mock management-API server: successful registration, rejected
      invalid signatures, rejected replay with a substituted management
      URL, single-use challenge consumption, and unaffected steady-state
      heartbeats for already-registered nodes.