### PR TITLE
Add an Enable Workflow Management toggle to both Add Runtime dialogs

### DIFF
--- a/frontend/src/pages/OrgRuntimes.tsx
+++ b/frontend/src/pages/OrgRuntimes.tsx
@@ -31,11 +31,13 @@ import {
   DialogTitle,
   Divider,
   Drawer,
+  FormControlLabel,
   IconButton,
   ListingTable,
   PageContent,
   PageTitle,
   Stack,
+  Switch,
   Tab,
   TablePagination,
   Tabs,
@@ -57,7 +59,7 @@ import { Permissions } from '../constants/permissions';
 import { technologyLabel } from '../constants/technologies';
 import { useAccessControl } from '../contexts/AccessControlContext';
 import type { OrgScope } from '../nav';
-import { runtimeImports } from '../utils/runtimeToml';
+import { runtimeImports, workflowManagementToml } from '../utils/runtimeToml';
 
 const drawerSx = {
   '& .MuiDrawer-paper': { width: '45%', maxWidth: 560, minWidth: 360, position: 'fixed', top: 64, height: 'calc(100% - 64px)', borderLeft: '1px solid', borderColor: 'divider' },
@@ -158,17 +160,23 @@ secret = "${secret}"
 #icp_url = "https://<hostname>:9445"`;
 }
 
-// No workflow configuration here: this dialog is org-scoped, with the project and integration left
-// as fill-in placeholders, so it cannot tell whether the runtime belongs to a Workflow integration.
-// Register a workflow runtime from that integration's own Runtime page, which knows its type.
-function biToml(envName: string, secret: string): string {
-  return `[wso2.icp.runtime.bridge]
+// This dialog is org-scoped: the project and integration are fill-in placeholders, so it cannot
+// derive workflow management from an integration's type the way the component Runtime page does. The
+// toggle stands in for that, and the task queue placeholder below is the same `<integration name>`
+// the bridge block carries so the two still agree once both are filled in.
+function biToml(envName: string, secret: string, workflowMgt: boolean): string {
+  const workflowKeys = workflowMgt ? '\nenableWorkflowManagement = true\n# workflowManagementApiPort = 8234' : '';
+  const base = `[wso2.icp.runtime.bridge]
 environment = "${envName}"
 project = "<project name>"
 integration = "<integration name>"
 runtime = "<unique id for the runtime>"
-secret = "${secret}"
+secret = "${secret}"${workflowKeys}
 #serverUrl="https://<hostname>:9445"`;
+  if (!workflowMgt) return base;
+  return `${base}
+
+${workflowManagementToml('<integration name>', secret)}`;
 }
 
 function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () => void }) {
@@ -176,6 +184,7 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
   const [secret, setSecret] = useState<string | null>(null);
   const [tab, setTab] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [workflowMgt, setWorkflowMgt] = useState(false);
 
   const handleGenerate = () => {
     setError(null);
@@ -188,7 +197,7 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
     );
   };
 
-  const config = secret ? (tab === 0 ? biToml(env.handler, secret) : miToml(env.handler, secret)) : null;
+  const config = secret ? (tab === 0 ? biToml(env.handler, secret, workflowMgt) : miToml(env.handler, secret)) : null;
 
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
@@ -207,9 +216,6 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
             <Alert severity="warning" sx={{ mb: 2 }}>
               <strong>The secret will be shown once — copy it before closing.</strong>
             </Alert>
-            <DialogContentText variant="caption" sx={{ mb: 2, display: 'block' }}>
-              Applies to Default (BI) runtimes only — the MI configuration is not affected.
-            </DialogContentText>
             <Button variant="contained" onClick={handleGenerate} disabled={createMutation.isPending}>
               {createMutation.isPending ? 'Generating...' : 'Generate Secret'}
             </Button>
@@ -223,9 +229,18 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
               <Tab label="Default" />
               <Tab label="MI" />
             </Tabs>
+            {/* Workflow support is a Ballerina-only capability, and the toggle lives on the results
+                step so it can be flipped without spending another secret on a fresh dialog. */}
+            {tab === 0 && <FormControlLabel control={<Switch checked={workflowMgt} onChange={(e) => setWorkflowMgt(e.target.checked)} />} label="Enable Workflow Management" sx={{ display: 'flex', mb: 1 }} />}
             <DialogContentText sx={{ mb: 1 }}>
               Add the following configuration to your runtime's <strong>{tab === 0 ? 'Config.toml' : 'deployment.toml'}</strong> file. Change the <strong>project, integration and runtime</strong> values as needed. The runtime value must be unique for each
               runtime you register.
