### PR TITLE
Allow a restarted runtime to reclaim its own name

### DIFF
--- a/icp_server/modules/storage/heartbeat_repository.bal
+++ b/icp_server/modules/storage/heartbeat_repository.bal
@@ -539,16 +539,24 @@ isolated function upsertRuntime(types:Heartbeat heartbeat) returns string?|error
     // Bare, reachable host/IP for this runtime process (optional; NULL when absent) - used by the Try-It proxy
     string? tryItHost = heartbeat?.tryItHost;
 
-    // Check if a stale OFFLINE runtime with the same component/env/name but different ID exists.
-    // Restricting to OFFLINE prevents live sibling replicas in multi-replica deployments from
-    // being mistakenly treated as "old restarted instances" and deleted.
+    // Check if a runtime with the same component/env/name but a different ID already exists.
+    // A restarting runtime generally comes back with a fresh ID (containers lose the persisted
+    // ID with their filesystem), so the old row has to be cleared out before the upsert.
     stream<record {|string runtime_id;|}, sql:Error?> existingByName;
     if runtimeName is string {
+        // Named runtimes are covered by uq_runtime_identity (component_id, environment_id, name),
+        // so at most one row can hold this name and it cannot belong to a live sibling replica.
+        // A differing ID here is therefore always a restarted instance. Matching only OFFLINE rows
+        // would leave a fast restart - a rolling update, eviction or reschedule - unable to
+        // register until the old row times out, because the INSERT below hits that constraint.
         existingByName = dbClient->query(`
             SELECT runtime_id FROM runtimes
-            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName} AND status = 'OFFLINE'
+            WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name = ${runtimeName}
         `);
     } else {
+        // Unnamed runtimes are NOT covered by that constraint - NULLs compare as distinct - so
+        // live sibling replicas can legitimately share a NULL name here. Keep the OFFLINE guard
+        // so they are not mistaken for old restarted instances and deleted.
         existingByName = dbClient->query(`
             SELECT runtime_id FROM runtimes
             WHERE component_id = ${heartbeat.component} AND environment_id = ${heartbeat.environment} AND name IS NULL AND status = 'OFFLINE'

--- a/icp_server/tests/heartbeat_tests.bal
+++ b/icp_server/tests/heartbeat_tests.bal
@@ -258,6 +258,54 @@ function testVmRestartCleansUpOfflineRecord() returns error? {
     cleanupRuntime(HB_RESTART_NEW_ID);
 }
 
+// =============================================================================
+// Test 4: Kubernetes rolling restart — the old record is still RUNNING
+//
+// A pod replaced faster than heartbeatTimeoutSeconds (any rolling update, eviction
+// or reschedule) comes back with a fresh UUID while its previous row is still
+// RUNNING. Restricting the cleanup query to OFFLINE rows left that row in place,
+// so the INSERT violated uq_runtime_identity (component_id, environment_id, name)
+// and the heartbeat was rejected — permanently for runtimes that do not retry.
+//
+// Named runtimes are safe to reclaim this way: the unique constraint guarantees no
+// live sibling can be holding the name. The null-name replica tests above cover the
+// case where siblings genuinely can, and that guard is retained.
+// =============================================================================
+@test:Config {
+    groups: ["heartbeat", "heartbeat-restart"]
+}
+function testK8sRestartReplacesRunningRecord() returns error? {
+    cleanupRuntime(HB_RESTART_OLD_ID);
+    cleanupRuntime(HB_RESTART_NEW_ID);
+
+    // Old instance registers and stays RUNNING — it is never marked OFFLINE, because
+    // the replacement comes up well inside the heartbeat timeout.
+    _ = check storage:processHeartbeat(
+            buildHeartbeat(HB_RESTART_OLD_ID, HB_RESTART_NAME), preResolved = true);
+    types:Runtime? seeded = check storage:getRuntimeById(HB_RESTART_OLD_ID);
+    test:assertNotEquals(seeded, (), "Old runtime should be seeded as RUNNING before the restart");
+
+    // Replacement instance: same name, fresh UUID, old row still RUNNING.
+    types:HeartbeatResponse response = check storage:processHeartbeat(
+            buildHeartbeat(HB_RESTART_NEW_ID, HB_RESTART_NAME), preResolved = true);
+    test:assertTrue(response.acknowledged,
+            "Restarted runtime must be acknowledged even though the old record is still RUNNING");
+
+    types:Runtime? oldRecord = check storage:getRuntimeById(HB_RESTART_OLD_ID);
+    test:assertEquals(oldRecord, (), "Superseded RUNNING record must be replaced, not left behind");
+
+    types:Runtime? newRuntime = check storage:getRuntimeById(HB_RESTART_NEW_ID);
+    test:assertNotEquals(newRuntime, (), "Restarted runtime must be registered under its new ID");
+}
+
+@test:AfterGroups {
+    value: ["heartbeat-restart"]
+}
+function afterHeartbeatRestartTests() {
+    cleanupRuntime(HB_RESTART_OLD_ID);
+    cleanupRuntime(HB_RESTART_NEW_ID);
+}
+
 @test:Config {
     groups: ["heartbeat", "mi-artifacts"]
 }


### PR DESCRIPTION
Fixes #829

## Problem

A runtime replaced faster than `heartbeatTimeoutSeconds` (default 30s) cannot register
again. It comes back with a fresh runtime ID, so `upsertRuntime` treats it as new and
inserts a row - but its previous row is still present and still RUNNING, so the insert
violates `uq_runtime_identity (component_id, environment_id, name)` and the heartbeat is
rejected.

In Kubernetes this is the normal path rather than an edge case. A rolling update, eviction
or reschedule replaces a pod within seconds, and the persisted runtime ID is lost with the
container filesystem. With the default `maxSurge` the replacement always starts while the
old row is still live, so the collision is guaranteed rather than occasional.

MI retries on its schedule and recovers after about 90 seconds. BI shuts down its heartbeat
scheduler when the first heartbeat is rejected, so it never recovers - the pod keeps serving
traffic while ICP shows it offline, or with `deploymentType = "K8S"` drops it from the
console entirely.

## Root cause and fix

The stale-row cleanup already handles a changed runtime ID: it finds the old row by
(component, environment, name) and deletes it before the upsert. That lookup was restricted
to rows already marked OFFLINE, so during a fast restart it matched nothing and the insert
collided.

That restriction is unnecessary for **named** runtimes. `uq_runtime_identity` guarantees no
live sibling can hold the name, so a heartbeat arriving with an existing name and a
different ID can only be a restarted instance.

It is still necessary for **unnamed** runtimes, where NULLs compare as distinct and sibling
replicas genuinely can coexist. That branch is unchanged, and its regression tests
(`testMultiReplicaNullNamesBothSurvive`, `testFiveReplicasNullNamesAllSurvive`) still pass.

## Known trade-off

During the `maxSurge` overlap both pods are briefly alive with the same name and different
IDs, so they alternately reclaim the row until the old pod terminates - measured at 3-5
reclaim events over roughly 5-10 seconds, then stable. This is self-correcting and much
preferable to the permanent failure it replaces, but it is inherent to treating the name as
the identity. `maxSurge: 0` avoids it entirely, and a stable runtime ID would remove it
properly.

## Follow-up worth considering

`upsertRuntime` checks whether a row exists and then inserts, as two separate steps with no
transaction around them. If two heartbeats for the same runtime name arrive at almost the
same instant, both can pass the check and both attempt the insert, and one will still be
rejected with 23505. This change removes the collision that happened on every restart; it
does not make that path safe against simultaneous heartbeats.
