### PR TITLE
[WSO2 Cloud] fix(endpoints): fall back to the port when an endpoint has no usable name

### DIFF
--- a/ipaas/src/api/cloud/deployments.ts
+++ b/ipaas/src/api/cloud/deployments.ts
@@ -47,6 +47,7 @@ import type { ComponentDeployment, BuildRun, ReleaseMgtDeployment, DeploymentTra
 import type { EnvEndpoint } from '../../types/component';
 import type { DeployComponentInput } from '../../types/build';
 import { bff, items, q, seg, type ListResponse, type MessageResponse } from './_client';
+import { getEndpointLabel } from '../../utils/endpoints';
 
 // Underscored params (_orgHandler, _orgUuid, _projectId, _versionId) are kept
 // on these signatures for devant contract parity; cloud does not use them.
@@ -92,7 +93,7 @@ function toEnvEndpoint(ep: BffEndpointResources, releaseId: string): EnvEndpoint
     id: ep.name,
     releaseId,
     environmentId: '',
-    displayName: ep.displayName || ep.name,
+    displayName: getEndpointLabel(ep),
     type: ep.type ?? '',
     port: ep.port ?? null,
     visibility: networkVisibilities[0] ?? '',

--- a/ipaas/src/components/EnvironmentCard/EnvironmentCardBody.tsx
+++ b/ipaas/src/components/EnvironmentCard/EnvironmentCardBody.tsx
@@ -26,17 +26,7 @@ import SwaggerOperationsList from '../Overview/integration-as-api/SwaggerOperati
 import { useFetchComponentEndpointSpec } from '../../hooks/useComponents';
 import { useApiDefinition } from '../../hooks/useDeployments';
 import type { EnvEndpoint } from '../../types/component';
-
-// ---------- helpers ----------
-
-function trimEndpointName(name: string) {
-  return (
-    name
-      .replace(/^\s*Endpoint\b\s*/i, '')
-      .replace(/\s+/g, ' ')
-      .trim() || name
-  );
-}
+import { trimEndpointName } from '../../utils/endpoints';
 
 // ---------- CopyButton ----------
 

--- a/ipaas/src/components/Overview/_shared/EndpointUrlsPanel.tsx
+++ b/ipaas/src/components/Overview/_shared/EndpointUrlsPanel.tsx
@@ -21,15 +21,7 @@ import { Building2, Check, Copy, Download, Folder, Globe } from '@wso2/oxygen-ui
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFetchComponentEndpointSpec } from '../../../hooks/useComponents';
 import type { EnvEndpoint } from '../../../types/component';
-
-function trimEndpointName(name: string) {
-  return (
-    name
-      .replace(/^\s*Endpoint\b\s*/i, '')
-      .replace(/\s+/g, ' ')
-      .trim() || name
-  );
-}
+import { trimEndpointName } from '../../../utils/endpoints';
 
 function CopyButton({ url }: { url: string }) {
   const [copied, setCopied] = useState(false);

--- a/ipaas/src/utils/endpoints.test.ts
+++ b/ipaas/src/utils/endpoints.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveEndpointInvokeUrl } from './endpoints';
+import { getEndpointLabel, resolveEndpointInvokeUrl, trimEndpointName } from './endpoints';
 import type { EnvEndpoint } from '../types/component';
 
 const ep = (partial: Partial<EnvEndpoint>): EnvEndpoint => ({ id: 'e', releaseId: 'r', environmentId: 'env', displayName: 'ep', type: 'GraphQL', visibility: 'Public', ...partial }) as EnvEndpoint;
@@ -40,5 +40,68 @@ describe('resolveEndpointInvokeUrl', () => {
   it('falls back to any available url when no visibility matches', () => {
     const e = ep({ networkVisibilities: [], invokeUrl: 'https://any/graphql' });
     expect(resolveEndpointInvokeUrl(e)).toBe('https://any/graphql');
+  });
+});
+
+describe('trimEndpointName', () => {
+  it('drops a redundant leading "Endpoint" word', () => {
+    expect(trimEndpointName('Endpoint Covid Status')).toBe('Covid Status');
+    // The auto-generated shape the wip/GraphQL path relies on.
+    expect(trimEndpointName('Endpoint 1')).toBe('1');
+    expect(trimEndpointName('  Endpoint   Foo  ')).toBe('Foo');
+  });
+
+  it('only strips the word when it stands alone', () => {
+    expect(trimEndpointName('EndpointFoo')).toBe('EndpointFoo');
+    expect(trimEndpointName('Endpoints')).toBe('Endpoints');
+    expect(trimEndpointName('My Endpoint')).toBe('My Endpoint');
+  });
+
+  it('leaves a hyphenated name starting with "endpoint" intact', () => {
+    // The old /^\s*Endpoint\b\s*/i matched before the hyphen and produced "-metrics".
+    expect(trimEndpointName('endpoint-metrics')).toBe('endpoint-metrics');
+    expect(trimEndpointName('endpoint-9097')).toBe('endpoint-9097');
+  });
+
+  it('keeps the original when trimming would empty it', () => {
+    expect(trimEndpointName('Endpoint')).toBe('Endpoint');
+  });
+});
+
+describe('getEndpointLabel', () => {
+  // Titles the Ballerina OpenAPI generator emits for the covid19-status sample.
+  it('keeps a title that names something', () => {
+    expect(getEndpointLabel({ displayName: 'Covid Status', name: 'covid-status', port: 9000 })).toBe('Covid Status');
+    expect(getEndpointLabel({ displayName: 'Covid Community Support', name: 'covid-commu-3e5', port: 9003 })).toBe('Covid Community Support');
+  });
+
+  it('falls back to the port for a base-path-only title', () => {
+    expect(getEndpointLabel({ displayName: '/', name: 'endpoint-9001', port: 9001 })).toBe('9001');
+  });
+
+  it('falls back to the port for an empty or absent title', () => {
+    expect(getEndpointLabel({ displayName: '', name: 'endpoint-9097', port: 9097 })).toBe('9097');
+    expect(getEndpointLabel({ name: 'endpoint-9097', port: 9097 })).toBe('9097');
+  });
+
+  it('falls back to the port for a generated numeric-hash title', () => {
+    expect(getEndpointLabel({ displayName: '484419380', name: 'endpoint-9002', port: 9002 })).toBe('9002');
+  });
+
+  it('prefers a meaningful component.yaml key over the port when the title is absent', () => {
+    expect(getEndpointLabel({ name: 'greeter-api', port: 9090 })).toBe('greeter-api');
+    expect(getEndpointLabel({ name: 'sample-agent-endpoint', port: 8000 })).toBe('sample-agent-endpoint');
+  });
+
+  it('ignores the generated endpoint-<port> key in favour of the port', () => {
+    expect(getEndpointLabel({ name: 'endpoint-9090', port: 9090 })).toBe('9090');
+  });
+
+  it('normalizes whitespace in a usable title', () => {
+    expect(getEndpointLabel({ displayName: '  Covid   Status  ', name: 'covid-status', port: 9000 })).toBe('Covid Status');
+  });
+
+  it('returns the key when there is no port to fall back to', () => {
+    expect(getEndpointLabel({ displayName: '/', name: 'endpoint-9001' })).toBe('endpoint-9001');
   });
 });