+              {tab === 0 && workflowMgt && (
+                <>
+                  {' '}
+                  Keep <strong>taskQueue</strong> the same as the <strong>integration</strong> value.
+                </>
+              )}
             </DialogContentText>
             {config && <CodeBoxWithCopy code={config} />}
             {tab === 0 && (
@@ -235,11 +250,17 @@ function AddRuntimeModal({ env, onClose }: { env: GqlEnvironment; onClose: () =>
                 </DialogContentText>
                 <CodeBoxWithCopy code={`[build-options]\nremoteManagement = true`} />
                 <DialogContentText sx={{ mb: 1 }}>
-                  Import wso2/icp.runtime.bridge to your runtime's <strong>main.bal</strong> file:
+                  {workflowMgt ? (
+                    <>
+                      Add the following imports to your runtime's <strong>main.bal</strong> file:
+                    </>
+                  ) : (
+                    <>
+                      Import wso2/icp.runtime.bridge to your runtime's <strong>main.bal</strong> file:
+                    </>
+                  )}
                 </DialogContentText>
-                {/* Bridge import only: this dialog emits no workflow configuration, so the workflow
-                    management module is not needed here. */}
-                <CodeBoxWithCopy code={runtimeImports(false)} />
+                <CodeBoxWithCopy code={runtimeImports(workflowMgt)} />
                 <Alert severity="info" sx={{ mt: 2 }}>
                   The above configuration is for runtimes using the <strong>Default</strong> integration. If you're using the <strong>MI</strong> integration, switch to the MI tab to see the correct configuration.
                 </Alert>

--- a/frontend/src/pages/Runtime.tsx
+++ b/frontend/src/pages/Runtime.tsx
@@ -38,6 +38,7 @@ import {
   PageContent,
   PageTitle,
   Stack,
+  Switch,
   TablePagination,
   Typography,
 } from '@wso2/oxygen-ui';
@@ -85,8 +86,8 @@ secret = "${secret}"
 }
 
 function biToml(envName: string, secret: string, projectHandle: string, integrationHandle: string, workflowMgt: boolean): string {
-  // The bridge's workflow keys belong to a Workflow integration only, like the [ballerina.workflow]
-  // blocks appended below — no other integration type's snippet mentions workflows at all.
+  // The bridge's workflow keys and the [ballerina.workflow] blocks appended below are written as a
+  // set: either the runtime carries workflow management or its snippet mentions workflows nowhere.
   const workflowKeys = workflowMgt ? '\nenableWorkflowManagement = true\n# workflowManagementApiPort = 8234' : '';
   const base = `[wso2.icp.runtime.bridge]
 environment = "${envName}"
@@ -126,11 +127,17 @@ function AddRuntimeModal({
   const [secret, setSecret] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [workflowMgtChoice, setWorkflowMgtChoice] = useState(false);
   const isBI = componentType === 'BI';
-  // Only a Workflow integration gets workflow configuration; no other type carries anything workflow
-  // related, so this follows the integration's type with nothing to choose. Derived rather than held
-  // in state so a late-arriving type still takes effect.
-  const workflowMgt = isWorkflowIntegration(displayType);
+  // A Workflow integration exists to host workflows, so its runtime always registers with workflow
+  // management enabled and there is nothing to choose. Derived rather than seeded into state so a
+  // late-arriving integration type still takes effect.
+  const alwaysWorkflowMgt = isWorkflowIntegration(displayType);
+  // Every other type still offers the toggle, because an integration's type can be changed after the
+  // fact: a runtime registered without this configuration exposes no workflow data, and switching
+  // the integration to Workflow later cannot add it retroactively. Turning it on up front keeps that
+  // switch usable without re-registering the runtime.
+  const workflowMgt = alwaysWorkflowMgt || workflowMgtChoice;
 
   const handleGenerate = () => {
     setError(null);
@@ -181,6 +188,10 @@ function AddRuntimeModal({
             <Alert severity="warning" sx={{ mb: 2 }}>
               Copy this secret now. It will not be shown again.
             </Alert>
+            {/* On the results step so it can be flipped without spending another secret on a fresh
+                dialog. Hidden for a Workflow integration, which is always enabled, and for MI, whose
+                deployment.toml has no workflow configuration. */}
+            {isBI && !alwaysWorkflowMgt && <FormControlLabel control={<Switch checked={workflowMgtChoice} onChange={(e) => setWorkflowMgtChoice(e.target.checked)} />} label="Enable Workflow Management" sx={{ display: 'flex', mb: 1 }} />}
             <DialogContentText sx={{ mb: 1 }}>
               Add the following configuration to your runtime's <strong>{isBI ? 'Config.toml' : 'deployment.toml'}</strong> file. Change the <strong>runtime</strong> value; it must be unique for each registered runtime.
             </DialogContentText>

--- a/frontend/src/utils/runtimeToml.ts
+++ b/frontend/src/utils/runtimeToml.ts
@@ -46,7 +46,7 @@ export function runtimeImports(workflowMgt: boolean): string {
 }
 
 /**
- * TOML the "Enable Workflow Management" toggle adds to a BI runtime: the workflow engine block,
+ * TOML a workflow-enabled BI runtime carries: the workflow engine block,
  * then the management API block keyed by the org secret. `integration` becomes the workflow task
  * queue and should be whatever the `integration` key of the bridge config above holds, so the two
  * always agree — the real handle on the component runtime page, the same fill-in placeholder on the


### PR DESCRIPTION
## Purpose

Registering a runtime for workflow management is a decision that has to be made **before the runtime starts** — `enableWorkflowManagement` and the `[ballerina.workflow]` blocks live in the runtime's `Config.toml`, and nothing in ICP can add them retroactively. Two gaps in the Add Runtime dialogs made that decision impossible to express:

1. **The org-level flow could not ask for it at all.** Adding a runtime from the org **Runtimes** page — or from the **+ Add Runtime** button the Projects page shows when no project exists yet — skips the project, integration and integration type entirely. Since the toggle was dropped, that flow emitted a snippet with no workflow configuration and no way to change that, so a runtime registered through it could never serve workflow data.

2. **Non-workflow integrations could not opt in.** An integration's type is no longer fixed at creation. A user can build an *Integration as API*, then switch it to *Workflow* to see its workflow data — but that switch only updates a row in ICP. The runtime behind it was registered without the workflow configuration, so it exposes no management API, no workflow data appears, and nothing in the UI explains why.

This PR restores the **Enable Workflow Management** toggle to both dialogs.

## Changes

**Org Add Runtime dialog (`pages/OrgRuntimes.tsx`)**

- Adds the toggle under the **Default** tab. This dialog cannot derive the answer from an integration's type the way the component page does — it is org-scoped, with the project and integration left as fill-in placeholders — so the toggle stands in for that.
- `taskQueue` is emitted as the same `<integration name>` placeholder the bridge block carries, and the instructions now say to keep the two the same; filling in one and not the other would point the runtime at a queue nothing reads.
- Removes the caption "Applies to Default (BI) runtimes only …", which was orphaned when the toggle was removed and is now implied by the toggle's placement under the tab.

**Component Add Runtime dialog (`pages/Runtime.tsx`)**

- A **Workflow** integration is unchanged: always enabled, no toggle, since that is what the type means.
- Every other BI type now gets the toggle, so someone who intends to switch the integration to Workflow later can say so while registering the runtime.
- Still hidden for MI, whose `deployment.toml` carries no workflow configuration.

**Both dialogs**

- The toggle sits on the snippet step rather than before **Generate Secret**, so it re-renders the config in place. On the first step, changing one's mind would mean closing the dialog and burning a second org secret.

## Emitted configuration

Off — the snippet is byte-for-byte what it is today. On, the Default/BI snippet gains:

```toml
[wso2.icp.runtime.bridge]
...
enableWorkflowManagement = true
# workflowManagementApiPort = 8234

[ballerina.workflow]
# mode = "LOCAL"
taskQueue = "<integration name>"

[ballerina.workflow.management]
enableManagementApi = true
...
```

plus the `ballerina/workflow.management` import in `main.bal`, which the `[ballerina.workflow.management]` block needs to take effect. Both snippets are produced by the existing shared `utils/runtimeToml.ts` helpers, so the two dialogs cannot drift.

## Scope

Frontend only — no API, schema or backend change. Existing behaviour is untouched with the toggle off, and for Workflow integrations and MI runtimes.

## Testing

- `prettier --check`, `eslint` and `tsc -b` clean on the touched files. (Three type errors and two `no-explicit-any` errors elsewhere on `main` are pre-existing and unrelated: `RegistryFileViewer.tsx:119`, `SyncSwitch.tsx:20`, `EditEnvironment.tsx:61`, `Runtime.tsx:389-390`.)
- The snippet builders are pure functions of the toggle, and the off branch returns the existing string unchanged, so the current output is preserved by construction.
- Not yet exercised against a running runtime — worth a manual pass of both dialogs before merge.

## Known limitation (not addressed here)

A runtime registered through the **org-level** dialog auto-creates its integration with the default `service` display type, not `ballerinaWorkflow`, so the per-integration **Workflows** nav entry will not appear for it until the type is changed. Its workflows are still reachable from the project-scope Workflows page, which deliberately keeps differently-typed integrations in the fan-out. Having the runtime report its workflow capability at registration would close that gap and is worth a follow-up.
