### PR TITLE
[WSO2 Cloud] Enable Component Level Container Management Page

### DIFF
--- a/ipaas/src/api/cloud/devopsConfigs.ts
+++ b/ipaas/src/api/cloud/devopsConfigs.ts
@@ -213,21 +213,38 @@ const listEnvGroups = async (projectId: string, env: string): Promise<BffEnvGrou
   return fetchEnvGroups(componentId, projectId, env);
 };
 
-// ── release (synthetic container carrying the resolved env) ────────────────────
+// ── release (real container data, keyed by the resolved env) ───────────────────
 
-// Cloud has no release/container resource. Resolve the environment for the
-// release and return it AS the (single, MAIN) container id, so the mount/delete
-// functions — which receive containerId but not envId — read the env off it.
+// Cloud has no release resource distinct from an app-environment binding, so
+// releaseId resolves to an environment (see envForRelease), and the container's
+// `ID` stays the environment string — every downstream consumer (config
+// mounts, scaling, health checks, storage) reads containerId expecting the env,
+// not a real container id; changing that would break them. `name` is display-only
+// (never used for addressing), so it keeps the real container name from the BFF,
+// falling back to the env only if the BFF didn't return one. Real container
+// fields (image/resources/ports/pull-policy/command/args) come from the BFF's
+// Containers endpoint, keyed on that same env — its JSON shape already matches
+// ReleaseContainer field-for-field, so the response is spread in directly.
 export const getReleaseById = async (_orgUuid: string, _projectId: string, componentId: string, releaseId: string): Promise<ReleaseDetails> => {
   const env = await envForRelease(componentId, releaseId);
-  if (env) setComponentForEnv(env, componentId);
-  const containers: ReleaseContainer[] = env ? [{ ID: env, name: env, type: 'MAIN' }] : [];
-  return { ID: releaseId, containers };
+  if (!env) return { ID: releaseId, containers: [] };
+  setComponentForEnv(env, componentId);
+  const list = await bff.get<ListResponse<ReleaseContainer>>(`${filesBase(componentId, env)}/containers`).catch(() => null);
+  const real = items(list)[0] ?? ({} as Partial<ReleaseContainer>);
+  return { ID: releaseId, containers: [{ ...real, ID: env, name: real.name ?? env, type: real.type ?? 'MAIN' }] };
 };
 
-/** Container editing is a WIP-only devops surface; OpenChoreo has no equivalent BFF endpoint. */
-export const updateContainer = (_orgUuid: string, _projectId: string, _componentId: string, _releaseId: string, _containerId: string, _data: ContainerWriteData): Promise<ReleaseContainer> =>
-  Promise.reject(new Error('[cloud] devopsConfigs.updateContainer: not implemented'));
+// PUT splits into a ReleaseBinding write (cpu/memory/limits/pull-policy, visible
+// on the next GET once the rollout completes) and a declarative-only Workload
+// write (command/args, takes effect only on the next release cut+promote) on the
+// BFF side — see ipaas-service's CONTAINERS_FEATURE_PROMPT.md. containerId is the
+// env (carried through from getReleaseById); the URL's containerId segment is a
+// fixed literal since the BFF ignores it — there is only ever one container.
+export const updateContainer = async (_orgUuid: string, _projectId: string, componentId: string, _releaseId: string, containerId: string, data: ContainerWriteData): Promise<ReleaseContainer> => {
+  const env = containerId;
+  await bff.put(`${filesBase(componentId, env)}/containers/main`, data);
+  return { ID: env, name: env, type: 'MAIN', ...data };
+};
 
 // ── config maps / secrets = env-var groups (files have no env-scoped source) ───
 

--- a/ipaas/src/api/cloud/devopsConfigs.ts
+++ b/ipaas/src/api/cloud/devopsConfigs.ts
@@ -216,15 +216,19 @@ const listEnvGroups = async (projectId: string, env: string): Promise<BffEnvGrou
 // ── release (real container data, keyed by the resolved env) ───────────────────
 
 // Cloud has no release resource distinct from an app-environment binding, so