--- a/ipaas/src/utils/endpoints.ts
+++ b/ipaas/src/utils/endpoints.ts
@@ -19,6 +19,49 @@
 import type { EnvEndpoint } from '../types/component';
 
 /**
+ * Drop a redundant leading "Endpoint" word from a label, so "Endpoint Covid Status"
+ * reads as "Covid Status". The trailing whitespace is required: without it the word
+ * boundary also matches before a hyphen, turning the generated key "endpoint-9097"
+ * into "-9097".
+ */
+export function trimEndpointName(name: string): string {
+  const raw = name ?? '';
+  return (
+    raw
+      .replace(/^\s*Endpoint\s+/i, '')
+      .replace(/\s+/g, ' ')
+      .trim() || raw
+  );
+}
+
+/** Endpoint keys the build pipeline generates when the spec title was unusable. */
+const GENERATED_ENDPOINT_KEY = /^endpoint-\d+$/i;
+
+const hasLetter = (value: string) => /[a-z]/i.test(value);
+
+/**
+ * Resolve the label to show for an endpoint.
+ *
+ * The Ballerina OpenAPI generator derives `info.title` from the service base path, so
+ * `service / on ...` yields "/", a listener with no base path yields "", and a service
+ * bound to a listener variable yields a numeric hash. None of those name anything, and
+ * the build pipeline applies the same "must contain a letter" test when it generates the
+ * endpoint key (RFC 6335), falling back to `endpoint-<port>`.
+ *
+ * Order: spec title → endpoint key (when it is not that generated form, so component.yaml
+ * names like "greeter-api" still win) → the port number.
+ */
+export function getEndpointLabel(endpoint: { displayName?: string | null; name?: string | null; port?: number | null }): string {
+  const title = trimEndpointName(endpoint.displayName ?? '').trim();
+  if (hasLetter(title)) return title;
+
+  const key = trimEndpointName(endpoint.name ?? '').trim();
+  if (hasLetter(key) && !GENERATED_ENDPOINT_KEY.test(key)) return key;
+
+  return endpoint.port != null ? String(endpoint.port) : key;
+}
+
+/**
  * Resolve the URL to invoke an endpoint at, preferring the widest network
  * visibility it is exposed on (Public → Organization → Project), then any URL
  * available. The trailing slash is stripped so a path can be appended cleanly.


### PR DESCRIPTION
## Purpose
The Ballerina OpenAPI generator derives info.title from the service base path, so `service / on ...` yields "/", a listener with no base path yields "", and a service bound to a listener variable yields a numeric hash. The build pipeline copies that title into the Workload CR's displayName and the environment overview card rendered it as-is, showing "/" for port 9001. The empty case was worse: the mapper fell back to the endpoint key and trimEndpointName then mangled "endpoint-9097" into "-9097".

Resolve the label at the read layer instead, leaving the Workload CR a faithful mirror of the spec: title if it contains a letter, else the endpoint key when it is not the pipeline's generated endpoint-<port> form, else the port. The middle step keeps today's behaviour for component.yaml endpoints that have no title but a meaningful key (greeter-api, editor). "Contains a letter" is the same test the pipeline already applies when generating the endpoint key (RFC 6335).

Applied in the cloud mapper toEnvEndpoint, the single point all workload-CR endpoints flow through, so every render site inherits it and existing components are fixed without a rebuild. Verified against all 135 endpoints in the dev cluster: 51 labels changed, 0 left degenerate.

Also fix trimEndpointName while de-duplicating it into utils/endpoints.ts: /^\s*Endpoint\b\s*/i matched the word boundary before a hyphen, so any name starting with "Endpoint" followed by punctuation lost its first word ("endpoint-metrics" -> "-metrics"). Requiring trailing whitespace strips only a genuine "Endpoint <name>" prefix. This helper is shared across products; a differential test over 31 inputs shows the only divergence is that class, where the previous output was already broken.

<img width="1728" height="1041" alt="Screenshot 2026-08-17 at 15 00 33" src="https://github.com/user-attachments/assets/7e1bb220-1d5e-4abe-89bb-395c888431c8" />


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.