-// releaseId resolves to an environment (see envForRelease), and the container's
-// `ID` stays the environment string — every downstream consumer (config
-// mounts, scaling, health checks, storage) reads containerId expecting the env,
-// not a real container id; changing that would break them. `name` is display-only
-// (never used for addressing), so it keeps the real container name from the BFF,
-// falling back to the env only if the BFF didn't return one. Real container
-// fields (image/resources/ports/pull-policy/command/args) come from the BFF's
-// Containers endpoint, keyed on that same env — its JSON shape already matches
-// ReleaseContainer field-for-field, so the response is spread in directly.
+// releaseId resolves to an environment via envForRelease. `ID` is aliased to
+// that env string on purpose — every downstream consumer (config mounts,
+// scaling, health checks, storage) addresses the container by env, not a real
+// container id, so changing `ID` here would break them.
+//
+// `name` isn't under that constraint (nothing addresses by it), so it keeps
+// the real container name from the BFF, falling back to the env only if the
+// BFF didn't return one.
+//
+// The rest of the container fields (image/resources/ports/pull-policy/
+// command/args) come from the BFF's Containers endpoint, keyed on the same
+// env — its JSON already matches ReleaseContainer field-for-field, so the
+// response is spread in directly.
 export const getReleaseById = async (_orgUuid: string, _projectId: string, componentId: string, releaseId: string): Promise<ReleaseDetails> => {
   const env = await envForRelease(componentId, releaseId);
   if (!env) return { ID: releaseId, containers: [] };

--- a/ipaas/src/components/Containers/ContainerEditForm.tsx
+++ b/ipaas/src/components/Containers/ContainerEditForm.tsx
@@ -73,8 +73,7 @@ export default function ContainerEditForm({ container, projectId, componentId, r
         </Alert>
       )}
 
-      {/* Toggling limits on/off isn't supported for cloud; the sliders below still
-          reflect whatever limitsEnabled the container's actual data carries. */}
+      {/* Toggling limits on/off isn't supported for cloud; */}
       {isPaidOrPdpUser && !IS_CLOUD && (
         <FormControlLabel
           labelPlacement="start"

--- a/ipaas/src/components/Containers/ContainerEditForm.tsx
+++ b/ipaas/src/components/Containers/ContainerEditForm.tsx
@@ -18,9 +18,10 @@
 
 import { Alert, Box, Button, CircularProgress, Divider, FormControlLabel, Grid, Radio, RadioGroup, Slider, Stack, Switch, Typography } from '@wso2/oxygen-ui';
 import { ArrowLeft } from '@wso2/oxygen-ui-icons-react';
-import { useState, type JSX } from 'react';
+import { useRef, useState, type JSX } from 'react';
 import ResourceRangeSlider from '../common/ResourceRangeSlider';
 import StringArrayInput from '../common/StringArrayInput';
+import { IS_CLOUD } from '../../features';
 import { useUpdateContainer } from '../../hooks/useDevopsConfigs';
 import { CPU_MAX, CPU_MIN, CPU_STEP, MEMORY_MAX, MEMORY_MIN, MEMORY_STEP, MIN_GAP_CPU, MIN_GAP_MEMORY, containerToForm, formToWriteData } from '../../utils/containers';
 import { IMAGE_PULL_POLICY, type ImagePullPolicy, type ReleaseContainer } from '../../types/devopsConfigs';
@@ -42,6 +43,8 @@ const memFmt = (v: number): string => String(Math.round(v));
 
 export default function ContainerEditForm({ container, projectId, componentId, releaseId, isPaidOrPdpUser, onClose, onSaved, onError }: ContainerEditFormProps): JSX.Element {
   const [form, setForm] = useState(() => containerToForm(container));
+  const initialForm = useRef(form).current;
+  const isDirty = JSON.stringify(form) !== JSON.stringify(initialForm);
   const update = useUpdateContainer(projectId, componentId, releaseId);
 
   const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]): void => setForm((prev) => ({ ...prev, [key]: value }));
@@ -70,7 +73,9 @@ export default function ContainerEditForm({ container, projectId, componentId, r
         </Alert>
       )}
 
-      {isPaidOrPdpUser && (
+      {/* Toggling limits on/off isn't supported for cloud; the sliders below still
+          reflect whatever limitsEnabled the container's actual data carries. */}
+      {isPaidOrPdpUser && !IS_CLOUD && (
         <FormControlLabel
           labelPlacement="start"
           sx={{ ml: 0, mb: 2 }}
@@ -142,18 +147,22 @@ export default function ContainerEditForm({ container, projectId, componentId, r
         </Grid>
       </Grid>
 
-      <Divider sx={{ my: 3 }} />
-
-      <Stack gap={3}>
-        <StringArrayInput label="Command" value={form.command} onChange={(v) => set('command', v)} addLabel="Add Command" />
-        <StringArrayInput label="Arguments" value={form.args} onChange={(v) => set('args', v)} addLabel="Add Arguments" />
-      </Stack>
+      {/* Command/Args editing isn't supported for cloud */}
+      {!IS_CLOUD && (
+        <>
+          <Divider sx={{ my: 3 }} />
+          <Stack gap={3}>
+            <StringArrayInput label="Command" value={form.command} onChange={(v) => set('command', v)} addLabel="Add Command" />
+            <StringArrayInput label="Arguments" value={form.args} onChange={(v) => set('args', v)} addLabel="Add Arguments" />
+          </Stack>
+        </>
+      )}
 
       <Stack direction="row" gap={1.5} sx={{ mt: 4 }}>
         <Button variant="outlined" onClick={onClose} disabled={update.isPending}>
           Cancel
         </Button>
-        <Button variant="contained" onClick={onSubmit} disabled={update.isPending} startIcon={update.isPending ? <CircularProgress size={16} color="inherit" /> : undefined}>
+        <Button variant="contained" onClick={onSubmit} disabled={update.isPending || !isDirty} startIcon={update.isPending ? <CircularProgress size={16} color="inherit" /> : undefined}>
           Save Changes
         </Button>
       </Stack>

--- a/ipaas/src/hooks/useDevopsConfigs.ts
+++ b/ipaas/src/hooks/useDevopsConfigs.ts
@@ -19,14 +19,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createConfigMap, createSecret, getConfigMapDetails, getConfigMaps, getContainerConfigMounts, getReleaseById, getSecrets, mountConfig, removeConfigMount, updateConfigMapData, updateConfigMount, updateContainer, updateSecret } from '#api/devopsConfigs';
 import type { ConfigMapWriteData, ConfigMountPath, ConfigMountWriteData, ContainerWriteData, DevopsConfigMap, DevopsConfigMapDetails, DevopsConfigMount, DevopsSecret, ReleaseDetails, SaveConfigInput, SecretWriteData } from '../types/devopsConfigs';
-import { IS_WIP } from '../features';
+import { IS_CLOUD, IS_WIP } from '../features';
 import { useOrgUuid } from './useOrgUuid';
 
 const ROOT = 'devopsConfigs';
 
-/** Container management is a WIP-only devops surface (cloud/icp API stubs throw). */
+/** Container management is enabled for WIP and cloud (icp API stubs throw). */
 export function isContainersEnabled(): boolean {
-  return IS_WIP;
+  return IS_WIP || IS_CLOUD;
 }
 
 // ── reads ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary:
- Cloud's Containers page now shows real container data (image, resources, ports) instead of a placeholder, and displays the real container name instead of the environment name.
- Implemented updateContainer for cloud so edits actually save.
- Hid Command/Args and the Limits toggle there since cloud doesn't support them.
- Save button is now disabled until a field actually changes (was always clickable).